### PR TITLE
[2.1.0] Update instructions on 'export-api' command

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -52,16 +52,17 @@ Command Line tool for importing and exporting APIs between different API Environ
             Required:
                 --name, -n
                 --version, -v
+                --provider, -r
                 --environment, -e
             Optional:
                 --username, -u
                 --password, -p
                 NOTE: user will be prompted to enter credentials if they are not provided with these flags
         Examples:
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -u admin -p 123456
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -u admin
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -p 123456
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin -p 123456
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -p 123456
 ```
 
 * #### import-api

--- a/import-export-cli/cmd/apis.go
+++ b/import-export-cli/cmd/apis.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"net/http"
-	"net/url"
 	"os"
 )
 
@@ -98,10 +97,12 @@ func GetAPIList(query, accessToken, apiManagerEndpoint string) (count int32, api
 	}
 	url_ += "api/am/publisher/v0.11/apis"
 
-	fmt.Println("Query before encoding:", query)
-	encodedQuery, _ := url.Parse(query) // convert query into a url-path-encoded string
-	fmt.Println("Query after encoding:", encodedQuery.String())
-	url_ += "?query=" + encodedQuery.String()
+	/*
+		fmt.Println("Query before encoding:", query)
+		encodedQuery, _ := url.Parse(query) // convert query into a url-path-encoded string
+		fmt.Println("Query after encoding:", encodedQuery.String())
+		url_ += "?query=" + encodedQuery.String()
+	*/
 	utils.Logln(utils.LogPrefixInfo+"URL:", url_)
 
 	headers := make(map[string]string)

--- a/import-export-cli/resources/README.md
+++ b/import-export-cli/resources/README.md
@@ -1,7 +1,20 @@
 # CLI for Importing and Exporting APIs
 ## For WSO2 API Manager 2.1.x
 
-Command Line tool for importing and exporting APIs between different API Environemnts
+Command Line tool for importing and exporting APIs between different API Environments
+
+- ### Adding Environments
+    Add environments by either manually editing `main_config.yaml` or using the command
+    `apimcli set`.
+    
+    Execute `set --help` for detailed instructions
+    
+- ### Command Autocompletion (For Bash Only)
+    Copy the file `apimcli_bash_completion.sh` to `/etc/bash_completion.d/` and source it with
+    `source /etc/bash_completion.d/apimcli_bash_completion.sh` to enable bash auto-completion.
+
+<hr/>
+<br/>
 
 ## Usage 
 ```bash
@@ -15,15 +28,17 @@ Command Line tool for importing and exporting APIs between different API Environ
             Required:
                 --name, -n
                 --version, -v
+                --provider, -r
                 --environment, -e
             Optional:
                 --username, -u
                 --password, -p
+                NOTE: user will be prompted to enter credentials if they are not provided with these flags
         Examples:
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -u admin -p 123456
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -u admin
-            apimcli export-api -n TestAPI -v 1.0.1 -e staging -p 123456
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin -p 123456
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin
+            apimcli export-api -n TestAPI -v 1.0.1 -r admin -e staging -p 123456
 ```
 
 * #### import-api
@@ -36,6 +51,7 @@ Command Line tool for importing and exporting APIs between different API Environ
             Optional:
                 --username, -u 
                 --password, -p 
+                NOTE: user will be prompted to enter credentials if they are not provided with these flags
         Examples:
             apimcli import-api -f dev/TestAPI_1.0.0.zip -e dev
             apimcli import-api -f qa/TestAPI_2.0.0.zip -e dev -u admin -p 123456
@@ -51,6 +67,7 @@ Command Line tool for importing and exporting APIs between different API Environ
             Optional:
                 --username, -u 
                 --password, -p 
+                NOTE: user will be prompted to enter credentials if they are not provided with these flags
                 --query, -q
         Examples:
             apimcli list apis -e dev
@@ -74,12 +91,12 @@ Command Line tool for importing and exporting APIs between different API Environ
         Flags:
             Required:
                 --name, -n (Name of the environment)
-                --publisher, -p (Publisher endpoint)
+                --apim, -a (API Manager endpoint)
                 --registration, -r (Registration Endpoint)
                 --token, -t (Token Endpoint)
             Examples:
                 apimcli add-env -n dev \
-                --apim https://localhost:9292/api/am/publisher/v1.0 \
+                --apim https://localhost:9443 \ 
                 --registration https://localhost:9443/identity/connect/register \
                 --token https: https://localhost:9443/oauth2/token
 ```
@@ -117,7 +134,10 @@ Command Line tool for importing and exporting APIs between different API Environ
         
 #### Global Flags
 ```bash
-    --verbose
-    --insecure, -k
-    --help, -h
+      --verbose
+           Enable verbose logs (Provides more information on execution)
+      --insecure, -k
+          Allow connections to SSL sites without certs
+      --help, -h
+          Display information and example usage of a command
 ```


### PR DESCRIPTION
## Purpose
Include missing instructions on exporting an API i.e. mentioning that `--provider, -r` flag is mandatory in APIM 2.1.0 export operation.