### PR TITLE
Add OAuth Authentication to API import export

### DIFF
--- a/import-export-cli/box/resources/sample/sample_config.yaml
+++ b/import-export-cli/box/resources/sample/sample_config.yaml
@@ -6,7 +6,7 @@ environments:
     admin_endpoint: "https://localhost:9443/api/am/admin/v0.15"
     api_list_endpoint: "https://localhost/publisher/apis"
     api_manager_endpoint: "https://localhost/apim"
-    application_list_endpoint: "https://localhost:9443/api/am/admin/v0.14/applications"
+    application_list_endpoint: "https://localhost:9443/api/am/admin/v0.15/applications"
     registration_endpoint: "https://localhost/register"
     token_endpoint: "https://localhost/token"
   sample-env2:

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -45,7 +45,7 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n prod
 
 ` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n test \
 --registration https://localhost:9443/client-registration/v0.14/register \
---list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--api_list https://localhsot:9443/api/am/publisher/v0.14/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 

--- a/import-export-cli/cmd/exportAPI.go
+++ b/import-export-cli/cmd/exportAPI.go
@@ -83,7 +83,7 @@ func executeExportAPICmd(credential credentials.Credential, exportDirectory stri
 			utils.HandleErrorAndExit("Error while exporting", err)
 		}
 		// Print info on response
-		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
+		utils.Logf(utils.LogPrefixInfo + "ResponseStatus: %v\n", resp.Status())
 		apiZipLocationPath := filepath.Join(exportDirectory, cmdExportEnvironment)
 		if resp.StatusCode() == http.StatusOK {
 			WriteToZip(exportAPIName, exportAPIVersion, apiZipLocationPath, resp)

--- a/import-export-cli/cmd/exportAPI.go
+++ b/import-export-cli/cmd/exportAPI.go
@@ -73,24 +73,30 @@ var ExportAPICmd = &cobra.Command{
 
 func executeExportAPICmd(credential credentials.Credential, exportDirectory string) {
 	runnigExportApiCommand = true
-	b64encodedCredentials := credentials.GetBasicAuth(credential)
-	adminEndpoint := utils.GetAdminEndpointOfEnv(cmdExportEnvironment, utils.MainConfigFilePath)
-	resp, err := getExportApiResponse(exportAPIName, exportAPIVersion, exportProvider, exportAPIFormat, adminEndpoint,
-		b64encodedCredentials, exportAPIPreserveStatus)
-	if err != nil {
-		utils.HandleErrorAndExit("Error while exporting", err)
-	}
-	// Print info on response
-	utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
-	apiZipLocationPath := filepath.Join(exportDirectory, cmdExportEnvironment)
-	if resp.StatusCode() == http.StatusOK {
-		WriteToZip(exportAPIName, exportAPIVersion, apiZipLocationPath, resp)
-	} else if resp.StatusCode() == http.StatusInternalServerError {
-		// 500 Internal Server Error
-		fmt.Println(string(resp.Body()))
+	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, cmdExportEnvironment)
+
+	if preCommandErr == nil {
+		adminEndpoint := utils.GetAdminEndpointOfEnv(cmdExportEnvironment, utils.MainConfigFilePath)
+		resp, err := getExportApiResponse(exportAPIName, exportAPIVersion, exportProvider, exportAPIFormat, adminEndpoint,
+			accessToken, exportAPIPreserveStatus)
+		if err != nil {
+			utils.HandleErrorAndExit("Error while exporting", err)
+		}
+		// Print info on response
+		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
+		apiZipLocationPath := filepath.Join(exportDirectory, cmdExportEnvironment)
+		if resp.StatusCode() == http.StatusOK {
+			WriteToZip(exportAPIName, exportAPIVersion, apiZipLocationPath, resp)
+		} else if resp.StatusCode() == http.StatusInternalServerError {
+			// 500 Internal Server Error
+			fmt.Println(string(resp.Body()))
+		} else {
+			// neither 200 nor 500
+			fmt.Println("Error exporting API:", resp.Status(), "\n", string(resp.Body()))
+		}
 	} else {
-		// neither 200 nor 500
-		fmt.Println("Error exporting API:", resp.Status(), "\n", string(resp.Body()))
+		// error exporting Api
+		fmt.Println("Error getting OAuth tokens while exporting API:" + preCommandErr.Error())
 	}
 }
 
@@ -126,9 +132,9 @@ func WriteToZip(exportAPIName, exportAPIVersion, zipLocationPath string, resp *r
 // @param name : Name of the API to be exported
 // @param version : Version of the API to be exported
 // @param adminEndpoint : API Manager Admin Endpoint for the environment
-// @param  b64encodedCredentials: Base64 Encoded 'username:password'
+// @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
-func getExportApiResponse(name, version, provider, format, adminEndpoint, b64encodedCredentials string, preserveStatus bool) (*resty.Response, error) {
+func getExportApiResponse(name, version, provider, format, adminEndpoint, accessToken string, preserveStatus bool) (*resty.Response, error) {
 	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
 	query := "export/api?name=" + name + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(preserveStatus)
@@ -139,7 +145,7 @@ func getExportApiResponse(name, version, provider, format, adminEndpoint, b64enc
 	url := adminEndpoint + query
 	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", url)
 	headers := make(map[string]string)
-	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
 
 	resp, err := utils.InvokeGETRequest(url, headers)

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -42,14 +42,13 @@ var cmdUsername string
 var cmdExportEnvironment string
 var cmdResourceTenantDomain string
 var cmdForceStartFromBegin bool
+var configVars *utils.MainConfig
 
 // RootCmd related info
 const RootCmdShortDesc = "CLI for Importing and Exporting APIs and Applications"
 const RootCmdLongDesc = utils.ProjectName + ` is a Command Line Tool for Importing and Exporting APIs and Applications between different environments of WSO2 API Manager
 (Dev, Production, Staging, QA etc.)`
 
-//Get config to check mode
-var configVars = utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 // This represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use: utils.ProjectName,
@@ -82,6 +81,8 @@ func Execute() {
 // init using Cobra
 func init() {
 	createConfigFiles()
+	//Get config to check mode
+	configVars = utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 
 	cobra.OnInitialize(initConfig)
 
@@ -179,14 +180,16 @@ func initConfig() {
 		}
 	*/
 }
+
 //diable flags when the mode set to kubernetes
 func setDisableFlagParsing() bool {
-	if configVars.Config.KubernetesMode {
+	if configVars != nil && configVars.Config.KubernetesMode {
 		return true
 	} else {
 		return false
 	}
 }
+
 //execute kubernetes commands
 func executeKubernetes(arg ...string) {
 	cmd := exec.Command(

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -65,6 +65,8 @@ var RootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if configVars.Config.KubernetesMode {
 			executeKubernetes(args...)
+		} else {
+			cmd.Help()
 		}
 	},
 }

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -81,8 +81,6 @@ func Execute() {
 // init using Cobra
 func init() {
 	createConfigFiles()
-	//Get config to check mode
-	configVars = utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 
 	cobra.OnInitialize(initConfig)
 
@@ -181,8 +179,10 @@ func initConfig() {
 	*/
 }
 
-//diable flags when the mode set to kubernetes
+//disable flags when the mode set to kubernetes
 func setDisableFlagParsing() bool {
+	//Get config to check mode
+	configVars = utils.GetMainConfigFromFileSilently(utils.MainConfigFilePath)
 	if configVars != nil && configVars.Config.KubernetesMode {
 		return true
 	} else {

--- a/import-export-cli/docs/apimcli_add-env.md
+++ b/import-export-cli/docs/apimcli_add-env.md
@@ -21,7 +21,7 @@ apimcli add-env -n production \
 
 apimcli add-env -n test \
 --registration https://localhost:9443/client-registration/v0.14/register \
---list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--api_list https://localhsot:9443/api/am/publisher/v0.14/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 

--- a/import-export-cli/docs/apimcli_set.md
+++ b/import-export-cli/docs/apimcli_set.md
@@ -29,7 +29,7 @@ apimcli set --mode default
 ```
       --export-directory string    Path to directory where APIs should be saved (default "/home/dushaniw/.wso2apimcli/exported")
   -h, --help                       help for set
-      --http-request-timeout int   Timeout for HTTP Client (default 5000)
+      --http-request-timeout int   Timeout for HTTP Client (default 10000)
   -m, --mode string                mode of apimcli
 ```
 

--- a/import-export-cli/shell-completions/apimcli_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apimcli_zsh_completions.sh
@@ -17,13 +17,13 @@ case $state in
   ;;
   level2)
     case $words[2] in
+      add)
+        _arguments '2: :(api help)'
+      ;;
       list)
         _arguments '2: :(apis apps envs help)'
       ;;
       update)
-        _arguments '2: :(api help)'
-      ;;
-      add)
         _arguments '2: :(api help)'
       ;;
       *)

--- a/import-export-cli/shell-completions/apimcli_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apimcli_zsh_completions.sh
@@ -17,13 +17,13 @@ case $state in
   ;;
   level2)
     case $words[2] in
-      add)
-        _arguments '2: :(api help)'
-      ;;
       list)
         _arguments '2: :(apis apps envs help)'
       ;;
       update)
+        _arguments '2: :(api help)'
+      ;;
+      add)
         _arguments '2: :(api help)'
       ;;
       *)

--- a/import-export-cli/utils/fileIOUtils.go
+++ b/import-export-cli/utils/fileIOUtils.go
@@ -77,6 +77,18 @@ func GetMainConfigFromFile(filePath string) *MainConfig {
 	return &mainConfig
 }
 
+// Read and return MainConfig. Silently catch the error  when config file is not found
+func GetMainConfigFromFileSilently(filePath string) *MainConfig {
+	var mainConfig MainConfig
+	data, err := ioutil.ReadFile(filePath)
+	if err == nil {
+		if err := mainConfig.ParseMainConfigFromFile(data); err != nil {
+			HandleErrorAndExit("MainConfig: Error parsing "+filePath, err)
+		}
+	}
+	return &mainConfig
+}
+
 // Read and validate contents of main_config.yaml
 // will throw errors if the any of the lines is blank
 func (mainConfig *MainConfig) ParseMainConfigFromFile(data []byte) error {

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -313,7 +313,8 @@ func GetBase64EncodedCredentials(key, secret string) (encodedValue string) {
 func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url string) (map[string]string, error) {
 	validityPeriod := DefaultTokenValidityPeriod
 	body := "grant_type=password&username=" + username + "&password=" + password + "&validity_period=" +
-		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe+apim:api_publish"
+		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe" +
+		"+apim:api_publish+apim:api_import_export"
 
 	// set headers
 	headers := make(map[string]string)

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -311,10 +311,9 @@ func GetBase64EncodedCredentials(key, secret string) (encodedValue string) {
 // @return response as a map
 // @return error
 func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url string) (map[string]string, error) {
-	validityPeriod := DefaultTokenValidityPeriod
-	body := "grant_type=password&username=" + username + "&password=" + password + "&validity_period=" +
-		validityPeriod + "&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe" +
-		"+apim:api_publish+apim:api_import_export"
+	body := "grant_type=password&username=" + username + "&password=" + password +
+		"&scope=apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe+apim:api_publish" +
+		"+apim:api_import_export"
 
 	// set headers
 	headers := make(map[string]string)


### PR DESCRIPTION
## Purpose
This PR adds support to connect to Admin API Import Export REST APIs via OAuth2.
This PR fixes the bug in the CLI tool, of not creating the main_config.yaml by default when executing the ./apimcli command for the first time.
This PR fixes the bug in the CLI tool, of not printing the help menu when root command ./apimcli or apimcli  is executed without subcommands.

## Documentation
Has Doc Impact

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/102

## Test environment
Linux 18.04 LTS