### PR TITLE
Added api lifecycle command with relevant api oauth permissions

### DIFF
--- a/import-export-cli/cmd/api.go
+++ b/import-export-cli/cmd/api.go
@@ -1,0 +1,181 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/go-resty/resty"
+	"github.com/renstrom/dedent"
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var apiUsername = ""
+var apiPassword = ""
+var apiEnvironment = ""
+var apiLifCycleAction = ""
+var apiName = ""
+var apiVersion = ""
+var apiID = ""
+
+// API command related usage Info
+const apiCmdLiteral = "api"
+const apiCmdShortDesc = "Control API related stuffs"
+
+var apiCmdLongDesc = dedent.Dedent(`
+			allows to control an API given by id or name/version
+	`)
+
+var apiCmdExamples = dedent.Dedent(`
+		Examples:
+		apimcli api lifecycle -e dev --action="Publish" -u admin -p admin -k
+	`)
+
+// Status command related stuffs
+const lifecycleCmdLiteral = "lifecycle"
+const lifecycleCmdShortDesc = "Change lifecycle of an API"
+
+var lifecycleCmdLongDesc = dedent.Dedent(`
+			allows to control an API given by id or name/version
+	`)
+
+var lifecycleCmdExamples = dedent.Dedent(`
+		Examples:
+		apimcli api lifecycle -e dev --id="your-api-id" --action="Deploy as a Prototype" -u admin -p admin -k
+		apimcli api lifecycle -e dev --name="your-api-name" --version="api-version" --action="Deploy as a Prototype" -u admin -p admin -k
+	`)
+
+// lifecycleCmd represents lifecycle command
+var lifecycleCmd = &cobra.Command{
+	Use:   lifecycleCmdLiteral + " --action=<action to take> -e <environment> [flags]",
+	Short: lifecycleCmdShortDesc,
+	Long:  lifecycleCmdLongDesc + lifecycleCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + lifecycleCmdLiteral + " called")
+		err := changeLifecycle()
+		if err != nil {
+			utils.HandleErrorAndExit("Error", err)
+		}
+	},
+}
+
+// apiCmd represents the api command
+var apiCmd = &cobra.Command{
+	Use:   apiCmdLiteral,
+	Short: apiCmdShortDesc,
+	Long:  apiCmdLongDesc + apiCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + apiCmdLiteral + " called")
+	},
+}
+
+// init using Cobra
+func init() {
+	lifecycleCmd.Flags().StringVarP(&apiEnvironment, "environment", "e",
+		utils.DefaultEnvironmentName, "Environment from the which the API should be imported")
+	lifecycleCmd.Flags().StringVarP(&apiUsername, "username", "u", "", "Username")
+	lifecycleCmd.Flags().StringVarP(&apiPassword, "password", "p", "", "Password")
+	lifecycleCmd.Flags().StringVarP(&apiName, "name", "", "", "API name i.e. PizzaShackAPI")
+	lifecycleCmd.Flags().StringVarP(&apiID, "id", "", "", "API ID")
+	lifecycleCmd.Flags().StringVarP(&apiVersion, "version", "", "", "API version i.e. 1.0.0")
+	lifecycleCmd.Flags().StringVarP(&apiLifCycleAction, "action", "", "", "Action to be "+
+		"taken. Supported actions: Publish, Deploy as a Prototype, Demote to Created, Demote to Prototyped, Block, Deprecate, "+
+		"Re-Publish, Retire")
+
+	apiCmd.AddCommand(lifecycleCmd)
+	RootCmd.AddCommand(apiCmd)
+}
+
+// change lifecycle of an api
+func changeLifecycle() error {
+	// get access token
+	accessOAuthToken, err :=
+		utils.ExecutePreCommandWithOAuth(apiEnvironment, apiUsername, apiPassword,
+			utils.MainConfigFilePath, utils.EnvKeysAllFilePath)
+	if err != nil {
+		return err
+	}
+
+	// check for lifecycle
+	if apiLifCycleAction == "" {
+		return errors.New("api lifecycle action is not defined")
+	}
+	// check for apiID
+	if apiID == "" {
+		// if not provided check whether name and version is there
+		if apiName == "" || apiVersion == "" {
+			return errors.New("either set apiID or name and version")
+		}
+		// get apiID from api manager
+		apiID, err = getApiID(apiName, apiVersion, "", apiEnvironment, accessOAuthToken)
+		if err != nil {
+			return err
+		}
+	}
+
+	utils.Logln(utils.LogPrefixInfo + "Changing api lifecycle to " + apiLifCycleAction)
+	err = changeAPIStatusByID(apiID, apiLifCycleAction, apiEnvironment, accessOAuthToken)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Successfully changed lifecycle to " + apiLifCycleAction)
+	return nil
+}
+
+// changeAPIStatusByID changes status of an api given by apiID for the environment
+func changeAPIStatusByID(apiID, status, environment, accessToken string) error {
+	if apiID == "" {
+		return errors.New("api ID is not set")
+	}
+	if status == "" {
+		return errors.New("status is not set")
+	}
+
+	// get endpoint for API
+	endpointString := utils.GetApiListEndpointOfEnv(environment, utils.MainConfigFilePath)
+	endpoint, err := url.Parse(endpointString)
+	if err != nil {
+		return err
+	}
+	endpoint.Path = path.Join(endpoint.Path, "/change-lifecycle")
+
+	resty.SetTimeout(time.Duration(utils.HttpRequestTimeout) * time.Millisecond)
+	if utils.Insecure {
+		resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) // To bypass errors in SSL certificates
+	}
+	resp, err := resty.R().SetQueryParams(map[string]string{
+		"apiId":  apiID,
+		"action": status,
+	}).SetAuthToken(accessToken).Post(endpoint.String())
+	if err != nil {
+		return err
+	}
+
+	// check if response is 200
+	if resp.StatusCode() == 200 {
+		return nil
+	}
+	return errors.New(string(resp.Body()))
+}

--- a/import-export-cli/cmd/importAPI_test.go
+++ b/import-export-cli/cmd/importAPI_test.go
@@ -49,18 +49,15 @@ func TestImportAPI1(t *testing.T) {
 	}))
 	defer server.Close()
 
-	name := "sampleapi.zip"
+	name := "PizzaShackAPI_1.0.0.zip"
 	accessToken := "access-token"
 
-	_, err := ImportAPI(name, server.URL, accessToken, "")
-	if err != nil {
-		t.Errorf("Error: %s\n", err.Error())
-	}
+	err := ImportAPI(name, server.URL, accessToken, "testdata", "")
+	assert.Nil(t, err, "Error should be nil")
+
 	utils.Insecure = true
-	_, err = ImportAPI(name, server.URL, accessToken, "")
-	if err != nil {
-		t.Errorf("Error: %s\n", err.Error())
-	}
+	err = ImportAPI(name, server.URL, accessToken, "testdata", "")
+	assert.Nil(t, err, "Error should be nil")
 }
 
 func TestNewFileUploadRequest(t *testing.T) {
@@ -114,7 +111,7 @@ func TestExtractAPIInfoWithCorrectJSON(t *testing.T) {
 	}`
 
 	api, err := extractAPIInfo([]byte(content))
-	assert.Equal(t, api, &API{IdInfo{Provider: "admin", Version: "1.0.0", Name: "APIName"}},
+	assert.Equal(t, api, &ApiInfo{IdInfo{Provider: "admin", Version: "1.0.0", Name: "APIName"}},
 		"Should parse correct json")
 	assert.Equal(t, err, nil, "Should return nil error for correct json")
 }
@@ -133,7 +130,7 @@ func TestExtractAPIInfoWhenIDTagMissing(t *testing.T) {
 	}`
 
 	api, err := extractAPIInfo([]byte(content))
-	assert.Equal(t, &API{}, api, "Should return empty IDInfo when ID tag missing")
+	assert.Equal(t, &ApiInfo{}, api, "Should return empty IDInfo when ID tag missing")
 	assert.Nil(t, err, "Should return nil error")
 }
 
@@ -158,14 +155,14 @@ func TestExtractAPIInfoWithMalformedJSON(t *testing.T) {
 func TestGetAPIInfoCorrectZip(t *testing.T) {
 	api, err := getAPIInfo("testdata/PizzaShackAPI_1.0.0.zip")
 	assert.Nil(t, err, "Should return nil error on reading correct zip files")
-	assert.Equal(t, &API{IdInfo{Name: "PizzaShackAPI", Version: "1.0.0", Provider: "admin"}}, api,
+	assert.Equal(t, &ApiInfo{IdInfo{Name: "PizzaShackAPI", Version: "1.0.0", Provider: "admin"}}, api,
 		"Should return correct values for ID info")
 }
 
 func TestGetAPIInfoCorrectDirectoryStructure(t *testing.T) {
 	api, err := getAPIInfo("testdata/PizzaShackAPI-1.0.0")
 	assert.Nil(t, err, "Should return nil error on reading correct directories")
-	assert.Equal(t, &API{IdInfo{Name: "PizzaShackAPI", Version: "1.0.0", Provider: "admin"}}, api,
+	assert.Equal(t, &ApiInfo{IdInfo{Name: "PizzaShackAPI", Version: "1.0.0", Provider: "admin"}}, api,
 		"Should return correct values for ID info")
 }
 

--- a/import-export-cli/utils/envInject.go
+++ b/import-export-cli/utils/envInject.go
@@ -56,7 +56,9 @@ type EndpointData struct {
 type Environment struct {
 	// Name of the environment
 	Name string `yaml:"name"`
-	// Endpoints contain deatails about endpoints in a configuration
+	// Status of the API
+	Status string `yaml:"status"`
+	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
 }
 
@@ -174,10 +176,10 @@ func MergeJSON(firstSource, secondSource []byte) ([]byte, error) {
 }
 
 // GetEnv returns the EndpointData associated for key in the APIConfig, if not found returns nil
-func (config APIConfig) GetEnv(key string) *EndpointData {
+func (config APIConfig) GetEnv(key string) *Environment {
 	for index, env := range config.Environments {
 		if env.Name == key {
-			return config.Environments[index].Endpoints
+			return &config.Environments[index]
 		}
 	}
 	return nil

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -313,7 +313,7 @@ func GetBase64EncodedCredentials(key, secret string) (encodedValue string) {
 func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url string) (map[string]string, error) {
 	validityPeriod := DefaultTokenValidityPeriod
 	body := "grant_type=password&username=" + username + "&password=" + password + "&validity_period=" +
-		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe"
+		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe+apim:api_publish"
 
 	// set headers
 	headers := make(map[string]string)


### PR DESCRIPTION
## Purpose
To enable api status transition(aka lifecycle change) via cli

## Goals
- To allow people using a configuration file(.apim-vars.yml) to change API state on CI/CD stages
- To allow people to change API lifecycle using a command

## Approach
- Integrates with `.apim-vars.yml`. People now can define the status transition along with their definition like
```yaml
environments:
  - name: prod
    status: 'Publish'
    endpoints:
      production:
        url: 'http://test.foo.com'
        config:
          retryTimeOut: 60
      sandbox:
        url: 'http://test.foo.sandbox.com'
```
Then cli tool will change the lifecycle when API is successfully imported.

- Use a separate command to control api lifecycle
  - `apimcli api lifecycle -e dev --id="your-api-id" --action="Deploy as a Prototype" -u admin -p admin`
     This version uses api ID as the identifier
  - `apimcli api lifecycle -e dev --name="your-api-name" --version="api-version" --action="Deploy as a Prototype" -u admin -p admin
`
    This version uses API name and version as the identifier

It is mandatory to use either API ID or name/version combination to change lifecycle of an API.

Please note all above **status** or **action** variables are in compliance with [WSO2 Publisher API](https://docs.wso2.com/display/AM260/apidocs/publisher/#!/operations#APIIndividual#apisChangeLifecyclePost)
 
**Supported status or actions are:**
 - Publish
 - Deploy as a Prototype 
 - Demote to Created
 - Demote to Prototyped
 - Block
 - Deprecate
 - Re-Publish
 - Retire

## User stories
Users now easily can change API state without logging into API Manager with a UI

## Release note
- Added API lifecycle change support

## Documentation
Pl note above