### PR TITLE
Adding support for relative importapi filename

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -113,8 +113,17 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 	utils.Logln(utils.LogPrefixInfo + "Source Environment: " + sourceEnv)
 
 	fileName := query // ex:- fileName = dev/twitterapi_1.0.0.zip
+	
+	var zipFilePath string = fileName
+	// Test if we can find the file in the current workdirectory
+	if _, err := os.Stat(fileName); os.IsNotExist(err) {
+		// Doesnt exist... Check if available in the default exportDirectory
+		zipFilePath = filepath.Join(exportDirectory, fileName)
+		if _, err := os.Stat(zipFilePath); os.IsNotExist(err) {
+			utils.HandleErrorAndExit("Cant find API file " + zipFilePath + " to import", err)
+		}
+	}
 
-	zipFilePath := filepath.Join(exportDirectory, fileName)
 	fmt.Println("ZipFilePath:", zipFilePath)
 
 	// check if '.zip' exists in the input 'fileName'


### PR DESCRIPTION
## Purpose
I need to script the deployment of APIs. For that I need to be able to execute the apimcli from an arbitrary folder and with that an arbitrary location where the API-source zip is located. This is not possible in the current 2.x branch codebase.

## Goals
The apimcli should treat the passed-in filename argument as a relative (from current work directory) or absolute path first. If the file could not be found then search the original export directory location for the filename. This approach makes the additional file check backwards-compatible with the current usage scenario. 

## Approach
I have added a conditional that first 'stat's the passed-in filename, if it was found then use it. If it was not found then follow the original proces of finding the file in the configured export directory.
If neither was found then report that the source file could not be found to the user.