### PR TITLE
[2.x] Adding zip support for directories

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -119,16 +119,16 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 	zipFilePath := fileName
 
 	// Check whether the given path is a directory
-	// If it is a directory archive it
+	// If it is a directory, archive it
 	if info, err := os.Stat(fileName); err == nil && info.IsDir() {
 		fmt.Println(fileName + " is a directory")
 		fmt.Println("Creating an archive from the directory...")
 
+		// create a temp file in OS temp directory
 		tmpZip, err := ioutil.TempFile("", fileName+"*.zip")
 		if err != nil {
 			utils.HandleErrorAndExit("Error creating archive", err)
 		}
-
 		// schedule to delete the temp file
 		defer os.Remove(tmpZip.Name())
 

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -114,10 +114,35 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 	sourceEnv := strings.Split(query, "/")[0] // environment from which the API was exported
 	utils.Logln(utils.LogPrefixInfo + "Source Environment: " + sourceEnv)
 
-	fileName := query // ex:- fileName = dev/twitterapi_1.0.0.zip
+	// fileName can be a environment related path like dev/PizzaShackAPI.zip
+	fileName := query
+	zipFilePath := fileName
 
-	var zipFilePath string = fileName
-	// Test if we can find the file in the current work directory
+	// Check whether the given path is a directory
+	// If it is a directory archive it
+	if info, err := os.Stat(fileName); err == nil && info.IsDir() {
+		fmt.Println(fileName + " is a directory")
+		fmt.Println("Creating an archive from the directory...")
+
+		tmpZip, err := ioutil.TempFile("", fileName+"*.zip")
+		if err != nil {
+			utils.HandleErrorAndExit("Error creating archive", err)
+		}
+
+		// schedule to delete the temp file
+		defer os.Remove(tmpZip.Name())
+
+		// zip the given directory
+		err = utils.ZipDir(fileName, tmpZip.Name())
+		if err != nil {
+			utils.HandleErrorAndExit("Unable to create archive", err)
+		}
+
+		// change our zip file path to new archive
+		zipFilePath = tmpZip.Name()
+	}
+
+	// Test if we can find the zip file in the current work directory
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		// Doesn't exist... Check if available in the default exportDirectory
 		zipFilePath = filepath.Join(exportDirectory, fileName)
@@ -127,24 +152,6 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 	}
 
 	fmt.Println("ZipFilePath:", zipFilePath)
-
-	// check if '.zip' exists in the input 'fileName'
-	//hasZipExtension, _ := regexp.MatchString(`^\S+\.zip$`, fileName)
-
-	//if hasZipExtension {
-	//	// import the zip file directly
-	//	//fmt.Println("hasZipExtension: ", true)
-	//
-	//} else {
-	//	//fmt.Println("hasZipExtension: ", false)
-	//	// search for a directory with the given fileName
-	//	destination := filepath.Join(exportDirectory, fileName+".zip")
-	//	err := utils.ZipDir(zipFilePath, destination)
-	//	if err != nil {
-	//		utils.HandleErrorAndExit("Error creating zip archive", err)
-	//	}
-	//	zipFilePath += ".zip"
-	//}
 
 	extraParams := map[string]string{}
 	// TODO:: Add extraParams as necessary

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -137,7 +137,6 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 		if err != nil {
 			utils.HandleErrorAndExit("Unable to create archive", err)
 		}
-
 		// change our zip file path to new archive
 		zipFilePath = tmpZip.Name()
 	}

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -121,11 +121,13 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 	// Check whether the given path is a directory
 	// If it is a directory, archive it
 	if info, err := os.Stat(fileName); err == nil && info.IsDir() {
-		fmt.Println(fileName + " is a directory")
+		// Get base name of the file
+		fileBase := filepath.Base(fileName)
+		fmt.Println(fileBase + " is a directory")
 		fmt.Println("Creating an archive from the directory...")
 
 		// create a temp file in OS temp directory
-		tmpZip, err := ioutil.TempFile("", fileName+"*.zip")
+		tmpZip, err := ioutil.TempFile("", fileBase+"*.zip")
 		if err != nil {
 			utils.HandleErrorAndExit("Error creating archive", err)
 		}
@@ -133,7 +135,7 @@ func ImportAPI(query, apiImportExportEndpoint, accessToken, exportDirectory stri
 		defer os.Remove(tmpZip.Name())
 
 		// zip the given directory
-		err = utils.ZipDir(fileName, tmpZip.Name())
+		err = utils.Zip(fileName, tmpZip.Name())
 		if err != nil {
 			utils.HandleErrorAndExit("Unable to create archive", err)
 		}

--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-resty/resty v0.0.0-20171018191538-8b5e3f91fbea
 	github.com/hashicorp/hcl v0.0.0-20171017181929-23c074d0eceb // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jhoonb/archivex v0.0.0-20170408192736-be4efa7ec0c3
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/magiconair/properties v0.0.0-20170902060319-8d7837e64d3c // indirect
 	github.com/mattn/go-runewidth v0.0.0-20161012013512-737072b4e32b // indirect

--- a/import-export-cli/go.sum
+++ b/import-export-cli/go.sum
@@ -11,8 +11,6 @@ github.com/hashicorp/hcl v0.0.0-20171017181929-23c074d0eceb h1:1OvvPvZkn/yCQ3xBc
 github.com/hashicorp/hcl v0.0.0-20171017181929-23c074d0eceb/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jhoonb/archivex v0.0.0-20170408192736-be4efa7ec0c3 h1:YNwzaLzx53gqzWMPq16GnI6q2eXnXHSSkZfdOnRrtYk=
-github.com/jhoonb/archivex v0.0.0-20170408192736-be4efa7ec0c3/go.mod h1:GN1Mg/uXQ6qwXA0HypnUO3xlcQJS9/y68EsHNeuuRa4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/import-export-cli/utils/fileIOUtils_test.go
+++ b/import-export-cli/utils/fileIOUtils_test.go
@@ -318,7 +318,7 @@ func TestIsDirExist2(t *testing.T) {
 	os.Mkdir(tempDirName, os.ModePerm)
 	isDirExist, _ := IsDirExists(tempDirName)
 	if !isDirExist {
-		t.Error("Expected '%t' for a directory that does exist, got '%t' instead\n", true, false)
+		t.Errorf("Expected '%t' for a directory that does exist, got '%t' instead\n", true, false)
 	}
 
 	defer os.Remove(tempDirName)

--- a/import-export-cli/utils/zipUtils.go
+++ b/import-export-cli/utils/zipUtils.go
@@ -19,23 +19,71 @@
 package utils
 
 import (
-	"github.com/jhoonb/archivex"
+	"archive/zip"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
+// ZipDir will create an archive from source and store it in target
 func ZipDir(source, target string) error {
-	err := os.Chdir(source)
-	if err == nil {
-		Logln(LogPrefixInfo + "Directory " + source + " exists")
-		Logln(LogPrefixInfo + "Starting Compression...")
-		zip := new(archivex.ZipFile)
-		zip.Create(target)
-		zip.AddAll(source, true)
-		zip.Close()
-		Logln(LogPrefixInfo + "Compression completed: Find file " + target)
-		return nil
-	} else {
-		Logln(LogPrefixError + "Compressing " + source)
+	zipFile, err := os.Create(target)
+	if err != nil {
 		return err
 	}
+	defer zipFile.Close()
+
+	archive := zip.NewWriter(zipFile)
+	defer archive.Close()
+
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil
+	}
+
+	var baseDir string
+	if info.IsDir() {
+		baseDir = filepath.Base(source)
+	}
+
+	filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		if baseDir != "" {
+			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
+		}
+
+		if info.IsDir() {
+			header.Name += "/"
+		} else {
+			header.Method = zip.Deflate
+		}
+
+		writer, err := archive.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(writer, file)
+		return err
+	})
+
+	return err
 }

--- a/import-export-cli/utils/zipUtils.go
+++ b/import-export-cli/utils/zipUtils.go
@@ -32,7 +32,7 @@ func ZipDir(source, target string) error {
 	if err != nil {
 		return err
 	}
-	defer zipFile.Close()
+	defer zipFile.Close() // close the archive when exit
 
 	archive := zip.NewWriter(zipFile)
 	defer archive.Close()
@@ -60,7 +60,6 @@ func ZipDir(source, target string) error {
 		if baseDir != "" {
 			header.Name = filepath.Join(baseDir, strings.TrimPrefix(path, source))
 		}
-
 		if info.IsDir() {
 			header.Name += "/"
 		} else {
@@ -71,7 +70,6 @@ func ZipDir(source, target string) error {
 		if err != nil {
 			return err
 		}
-
 		if info.IsDir() {
 			return nil
 		}
@@ -81,9 +79,9 @@ func ZipDir(source, target string) error {
 			return err
 		}
 		defer file.Close()
+
 		_, err = io.Copy(writer, file)
 		return err
 	})
-
 	return err
 }

--- a/import-export-cli/utils/zipUtils_test.go
+++ b/import-export-cli/utils/zipUtils_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 func TestZipDirError(t *testing.T) {
-	err := ZipDir("", "")
+	err := Zip("", "")
 	if err == nil {
-		t.Errorf("ZipDir() didn't return an error for invalid source and destination")
+		t.Errorf("Zip() didn't return an error for invalid source and destination")
 	}
 }
 
@@ -90,7 +90,7 @@ func TestZipDirOK(t *testing.T) {
 	zipFile := filepath.Join(directoryPath, "testZip.zip")
 
 	// now try compressing
-	err = ZipDir(directoryPath, zipFile)
+	err = Zip(directoryPath, zipFile)
 
 	if err != nil {
 		t.Errorf("Error compressing directory: %s\n", err)


### PR DESCRIPTION
## Purpose
To enable apimcli to archive a directory in a given path and import it to APIM

## Approach
- Check given path exists and it is a directory
- If directory apimcli will pack an archive with directory contents
- Use new archive to import API

## User stories
- Users now can edit and easily import APIs without manually zipping it

## Test environment
- Linux 4.15.0-46-generic #49-Ubuntu SMP  x86_64 GNU/Linux
 