### PR TITLE
CLI support to Import/Export Applications for APIM 2.1.x

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -139,7 +139,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
             Optional
                   --skipSubscriptions, -s    
                   --owner, -o        
-                  --perserveOwner, -r        
+                  --preserveOwner, -r        
                   --username, -u      
                   --password, -p     
         Examples:      

--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -1,7 +1,7 @@
-# CLI for Importing and Exporting APIs
+# CLI for Importing and Exporting APIs and Applications
 ## For WSO2 API Manager 2.1.x
 
-Command Line tool for importing and exporting APIs between different API Environemnts
+Command Line tool for importing and exporting APIs/Applications between different API Environemnts
 
 ## Getting Started
 
@@ -113,6 +113,53 @@ Command Line tool for importing and exporting APIs between different API Environ
             apimcli list apis -e staging 
             apimcli list apis -e staging -u admin -p 123456
             apimcli list apis -e staging -p 123456
+```
+
+* #### export-app
+```bash
+        Flags
+            Required:
+                 --name, -n          
+                 --owner, -o         
+                 --environment, -e
+            Optional
+                 --username, -u
+                 --password, -p   
+                 NOTE: user will be prompted to enter credentials if they are not provided with these flags
+        Examples:        
+            apimcli export-app -n SampleApp -o admin -e dev
+            apimcli export-app -n SampleApp -o admin -e prod         
+```
+* #### import-app
+```bash    
+        Flags
+            Required
+                  --file, -f          
+                  --environment, -e   
+            Optional
+                  --skipSubscriptions, -s    
+                  --owner, -o        
+                  --perserveOwner, -r        
+                  --username, -u      
+                  --password, -p     
+        Examples:      
+            apimcli import-app -f qa/apps/sampleApp.zip -e dev
+            apimcli Import App -f staging/apps/sampleApp.zip -e prod -o testUser -u admin -p admin
+            apimcli import-app -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e staging               
+```
+* #### list apps
+```bash
+        Flags
+            Required
+                  --environment, -e          
+                  --owner, -o         
+            Optional
+                  --username, -u             
+                  --password, -p             
+        Examples:
+            apimcli list apps -e dev -o admin 
+            apimcli list apps -e staging -o sampleUser -u admin -p 123456                         
+
 ```
 
 *  #### list envs

--- a/import-export-cli/apimcli.go
+++ b/import-export-cli/apimcli.go
@@ -21,6 +21,5 @@ package main
 import "github.com/wso2/product-apim-tooling/import-export-cli/cmd"
 
 func main() {
-
 	cmd.Execute()
 }

--- a/import-export-cli/apimcli_bash_completion.sh
+++ b/import-export-cli/apimcli_bash_completion.sh
@@ -5,11 +5,16 @@ import_export_cli()
     current="${COMP_WORDS[COMP_CWORD]}"
     previous="${COMP_WORDS[COMP_CWORD-1]}"
 
-    options="export-api import-api list add-env remove-env reset-user version author"
+    options="export-api export-app import-api import-app list add-env remove-env reset-user version author"
 
     case "${previous}" in
         export-api)
             local flags="--name -n --version -v --environment -e --help -h"
+            COMPREPLY=( $(compgen -W "${flags}" -- ${current}) )
+            return 0
+            ;;
+        export-app)
+            local flags="--name -n --environment -e --help -h"
             COMPREPLY=( $(compgen -W "${flags}" -- ${current}) )
             return 0
             ;;
@@ -18,8 +23,13 @@ import_export_cli()
             COMPREPLY=( $(compgen -W "${flags}" -- ${current}) )
             return 0
             ;;
+        import-app)
+            local flags="--file -f --environment -e --help -h"
+            COMPREPLY=( $(compgen -W "${flags}" -- ${current}) )
+            return 0
+            ;;
         list)
-            local flags="apis envs"
+            local flags="apis apps envs"
             COMPREPLY=( $(compgen -W "${flags}" -- ${current}) )
             return 0
             ;;

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -30,8 +30,10 @@ var flagAddEnvName string              // name of the environment to be added
 var flagTokenEndpoint string           // token endpoint of the environment to be added
 var flagApiImportExportEndpoint string // ApiImportExportEndpoint of the environment to be added
 var flagApiListEndpoint string         // ApiListEnvironment of the environment to be added
+var flagAppListEndpoint string         // ApplicationListEndpoint of the environment to be added
 var flagRegistrationEndpoint string    // registration endpoint of the environment to be added
 var flagApiManagerEndpoint string      // api manager endpoint of the environment to be added
+var flagAdminEndpoint string           // admin endpoint of the environment to be added
 
 // AddEnv command related Info
 const addEnvCmdLiteral = "add-env"
@@ -79,6 +81,8 @@ func executeAddEnvCmd(mainConfigFilePath string) {
 
 	envEndpoints.ApiImportExportEndpoint = flagApiImportExportEndpoint
 	envEndpoints.ApiListEndpoint = flagApiListEndpoint
+	envEndpoints.AppListEndpoint = flagAppListEndpoint
+	envEndpoints.AdminEndpoint = flagAdminEndpoint
 	envEndpoints.TokenEndpoint = flagTokenEndpoint
 	err := addEnv(flagAddEnvName, envEndpoints, mainConfigFilePath)
 	if err != nil {
@@ -140,8 +144,10 @@ func init() {
 	addEnvCmd.Flags().StringVar(&flagApiManagerEndpoint, "apim", "", "API Manager endpoint for the environment")
 	addEnvCmd.Flags().StringVar(&flagApiImportExportEndpoint, "import-export", "",
 		"API Import Export endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagApiListEndpoint, "list", "", "API List endpoint for the environment")
+	addEnvCmd.Flags().StringVar(&flagApiListEndpoint, "api_list", "", "API List endpoint for the environment")
+	addEnvCmd.Flags().StringVar(&flagAppListEndpoint, "app_list", "", "Application List endpoint for the environment")
 	addEnvCmd.Flags().StringVar(&flagTokenEndpoint, "token", "", "Token endpoint for the environment")
 	addEnvCmd.Flags().StringVar(&flagRegistrationEndpoint, "registration", "",
 		"Registration endpoint for the environment")
+	addEnvCmd.Flags().StringVar(&flagAdminEndpoint, "admin", "", "Admin endpoint for the environment")
 }

--- a/import-export-cli/cmd/addEnv_test.go
+++ b/import-export-cli/cmd/addEnv_test.go
@@ -66,8 +66,10 @@ func TestAddEnv3(t *testing.T) {
 	sampleMainConnfig.Environments["dev"] = utils.EnvEndpoints{
 		"sample-publisher-endpoint",
 		"sample-import-export-endpoint",
-		"sample-list-endpoint",
+		"sample-api-list-endpoint",
+		"sample-application-list-endpoint",
 		"sample-reg-endpoint",
+		"sample-admin-endpoint",
 		"sample-token-endpoint"}
 	utils.WriteConfigFile(sampleMainConnfig, sampleMainConfigFilePath)
 
@@ -94,8 +96,10 @@ func TestAddEnv4(t *testing.T) {
 	sampleMainConnfig.Environments["dev"] = utils.EnvEndpoints{
 		"sample-publisher-endpoint",
 		"sample-import-export-endpoint",
-		"sample-list-endpoint",
+		"sample-api-list-endpoint",
+		"sample-application-list-endpoint",
 		"sample-reg-endpoint",
+		"sample-admin-endpoint",
 		"sample-token-endpoint"}
 	utils.WriteConfigFile(sampleMainConnfig, sampleMainConfigFilePath)
 

--- a/import-export-cli/cmd/apps.go
+++ b/import-export-cli/cmd/apps.go
@@ -37,7 +37,7 @@ var listAppsCmdPassword string
 
 // appsCmd related info
 const appsCmdLiteral = "apps"
-const appsCmdShortDesc = "Display a list of Applications in an environment specific to the user"
+const appsCmdShortDesc = "Display a list of Applications in an environment specific to an owner"
 
 var appsCmdLongDesc = dedent.Dedent(`
 		Display a list of Applications of the user in the environment specified by the flag --environment, -e

--- a/import-export-cli/cmd/apps.go
+++ b/import-export-cli/cmd/apps.go
@@ -1,0 +1,153 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/renstrom/dedent"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"fmt"
+	"net/http"
+	"encoding/json"
+	"errors"
+	"github.com/olekukonko/tablewriter"
+	"os"
+)
+
+var listAppsCmdEnvironment string
+var listAppsCmdAppOwner string
+var listAppsCmdUsername string
+var listAppsCmdPassword string
+
+// appsCmd related info
+const appsCmdLiteral = "apps"
+const appsCmdShortDesc = "Display a list of Applications in an environment specific to the user"
+
+var appsCmdLongDesc = dedent.Dedent(`
+		Display a list of Applications of the user in the environment specified by the flag --environment, -e
+	`)
+
+var appsCmdExamples = dedent.Dedent(`
+	` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e dev
+	` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e dev -o sampleUser
+	` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e prod -o sampleUser -u admin
+	` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e staging -o sampleUser -u admin -p admin
+	`)
+
+// appsCmd represents the apps command
+var appsCmd = &cobra.Command{
+	Use:   appsCmdLiteral,
+	Short: appsCmdShortDesc,
+	Long:  appsCmdLongDesc + appsCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + appsCmdLiteral + " called")
+		executeAppsCmd(listAppsCmdAppOwner, utils.MainConfigFilePath, utils.EnvKeysAllFilePath)
+	},
+}
+
+func executeAppsCmd(appOwner, mainConfigFilePath, envKeysAllFilePath string) {
+	accessToken, preCommandErr :=
+		utils.ExecutePreCommandWithOAuth(listAppsCmdEnvironment, listAppsCmdUsername, listAppsCmdPassword,
+			mainConfigFilePath, envKeysAllFilePath)
+
+	if preCommandErr == nil {
+		applicationListEndpoint := utils.GetApplicationListEndpointOfEnv(listAppsCmdEnvironment, mainConfigFilePath)
+		count, apps, err := GetApplicationList(appOwner, accessToken, applicationListEndpoint)
+
+		if err == nil {
+			// Printing the list of available Applications
+			fmt.Println("Environment:", listAppsCmdEnvironment)
+			fmt.Println("No. of Applications:", count)
+			if count > 0 {
+				printApps(apps)
+			}
+		} else {
+			utils.Logln(utils.LogPrefixError+"Getting List of Applications", err)
+		}
+
+	} else {
+		utils.Logln(utils.LogPrefixError + "calling 'list' " + preCommandErr.Error())
+		utils.HandleErrorAndExit("Error calling '"+appsCmdLiteral+"'", preCommandErr)
+	}
+
+}
+
+//Get Application List
+// @param accessToken : Access Token for the environment
+// @param apiManagerEndpoint : API Manager Endpoint for the environment
+// @return count (no. of Applications)
+// @return array of Application objects
+// @return error
+
+func GetApplicationList(appOwner, accessToken, applicationListEndpoint string) (count int32, apps []utils.Application,
+	err error) {
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	resp, err := utils.InvokeGETRequestWithQueryParam("user", appOwner, applicationListEndpoint, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+applicationListEndpoint, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		appListResponse := &utils.ApplicationListResponse{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &appListResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+		}
+
+		return appListResponse.Count, appListResponse.List, nil
+
+	} else {
+		return 0, nil, errors.New(resp.Status())
+	}
+}
+
+func printApps(apps []utils.Application) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Name", "Owner", "Status", "Group-ID"})
+
+	var data [][]string
+
+	for _, app := range apps {
+		data = append(data, []string{app.ID, app.Name, app.Owner, app.Status, app.GroupID})
+	}
+
+	for _, v := range data {
+		table.Append(v)
+	}
+
+	table.Render()
+}
+
+func init() {
+	ListCmd.AddCommand(appsCmd)
+
+	appsCmd.Flags().StringVarP(&listAppsCmdEnvironment, "environment", "e",
+		utils.DefaultEnvironmentName, "Environment to be searched")
+	appsCmd.Flags().StringVarP(&listAppsCmdAppOwner, "owner", "o", "",
+		"Owner of the Application")
+	appsCmd.Flags().StringVarP(&listAppsCmdUsername, "username", "u", "", "Username")
+	appsCmd.Flags().StringVarP(&listAppsCmdPassword, "password", "p", "", "Password")
+}

--- a/import-export-cli/cmd/exportApp.go
+++ b/import-export-cli/cmd/exportApp.go
@@ -56,7 +56,8 @@ var ExportAppCmd = &cobra.Command{
 	Long:  exportAppCmdLongDesc + exportAppCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + exportAppCmdLiteral + " called")
-		executeExportAppCmd(utils.MainConfigFilePath, utils.EnvKeysAllFilePath, utils.ExportDirectory)
+		var appsExportDirectory = filepath.Join(utils.ExportDirectory, utils.ExportedAppsDirName)
+		executeExportAppCmd(utils.MainConfigFilePath, utils.EnvKeysAllFilePath, appsExportDirectory)
 	},
 }
 
@@ -95,7 +96,7 @@ func executeExportAppCmd(mainConfigFilePath, envKeysAllFilePath, exportDirectory
 func WriteApplicationToZip(exportAppName, exportAppOwner, exportEnvironment, exportDirectory string,
 	resp *resty.Response) {
 	// Write to file
-	directory := filepath.Join(exportDirectory, exportEnvironment, utils.DefaultApplicationExportDirName)
+	directory := filepath.Join(exportDirectory, exportEnvironment)
 	// create directory if it doesn't exist
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
 		os.Mkdir(directory, 0777)

--- a/import-export-cli/cmd/exportApp.go
+++ b/import-export-cli/cmd/exportApp.go
@@ -1,0 +1,150 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"github.com/renstrom/dedent"
+	"net/http"
+	"fmt"
+	"github.com/go-resty/resty"
+	"path/filepath"
+	"os"
+	"io/ioutil"
+)
+
+var exportAppName string
+var exportAppOwner string
+var exportAppCmdUsername string
+var exportAppCmdPassword string
+
+//var flagExportAPICmdToken string
+// ExportApp command related usage info
+const exportAppCmdLiteral = "export-app"
+const exportAppCmdShortDesc = "Export App"
+
+var exportAppCmdLongDesc = "Export an Application from a specified  environment"
+
+var exportAppCmdExamples = dedent.Dedent(`
+		Examples:
+		` + utils.ProjectName + ` ` + exportAppCmdLiteral + ` -n SampleApp -o admin -e dev
+		` + utils.ProjectName + ` ` + exportAppCmdLiteral + ` -n SampleApp -o admin -e prod
+		NOTE: Flag --name (-n) and --owner (-o) are mandatory
+	`)
+// exportAppCmd represents the exportApp command
+var ExportAppCmd = &cobra.Command{
+	Use: exportAppCmdLiteral + " (--name <name-of-the-application> --owner <owner-of-the-application> --environment " +
+		"<environment-from-which-the-app-should-be-exported>)",
+	Short: exportAppCmdShortDesc,
+	Long:  exportAppCmdLongDesc + exportAppCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + exportAppCmdLiteral + " called")
+		executeExportAppCmd(utils.MainConfigFilePath, utils.EnvKeysAllFilePath, utils.ExportDirectory)
+	},
+}
+
+func executeExportAppCmd(mainConfigFilePath, envKeysAllFilePath, exportDirectory string) {
+	accessToken, preCommandErr :=
+		utils.ExecutePreCommandWithOAuth(exportEnvironment, exportAppCmdUsername, exportAppCmdPassword,
+			mainConfigFilePath, envKeysAllFilePath)
+
+	if preCommandErr == nil {
+		adminEndpiont := utils.GetAdminEndpointOfEnv(exportEnvironment, mainConfigFilePath)
+		resp := getExportAppResponse(exportAppName, exportAppOwner, adminEndpiont, accessToken)
+
+		// Print info on response
+		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
+
+		if resp.StatusCode() == http.StatusOK {
+			WriteApplicationToZip(exportAppName, exportAppOwner, exportEnvironment, exportDirectory, resp)
+		} else if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthenticated request
+			fmt.Println("Incorrect Password!")
+		} else {
+			// neither 200 nor 500
+			fmt.Println("Error exporting Application:", resp.Status())
+		}
+	} else {
+		// error exporting Application
+		fmt.Println("Error exporting Application:" + preCommandErr.Error())
+	}
+}
+
+// WriteApplicationToZip
+// @param exportAppName : Name of the Application to be exported
+// @param exportAppOwner : Owner of the Application to be exported
+// @param resp : Response returned from making the HTTP request (only pass a 200 OK)
+// Exported Application will be written to a zip file
+func WriteApplicationToZip(exportAppName, exportAppOwner, exportEnvironment, exportDirectory string,
+	resp *resty.Response) {
+	// Write to file
+	directory := filepath.Join(exportDirectory, exportEnvironment, utils.DefaultApplicationExportDirName)
+	// create directory if it doesn't exist
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		os.Mkdir(directory, 0777)
+		// permission 777 : Everyone can read, write, and execute
+	}
+	zipFilename := exportAppOwner + "_" + exportAppName + ".zip" // admin_testApp.zip
+	pFile := filepath.Join(directory, zipFilename)
+	err := ioutil.WriteFile(pFile, resp.Body(), 0644)
+	// permission 644 : Only the owner can read and write.. Everyone else can only read.
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating zip archive", err)
+	}
+	fmt.Println("Succesfully exported Application!")
+	fmt.Println("Find the exported Application at " + pFile)
+}
+
+// ExportApp
+// @param name : Name of the Application to be exported
+// @param apimEndpoint : API Manager Endpoint for the environment
+// @param accessToken : Access Token for the resource
+// @return response Response in the form of *resty.Response
+func getExportAppResponse(name, owner, adminEndpoint, accessToken string) *resty.Response {
+	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
+	query := "export/applications?appName=" + name + utils.SearchAndTag + "appOwner=" + owner
+
+	url := adminEndpoint + query
+	utils.Logln(utils.LogPrefixInfo+"ExportApp: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
+
+	resp, err := utils.InvokeGETRequest(url, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Error exporting Application: "+name, err)
+	}
+
+	return resp
+}
+
+//init using Cobra
+func init() {
+	RootCmd.AddCommand(ExportAppCmd)
+	ExportAppCmd.Flags().StringVarP(&exportAppName, "name", "n", "",
+		"Name of the Application to be exported")
+	ExportAppCmd.Flags().StringVarP(&exportAppOwner, "owner", "o", "",
+		"Owner of the Application to be exported")
+	ExportAppCmd.Flags().StringVarP(&exportEnvironment, "environment", "e",
+		utils.DefaultEnvironmentName, "Environment to which the Application should be exported")
+	ExportAppCmd.Flags().StringVarP(&exportAppCmdUsername, "username", "u", "", "Username")
+	ExportAppCmd.Flags().StringVarP(&exportAppCmdPassword, "password", "p", "", "Password")
+}

--- a/import-export-cli/cmd/exportApp_test.go
+++ b/import-export-cli/cmd/exportApp_test.go
@@ -1,0 +1,68 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+	"net/http/httptest"
+	"net/http"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"github.com/renstrom/dedent"
+	"fmt"
+	"github.com/go-resty/resty"
+	"os"
+	"path/filepath"
+)
+
+func TestExportApp(t *testing.T) {
+	var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected 'GET', got '%s'\n", r.Method)
+		}
+
+		if r.Header.Get(utils.HeaderAccept) != utils.HeaderValueApplicationZip {
+			t.Errorf("Expected '"+utils.HeaderValueApplicationZip+"', got '%s'\n",
+				r.Header.Get(utils.HeaderContentType))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set(utils.HeaderContentType, utils.HeaderValueApplicationJSON)
+		w.Header().Set(utils.HeaderContentEncoding, utils.HeaderValueGZIP)
+		w.Header().Set(utils.HeaderTransferEncoding, utils.HeaderValueChunked)
+
+		body := dedent.Dedent(`
+		`)
+
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	resp := getExportAppResponse("testApp", "admin", server.URL, "")
+	fmt.Println(resp)
+}
+
+func TestWriteApplicationToZip(t *testing.T) {
+	name := "sampleApp"
+	owner := "admin"
+	environment := "dev"
+	response := new(resty.Response)
+	exportDirectory := utils.CurrentDir
+	WriteApplicationToZip(name, owner, environment, exportDirectory, response)
+	defer os.RemoveAll(filepath.Join(exportDirectory, "dev"))
+}

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -65,7 +65,8 @@ var ImportAppCmd = &cobra.Command{
 	Long:  importAppCmdLongDesc + importAppCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + importAppCmdLiteral + " called")
-		executeImportAppCmd(importAppOwner, utils.MainConfigFilePath, utils.EnvKeysAllFilePath, utils.ExportDirectory)
+		var appsExportDirectory = filepath.Join(utils.ExportDirectory, utils.ExportedAppsDirName)
+		executeImportAppCmd(importAppOwner, utils.MainConfigFilePath, utils.EnvKeysAllFilePath, appsExportDirectory)
 	},
 }
 
@@ -214,13 +215,13 @@ func init() {
 	ImportAppCmd.Flags().StringVarP(&importAppFile, "file", "f", "",
 		"Name of the Application to be imported")
 	ImportAppCmd.Flags().StringVarP(&importAppOwner, "owner", "o", "",
-		"Name of the desired owner of the Application by Importer")
+		"Name of the target owner of the Application as desired by the Importer")
 	ImportAppCmd.Flags().StringVarP(&importAppEnvironment, "environment", "e",
 		utils.DefaultEnvironmentName, "Environment from the which the Application should be imported")
 	ImportAppCmd.Flags().BoolVarP(&preserveOwner, "perserveOwner", "r", false,
 		"Preserves app owner")
 	ImportAppCmd.Flags().BoolVarP(&skipSubscriptions, "skipSubscriptions", "s", false,
-		"Adds subscriptions of the Application")
+		"Skip subscriptions of the Application")
 	ImportAppCmd.Flags().StringVarP(&importAppCmdUsername, "username", "u", "", "Username")
 	ImportAppCmd.Flags().StringVarP(&importAppCmdPassword, "password", "p", "", "Password")
 }

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -1,0 +1,245 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/renstrom/dedent"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"net/http"
+	"crypto/tls"
+	"time"
+	"strings"
+	"path/filepath"
+	"bytes"
+	"mime/multipart"
+	"io"
+	"os"
+	"strconv"
+)
+
+var importAppFile string
+var importAppEnvironment string
+var importAppCmdUsername string
+var importAppCmdPassword string
+var importAppOwner string
+var preserveOwner bool
+var skipSubscriptions bool
+
+// ImportApp command related usage info
+const importAppCmdLiteral = "import-app"
+const importAppCmdShortDesc = "Import App"
+
+var importAppCmdLongDesc = "Import an Application to an environment"
+
+var importAppCmdExamples = dedent.Dedent(`
+		Examples:
+		` + utils.ProjectName + ` ` + importAppCmdLiteral + ` -f qa/apps/sampleApp.zip -e dev
+		` + utils.ProjectName + ` ` + importAppCmdShortDesc + ` -f staging/apps/sampleApp.zip -e prod -o testUser -u admin -p admin
+		` + utils.ProjectName + ` ` + importAppCmdLiteral + ` -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e prod
+	`)
+
+// importAppCmd represents the importApp command
+var ImportAppCmd = &cobra.Command{
+	Use: importAppCmdLiteral + " (--file <app-zip-file> --environment " +
+		"<environment-to-which-the-app-should-be-imported>)",
+	Short: importAppCmdShortDesc,
+	Long:  importAppCmdLongDesc + importAppCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + importAppCmdLiteral + " called")
+		executeImportAppCmd(importAppOwner, utils.MainConfigFilePath, utils.EnvKeysAllFilePath, utils.ExportDirectory)
+	},
+}
+
+func executeImportAppCmd(importAppOwner, mainConfigFilePath, envKeysAllFilePath, exportDirectory string) {
+	accessToken, preCommandErr :=
+		utils.ExecutePreCommandWithOAuth(importAppEnvironment, importAppCmdUsername, importAppCmdPassword,
+			mainConfigFilePath, envKeysAllFilePath)
+
+	if preCommandErr == nil {
+		adminEndpiont := utils.GetAdminEndpointOfEnv(importAppEnvironment, mainConfigFilePath)
+		resp, err := ImportApplication(importAppFile, importAppOwner, adminEndpiont, accessToken, exportDirectory)
+		if err != nil {
+			utils.HandleErrorAndExit("Error importing Application", err)
+		}
+
+		if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+			// 200 OK or 201 Created
+			utils.Logln(utils.LogPrefixInfo+"Header:", resp.Header)
+			fmt.Println("Succesfully imported Application!")
+		} else if resp.StatusCode == http.StatusMultiStatus {
+			// 207 Multi Status
+			fmt.Printf("\nPartially imported Application" +
+				"\nNOTE: One or more subscriptions were not imported due to unavailability of APIs/Tiers\n")
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			// 401 Unauthorized
+			fmt.Println("Invalid Credentials or You may not have enough permission!")
+		} else if resp.StatusCode == http.StatusForbidden {
+			// 401 Unauthorized
+			fmt.Printf("Invalid Owner!"+ "\nNOTE: Cross Tenant Imports are not allowed!\n")
+		} else {
+		fmt.Println("Error importing Application")
+		utils.Logln(utils.LogPrefixError + resp.Status)
+		}
+	} else {
+		// env_endpoints file is not configured properly by the user
+		fmt.Println("Error:", preCommandErr)
+		utils.Logln(utils.LogPrefixError + preCommandErr.Error())
+	}
+}
+
+// ImportApplication function is used with import-app command
+// @param name: name of the Application (zipped file) to be imported
+// @param apiManagerEndpoint: API Manager endpoint for the environment
+// @param accessToken: OAuth2.0 access token for the resource being accessed
+func ImportApplication(query, appOwner, adminEndpiont, accessToken, exportDirectory string) (*http.Response, error) {
+	adminEndpiont = utils.AppendSlashToString(adminEndpiont)
+
+	applicationImportEndpoint := adminEndpiont + "import/applications"
+	url := applicationImportEndpoint + "?appOwner=" + appOwner + utils.SearchAndTag + "preserveOwner=" +
+		strconv.FormatBool(preserveOwner) + utils.SearchAndTag + "skipSubscriptions=" +
+		strconv.FormatBool(skipSubscriptions)
+	utils.Logln(utils.LogPrefixInfo + "Import URL: " + applicationImportEndpoint)
+
+	sourceEnv := strings.Split(query, "/")[0] // environment from which the Application was exported
+	utils.Logln(utils.LogPrefixInfo + "Source Environment: " + sourceEnv)
+
+	fileName := query // ex:- fileName = dev/sampleApp.zip //TODO change the ex here appropriately
+
+	zipFilePath := filepath.Join(exportDirectory, fileName)
+	fmt.Println("ZipFilePath:", zipFilePath)
+
+	// check if '.zip' exists in the input 'fileName'
+	//hasZipExtension, _ := regexp.MatchString(`^\S+\.zip$`, fileName)
+
+	//if hasZipExtension {
+	//	// import the zip file directly
+	//	//fmt.Println("hasZipExtension: ", true)
+	//
+	//} else {
+	//	//fmt.Println("hasZipExtension: ", false)
+	//	// search for a directory with the given fileName
+	//	destination := filepath.Join(exportDirectory, fileName+".zip")
+	//	err := utils.ZipDir(zipFilePath, destination)
+	//	if err != nil {
+	//		utils.HandleErrorAndExit("Error creating zip archive", err)
+	//	}
+	//	zipFilePath += ".zip"
+	//}
+
+	extraParams := map[string]string{}
+	// TODO:: Add extraParams as necessary
+
+	req, err := NewAppFileUploadRequest(url, extraParams, "file", zipFilePath, accessToken)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating request.", err)
+	}
+
+	var tr *http.Transport
+	if utils.Insecure {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	} else {
+		tr = &http.Transport{}
+	}
+
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Duration(utils.HttpRequestTimeout) * time.Second,
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		utils.Logln(utils.LogPrefixError, err)
+	} else {
+		//var bodyContent []byte
+
+		if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK ||
+			resp.StatusCode == http.StatusMultiStatus {
+			// 207 Multi Status or 201 Created or 200 OK
+			fmt.Printf("\nCompleted importing the Application '" + fileName + "'\n")
+		} else {
+			fmt.Printf("\nUnable to import the Application\n")
+			fmt.Println("Status: " + resp.Status)
+		}
+
+		//fmt.Println(resp.Header)
+		//resp.Body.Read(bodyContent)
+		//resp.Body.Close()
+		//fmt.Println(bodyContent)
+	}
+
+	return resp, err
+}
+
+// NewFileUploadRequest form an HTTP Put request
+// Helper function for forming multi-part form data
+// Returns the formed http request and errors
+func NewAppFileUploadRequest(uri string, params map[string]string, paramName, path,
+accessToken string) (*http.Request, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile(paramName, filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(part, file)
+
+	for key, val := range params {
+		_ = writer.WriteField(key, val)
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest(http.MethodPost, uri, body)
+	request.Header.Add(utils.HeaderAuthorization, utils.HeaderValueAuthBearerPrefix+" "+accessToken)
+	request.Header.Add(utils.HeaderContentType, writer.FormDataContentType())
+	request.Header.Add(utils.HeaderAccept, "*/*")
+	request.Header.Add(utils.HeaderConnection, utils.HeaderValueKeepAlive)
+
+	return request, err
+}
+
+func init() {
+	RootCmd.AddCommand(ImportAppCmd)
+	ImportAppCmd.Flags().StringVarP(&importAppFile, "file", "f", "",
+		"Name of the Application to be imported")
+	ImportAppCmd.Flags().StringVarP(&importAppOwner, "owner", "o", "",
+		"Name of the desired owner of the Application by Importer")
+	ImportAppCmd.Flags().StringVarP(&importAppEnvironment, "environment", "e",
+		utils.DefaultEnvironmentName, "Environment from the which the Application should be imported")
+	ImportAppCmd.Flags().BoolVarP(&preserveOwner, "perserveOwner", "r", false,
+		"Preserves app owner")
+	ImportAppCmd.Flags().BoolVarP(&skipSubscriptions, "skipSubscriptions", "s", false,
+		"Adds subscriptions of the Application")
+	ImportAppCmd.Flags().StringVarP(&importAppCmdUsername, "username", "u", "", "Username")
+	ImportAppCmd.Flags().StringVarP(&importAppCmdPassword, "password", "p", "", "Password")
+}

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -94,10 +94,10 @@ func executeImportAppCmd(importAppOwner, mainConfigFilePath, envKeysAllFilePath,
 			fmt.Println("Invalid Credentials or You may not have enough permission!")
 		} else if resp.StatusCode == http.StatusForbidden {
 			// 401 Unauthorized
-			fmt.Printf("Invalid Owner!"+ "\nNOTE: Cross Tenant Imports are not allowed!\n")
+			fmt.Printf("Invalid Owner!" + "\nNOTE: Cross Tenant Imports are not allowed!\n")
 		} else {
-		fmt.Println("Error importing Application")
-		utils.Logln(utils.LogPrefixError + resp.Status)
+			fmt.Println("Error importing Application")
+			utils.Logln(utils.LogPrefixError + resp.Status)
 		}
 	} else {
 		// env_endpoints file is not configured properly by the user
@@ -122,31 +122,12 @@ func ImportApplication(query, appOwner, adminEndpiont, accessToken, exportDirect
 	sourceEnv := strings.Split(query, "/")[0] // environment from which the Application was exported
 	utils.Logln(utils.LogPrefixInfo + "Source Environment: " + sourceEnv)
 
-	fileName := query // ex:- fileName = dev/sampleApp.zip //TODO change the ex here appropriately
+	fileName := query // ex:- fileName = dev/sampleApp.zip
 
 	zipFilePath := filepath.Join(exportDirectory, fileName)
 	fmt.Println("ZipFilePath:", zipFilePath)
 
-	// check if '.zip' exists in the input 'fileName'
-	//hasZipExtension, _ := regexp.MatchString(`^\S+\.zip$`, fileName)
-
-	//if hasZipExtension {
-	//	// import the zip file directly
-	//	//fmt.Println("hasZipExtension: ", true)
-	//
-	//} else {
-	//	//fmt.Println("hasZipExtension: ", false)
-	//	// search for a directory with the given fileName
-	//	destination := filepath.Join(exportDirectory, fileName+".zip")
-	//	err := utils.ZipDir(zipFilePath, destination)
-	//	if err != nil {
-	//		utils.HandleErrorAndExit("Error creating zip archive", err)
-	//	}
-	//	zipFilePath += ".zip"
-	//}
-
 	extraParams := map[string]string{}
-	// TODO:: Add extraParams as necessary
 
 	req, err := NewAppFileUploadRequest(url, extraParams, "file", zipFilePath, accessToken)
 	if err != nil {

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -218,7 +218,7 @@ func init() {
 		"Name of the target owner of the Application as desired by the Importer")
 	ImportAppCmd.Flags().StringVarP(&importAppEnvironment, "environment", "e",
 		utils.DefaultEnvironmentName, "Environment from the which the Application should be imported")
-	ImportAppCmd.Flags().BoolVarP(&preserveOwner, "perserveOwner", "r", false,
+	ImportAppCmd.Flags().BoolVarP(&preserveOwner, "preserveOwner", "r", false,
 		"Preserves app owner")
 	ImportAppCmd.Flags().BoolVarP(&skipSubscriptions, "skipSubscriptions", "s", false,
 		"Skip subscriptions of the Application")

--- a/import-export-cli/cmd/importApp_test.go
+++ b/import-export-cli/cmd/importApp_test.go
@@ -1,0 +1,94 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/renstrom/dedent"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImportApplication1(t *testing.T) {
+	var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected '%s', got '%s' instead\n", http.MethodPost, r.Method)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set(utils.HeaderContentType, utils.HeaderValueApplicationJSON)
+		w.Header().Set(utils.HeaderContentEncoding, utils.HeaderValueGZIP)
+		w.Header().Set(utils.HeaderTransferEncoding, utils.HeaderValueChunked)
+
+		body := dedent.Dedent(`
+		`)
+
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	name := "sampleApp.zip"
+	owner := "admin"
+	accessToken := "access-token"
+
+	_, err := ImportApplication(name, owner, server.URL, accessToken, "")
+	if err != nil {
+		t.Errorf("Error: %s\n", err.Error())
+	}
+	utils.Insecure = true
+	_, err = ImportApplication(name, owner, server.URL, accessToken, "")
+	if err != nil {
+		t.Errorf("Error: %s\n", err.Error())
+	}
+}
+
+func TestNewAppFileUploadRequest(t *testing.T) {
+	var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("Expected '%s', got '%s' instead\n", http.MethodPut, r.Method)
+		}
+
+		if !strings.Contains(r.Header.Get(utils.HeaderAccept), utils.HeaderValueMultiPartFormData) {
+			t.Errorf("Expected '%s', got '%s' instead\n", utils.HeaderValueApplicationZip,
+				r.Header.Get(utils.HeaderContentType))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set(utils.HeaderContentType, utils.HeaderValueApplicationJSON)
+		w.Header().Set(utils.HeaderContentEncoding, utils.HeaderValueGZIP)
+		w.Header().Set(utils.HeaderTransferEncoding, utils.HeaderValueChunked)
+
+		body := dedent.Dedent(`
+		`)
+
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	extraParams := map[string]string{}
+	filePath := filepath.Join("sampleApp.zip")
+	accessToken := "access-token"
+	_, err := NewAppFileUploadRequest(server.URL, extraParams, "file", filePath, accessToken)
+	if err != nil {
+		t.Errorf("Error: %s\n", err.Error())
+	}
+}

--- a/import-export-cli/cmd/list.go
+++ b/import-export-cli/cmd/list.go
@@ -26,10 +26,11 @@ import (
 
 // List command related usage Info
 const listCmdLiteral = "list"
-const listCmdShortDesc = "List APIs in an environment or List the environments"
+const listCmdShortDesc = "List APIs/Applications in an environment or List the environments"
 
 var listCmdLongDesc = dedent.Dedent(`
-			Display a list containing all the APIs available in the environment specified by flag (--environment, -e)
+			Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
+			Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)
 			OR
 			List all the environments
 	`)

--- a/import-export-cli/cmd/listEnvs_test.go
+++ b/import-export-cli/cmd/listEnvs_test.go
@@ -28,8 +28,10 @@ func TestPrintEnvs(t *testing.T) {
 	envEndpoints["dev"] = utils.EnvEndpoints{
 		"apim-endpoint",
 		"import-export-endpoint",
-		"list-endpoint",
-		"reg-endpoint",
+		"api-list-endpoint",
+		"application-list-endpoint",
+		"token-endpoint",
+		"admin-endpoint",
 		"token-endpoint",
 	}
 	printEnvs(envEndpoints)

--- a/import-export-cli/cmd/removeEnv_test.go
+++ b/import-export-cli/cmd/removeEnv_test.go
@@ -36,8 +36,10 @@ func TestRemoveEnv1(t *testing.T) {
 	mainConfig.Environments["dev"] = utils.EnvEndpoints{
 		"sample-publisher-endpoint",
 		"sample-import-export-endpoint",
-		"sample-list-endpoint",
+		"sample-api-list-endpoint",
+		"sample-application-list-endpoint",
 		"sample-reg-endpoint",
+		"sample-admin-endpoint",
 		"sample-token-endpoint",
 	}
 	utils.WriteConfigFile(mainConfig, testMainConfigFilePath)
@@ -75,8 +77,10 @@ func TestRemoveEnv2(t *testing.T) {
 	sampleMainConfig.Environments["dev"] = utils.EnvEndpoints{
 		"sample-publisher-endpoint",
 		"sample-import-export-endpoint",
-		"sample-list-endpoint",
+		"sample-api-list-endpoint",
+		"sample-application-list-endpoint",
 		"sample-reg-endpoint",
+		"sample-admin-endpoint",
 		"sample-token-endpoint",
 	}
 	utils.WriteConfigFile(sampleMainConfig, sampleMainConfigFilePath)
@@ -100,8 +104,10 @@ func TestRemoveEnv3(t *testing.T) {
 	sampleMainConfig.Environments["dev"] = utils.EnvEndpoints{
 		"sample-publisher-endpoint",
 		"sample-import-export-endpoint",
-		"sample-list-endpoint",
+		"sample-api-list-endpoint",
+		"sample-application-list-endpoint",
 		"sample-reg-endpoint",
+		"sample-admin-endpoint",
 		"sample-token-endpoint",
 	}
 	utils.WriteConfigFile(sampleMainConfig, sampleMainConfigFilePath)

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -34,10 +34,10 @@ var cfgFile string
 var insecure bool
 
 // RootCmd related info
-const RootCmdShortDesc = "CLI for Importing and Exporting APIs"
+const RootCmdShortDesc = "CLI for Importing and Exporting APIs and Applications"
 
 var RootCmdLongDesc = dedent.Dedent(`
-		` + utils.ProjectName + ` is a Command Line Tool for Importing and Exporting APIs between different environments of WSO2 API Manager 2.1.x
+		` + utils.ProjectName + ` is a Command Line Tool for Importing and Exporting APIs and Applications between different environments of WSO2 API Manager 2.1.x
 		(Dev, Production, Staging, QA etc.)
 		`)
 
@@ -120,14 +120,18 @@ func createConfigFiles() {
 			"https://localhost/apim",
 			"https://localhost/api-import-export",
 			"https://localhost/publisher/apis",
+			"https://localhost:9443/api/am/admin/v0.11/applications",
 			"https://localhost/register",
+			"https://localhost:9443/api/am/admin/v0.11",
 			"https://localhost/token",
 		}
 		mainConfig.Environments["sample-env2"] = utils.EnvEndpoints{
 			"https://localhost/apim",
 			"",
 			"",
+			"",
 			"https://localhost/register",
+			"",
 			"https://localhost/token",
 		}
 		utils.WriteConfigFile(mainConfig, utils.SampleMainConfigFilePath)

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -1,6 +1,6 @@
-<h1 id="cli-for-importing-and-exporting-apis">CLI for Importing and Exporting APIs</h1>
+<h1 id="cli-for-importing-and-exporting-apis-and-applications">CLI for Importing and Exporting APIs and Applications</h1>
 <h2 id="for-wso2-api-manager-2-1-x">For WSO2 API Manager 2.1.x</h2>
-<p>Command Line tool for importing and exporting APIs between different API Environemnts</p>
+<p>Command Line tool for importing and exporting APIs and Applications between different API Environments</p>
 <h2 id="getting-started">Getting Started</h2>
 <ul>
     <li><h3 id="running">Running</h3>
@@ -86,6 +86,42 @@
             apimcli import-api -f TestAPI -e dev
 </code></pre>
 <ul>
+    <li><h4 id="export-app">export-app</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+            --name, -n
+            --owner, -o
+            --environment, -e
+       Optional:
+            --username, -u
+            --password, -p
+            NOTE: user will be prompted to enter credentials if they are not provided with these flags
+   Examples:
+            apimcli export-app -n SampleApp -o admin -e dev
+            apimcli export-app -n SampleApp -o admin -e prod
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li><h4 id="import-app">import-app</h4>
+    </li>
+</ul>
+<pre><code class="lang-bash">        Flags:
+            Required
+                  --file, -f
+                  --environment, -e
+            Optional
+                  --skipSubscriptions, -s
+                  --owner, -o
+                  --preserveOwner, -r
+                  --file, -f
+                  --environment, -e
+        Examples:
+            apimcli import-app -f qa/apps/sampleApp.zip -e dev
+            apimcli Import App -f staging/apps/sampleApp.zip -e prod -o testUser -u admin -p admin
+            apimcli import-app -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e staging
+</code></pre>
+<ul>
     <li><h4 id="list-apis">list apis</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
@@ -102,6 +138,19 @@
           apimcli list apis -e staging 
           apimcli list apis -e staging -u admin -p 123456
           apimcli list apis -e staging -p 123456
+</code></pre>
+    </li>
+    <li><h4 id="list-apps">list apps</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required
+                  --environment, -e
+                  --owner, -o
+            Optional
+                  --username, -u
+                  --password, -p
+        Examples:
+            apimcli list apps -e dev -o admin
+            apimcli list apps -e staging -o sampleUser -u admin -p 123456
 </code></pre>
     </li>
     <li><h4 id="list-envs">list envs</h4>

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -52,7 +52,9 @@ const ExportedAppsDirName = "apps"
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
 
 const defaultApiImportExportProduct = "api-import-export-2.1.0-v3"
+const defaultApplicationImportExportSuffix = "api/am/admin/v0.11"
 const defaultApiListEndpointSuffix = "api/am/publisher/v0.11/apis"
+const defaultApplicationListEndpointSuffix = "api/am/admin/v0.11/applications"
 
 const DefaultEnvironmentName = "default"
 
@@ -79,6 +81,9 @@ const HeaderValueMultiPartFormData = "multipart/form-data"
 const LogPrefixInfo = "[INFO]: "
 const LogPrefixWarning = "[WARN]: "
 const LogPrefixError = "[ERROR]: "
+
+// String Constants
+const SearchAndTag = "&"
 
 // Other
 const DefaultTokenValidityPeriod = "3600"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -44,7 +44,6 @@ const SampleMainConfigFileName = "main_config.yaml.sample"
 var MainConfigFilePath = filepath.Join(ConfigDirPath, MainConfigFileName)
 var SampleMainConfigFilePath = filepath.Join(ConfigDirPath, SampleMainConfigFileName)
 
-
 const DefaultExportDirName = "exported"
 const ExportedApisDirName = "apis"
 const ExportedAppsDirName = "apps"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -195,6 +195,18 @@ func GetApiListEndpointOfEnv(env, filePath string) string {
 	}
 }
 
+// Get ApplicationListEndpoint of a given environment
+func GetApplicationListEndpointOfEnv(env, filePath string) string {
+	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)
+	if !(envEndpoints.AppListEndpoint == "" || envEndpoints == nil) {
+		return envEndpoints.AppListEndpoint
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint+defaultApplicationListEndpointSuffix
+	}
+}
+
 // Get TokenEndpoint of a given environment
 func GetTokenEndpointOfEnv(env, filePath string) string {
 	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -171,6 +171,18 @@ func GetApiImportExportEndpointOfEnv(env, filePath string) string {
 	}
 }
 
+// Get AdminEndpoint of a given environment
+func GetAdminEndpointOfEnv(env, filePath string) string {
+	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)
+	if !(envEndpoints.AdminEndpoint == "" || envEndpoints == nil) {
+		return envEndpoints.AdminEndpoint
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint + defaultApplicationImportExportSuffix
+	}
+}
+
 // Get ApiListEndpoint of a given environment
 func GetApiListEndpointOfEnv(env, filePath string) string {
 	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -203,7 +203,7 @@ func GetApplicationListEndpointOfEnv(env, filePath string) string {
 	} else {
 		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
 		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
-		return apiManagerEndpoint+defaultApplicationListEndpointSuffix
+		return apiManagerEndpoint + defaultApplicationListEndpointSuffix
 	}
 }
 

--- a/import-export-cli/utils/envManagementUtils_test.go
+++ b/import-export-cli/utils/envManagementUtils_test.go
@@ -209,8 +209,10 @@ func TestRemoveEnvFromKeysFile4(t *testing.T) {
 	mainConfig.Environments[devName] = EnvEndpoints{
 		"dev_apim_endpoint",
 		"dev_import_export_endpoint",
-		"dev_list_endpoint",
+		"dev_api_list_endpoint",
+		"dev_application_list_endpoint",
 		"dev_reg_endpoint",
+		"dev_admin_endpoint",
 		"dev_token_endpoint",
 	}
 	WriteConfigFile(mainConfig, testMainConfigFilePath)
@@ -240,8 +242,10 @@ func TestIsDefaultEnvPresent1(t *testing.T) {
 	mainConfig.Environments[DefaultEnvironmentName] = EnvEndpoints{
 		"default-publisher",
 		"default-import-export",
-		"default-list",
+		"default-api-list",
+		"default-application-list",
 		"default-reg",
+		"default-admin",
 		"default-token",
 	}
 
@@ -280,8 +284,10 @@ func TestGetDefaultEnvironment1(t *testing.T) {
 	mainConfig.Environments[DefaultEnvironmentName] = EnvEndpoints{
 		"default-publisher",
 		"default-import-export",
-		"default-list",
+		"default-api-list",
+		"default-application-list",
 		"default-reg",
+		"default-admin",
 		"default-token",
 	}
 
@@ -329,8 +335,10 @@ func TestRemoveEnvFromMainConfigFile2(t *testing.T) {
 	mainConfig.Environments["dev"] = EnvEndpoints{
 		"default-publisher",
 		"default-import-export",
-		"default-list",
+		"default-api-list",
+		"default-application-list",
 		"default-reg",
+		"default-admin",
 		"default-token",
 	}
 
@@ -352,8 +360,10 @@ func TestRemoveEnvFromMainConfigFile3(t *testing.T) {
 	mainConfig.Environments["dev"] = EnvEndpoints{
 		"default-publisher",
 		"default-import-export",
-		"default-list",
+		"default-api-list",
+		"default-application-list",
 		"default-reg",
+		"default-admin",
 		"default-token",
 	}
 
@@ -372,8 +382,10 @@ func TestGetEndpointsOfEnvironment(t *testing.T) {
 	mainConfig.Environments["dev"] = EnvEndpoints{
 		"default-publisher",
 		"default-import-export",
-		"default-list",
+		"default-api-list",
+		"default-application-list",
 		"default-reg",
+		"default-admin",
 		"default-token",
 	}
 

--- a/import-export-cli/utils/fileIOUtils_test.go
+++ b/import-export-cli/utils/fileIOUtils_test.go
@@ -77,15 +77,19 @@ func initSampleMainConfig() {
 	mainConfig.Environments[devName] = EnvEndpoints{
 		"dev_apim_endpoint",
 		"dev_import_export_endpoint",
-		"dev_list_endpoint",
+		"dev_api_list_endpoint",
+		"dev_application_list_endpoint",
 		"dev_reg_endpoint",
+		"dev_admin_endpoint",
 		"dev_token_endpoint",
 	}
 	mainConfig.Environments[qaName] = EnvEndpoints{
 		"qa_apim_endpoint",
 		"qa_import_export_endpoint",
-		"qa_list_endpoint",
+		"qa_api_list_endpoint",
+		"qa_application_list_endpoint",
 		"qa_reg_endpoint",
+		"qa_admin_endpoint",
 		"dev_token_endpoint",
 	}
 }
@@ -170,7 +174,7 @@ func TestMainConfig_ParseMainConfigFromFile2(t *testing.T) {
 
 	mainConfig.Environments = make(map[string]EnvEndpoints)
 	mainConfig.Environments[devName] = EnvEndpoints{"", "", "",
-		"dev_reg_endpoint", "dev_token_endpoint"}
+		"", "dev_reg_endpoint", "", "dev_token_endpoint"}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
 
 	data, _ := ioutil.ReadFile(testMainConfigFilePath)
@@ -192,7 +196,7 @@ func TestMainConfig_ParseMainConfigFromFile3(t *testing.T) {
 
 	mainConfig.Environments = make(map[string]EnvEndpoints)
 	mainConfig.Environments[devName] = EnvEndpoints{"dev_apim_endpoint", "", "",
-		"", "dev_token_endpoint"}
+		"", "", "", "dev_token_endpoint"}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
 
 	data, _ := ioutil.ReadFile(testMainConfigFilePath)
@@ -214,7 +218,7 @@ func TestMainConfig_ParseMainConfigFromFile4(t *testing.T) {
 
 	mainConfig.Environments = make(map[string]EnvEndpoints)
 	mainConfig.Environments[devName] = EnvEndpoints{"dev_apim_endpoint", "", "",
-		"dev_reg_endpoint", ""}
+		"", "dev_reg_endpoint", "", ""}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
 
 	data, _ := ioutil.ReadFile(testMainConfigFilePath)

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -48,7 +48,9 @@ type EnvEndpoints struct {
 	ApiManagerEndpoint      string `yaml:"api_manager_endpoint"`
 	ApiImportExportEndpoint string `yaml:"api_import_export_endpoint"`
 	ApiListEndpoint         string `yaml:"api_list_endpoint"`
+	AppListEndpoint			string `yaml:"application_list_endpoint"`
 	RegistrationEndpoint    string `yaml:"registration_endpoint"`
+	AdminEndpoint           string `yaml:"admin_endpoint"`
 	TokenEndpoint           string `yaml:"token_endpoint"`
 }
 

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -48,7 +48,7 @@ type EnvEndpoints struct {
 	ApiManagerEndpoint      string `yaml:"api_manager_endpoint"`
 	ApiImportExportEndpoint string `yaml:"api_import_export_endpoint"`
 	ApiListEndpoint         string `yaml:"api_list_endpoint"`
-	AppListEndpoint			string `yaml:"application_list_endpoint"`
+	AppListEndpoint         string `yaml:"application_list_endpoint"`
 	RegistrationEndpoint    string `yaml:"registration_endpoint"`
 	AdminEndpoint           string `yaml:"admin_endpoint"`
 	TokenEndpoint           string `yaml:"token_endpoint"`
@@ -66,11 +66,11 @@ type API struct {
 }
 
 type Application struct {
-	ID         string `json:"applicationId"`
-	Name       string `json:"name"`
-	Owner 	   string `json:"owner"`
-	Status     string `json:"status"`
-	GroupID    string `json:"groupId"`
+	ID      string `json:"applicationId"`
+	Name    string `json:"name"`
+	Owner   string `json:"owner"`
+	Status  string `json:"status"`
+	GroupID string `json:"groupId"`
 }
 
 type RegistrationResponse struct {

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -65,6 +65,14 @@ type API struct {
 	Status   string `json:"status"`
 }
 
+type Application struct {
+	ID         string `json:"applicationId"`
+	Name       string `json:"name"`
+	Owner 	   string `json:"owner"`
+	Status     string `json:"status"`
+	GroupID    string `json:"groupId"`
+}
+
 type RegistrationResponse struct {
 	ClientID     string `json:"clientId"`
 	ClientSecret string `json:"clientSecret"`
@@ -83,4 +91,9 @@ type TokenResponse struct {
 type APIListResponse struct {
 	Count int32 `json:"count"`
 	List  []API `json:"list"`
+}
+
+type ApplicationListResponse struct {
+	Count int32         `json:"count"`
+	List  []Application `json:"list"`
 }

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -313,7 +313,7 @@ func GetBase64EncodedCredentials(key, secret string) (encodedValue string) {
 func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url string) (map[string]string, error) {
 	validityPeriod := DefaultTokenValidityPeriod
 	body := "grant_type=password&username=" + username + "&password=" + password + "&validity_period=" +
-		validityPeriod + "&scope=apim:api_view"
+		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change"
 
 	// set headers
 	headers := make(map[string]string)

--- a/import-export-cli/utils/tokenManagement_test.go
+++ b/import-export-cli/utils/tokenManagement_test.go
@@ -116,7 +116,9 @@ func TestExecutePreCommandWithBasicAuth1(t *testing.T) {
 		apimStub.URL,
 		apimStub.URL + "/api-import-export",
 		apimStub.URL + "/publisher/apis",
+		apimStub.URL + "/admin/applications",
 		registrationStub.URL,
+		apimStub.URL + "/admin",
 		oauthStub.URL,
 	}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
@@ -167,7 +169,9 @@ func TestExecutePreCommandWithBasicAuth2(t *testing.T) {
 		apimStub.URL,
 		apimStub.URL + "/api-import-export",
 		apimStub.URL + "/publisher/apis",
+		apimStub.URL + "/admin/applications",
 		registrationStub.URL,
+		apimStub.URL + "/admin",
 		oauthStub.URL,
 	}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
@@ -262,7 +266,9 @@ func TestExecutePreCommandWithOAuth1(t *testing.T) {
 		apimStub.URL,
 		apimStub.URL + "/api-import-export",
 		apimStub.URL + "/publisher/apis",
+		apimStub.URL + "/admin/applications",
 		registrationStub.URL,
+		apimStub.URL + "/admin",
 		oauthStub.URL,
 	}
 	WriteConfigFile(mainConfig, mainConfigFilePath)
@@ -311,7 +317,9 @@ func TestExecutePreCommandWithOAuth2(t *testing.T) {
 		apimStub.URL,
 		apimStub.URL + "/api-import-export",
 		apimStub.URL + "/publisher/apis",
+		apimStub.URL + "/admin/applications",
 		registrationStub.URL,
+		apimStub.URL + "/admin",
 		oauthStub.URL,
 	}
 	WriteConfigFile(mainConfig, mainConfigFilePath)

--- a/import-export-cli/utils/utils.go
+++ b/import-export-cli/utils/utils.go
@@ -52,6 +52,18 @@ func InvokeGETRequest(url string, headers map[string]string) (*resty.Response, e
 	return resp, err
 }
 
+// Invoke http-get request with query param
+func InvokeGETRequestWithQueryParam(queryParam string, paramValue string, url string, headers map[string]string) (
+	*resty.Response, error) {
+	if Insecure {
+		resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) // To bypass errors in SSL certificates
+	}
+	resty.SetTimeout(time.Duration(HttpRequestTimeout) * time.Millisecond)
+	resp, err := resty.R().SetHeaders(headers).SetQueryParam(queryParam, paramValue).Get(url)
+
+	return resp, err
+}
+
 func PromptForUsername() string {
 	reader := bufio.NewReader(os.Stdin)
 


### PR DESCRIPTION
## Purpose
 - Adding commands to provide Application import export support for the import-export CLI implemented 
   for API Manager 2.1.x 

## Approach
 - The implementation include commands to export an application from a desired environment ```export-app```, import an application to a desired environment ```import-app``` and to list applications of a specific environment ```list apps```. 

## Documentation
 - ```product-apim-tooling/import-export-cli/README.md``` for more info.
 -  [README.md](https://github.com/randilu/product-apim-tooling/blob/import-export-apps-cli/import-export-cli/README.md) 

## Automation tests
 - Unit tests included with the source
 - Execute ```go test -v``` inside ```product-apim-tooling/import-export-cli``` for more information

## Security checks
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Test environment
 - [Go 1.8.x](https://golang.org/dl/)
 - [Glide - Dependency manager for Go](https://github.com/Masterminds/glide#install)
 