### PR TITLE
Example URLs for add-env corrected. Markdown doc updated.

### DIFF
--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -40,14 +40,14 @@ const addEnvCmdLiteral = "add-env"
 const addEnvCmdShortDesc = "Add Environment to Config file"
 const addEnvCmdLongDesc = "Add new environment and its related endpoints to the config file"
 const addEnvCmdExamples = utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n production \
---registration https://localhost:9763/client-registration/v0.14/register \
+--registration http://localhost:9763/client-registration/v0.14/register \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 ` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n test \
 --registration https://localhost:9763/client-registration/v0.14/register \
 --import-export https://localhost:9443/api-import-export-2.6.0-v0 \
---list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--list https://localhost:9443/api/am/publisher/v0.14/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 

--- a/import-export-cli/docs/apimcli_add-env.md
+++ b/import-export-cli/docs/apimcli_add-env.md
@@ -15,14 +15,14 @@ apimcli add-env [flags]
 
 ```
 apimcli add-env -n production \
---registration https://localhost:9763/client-registration/v0.14/register \
+--registration http://localhost:9763/client-registration/v0.14/register \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 apimcli add-env -n test \
 --registration https://localhost:9763/client-registration/v0.14/register \
 --import-export https://localhost:9443/api-import-export-2.6.0-v0 \
---list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--list https://localhost:9443/api/am/publisher/v0.14/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 

--- a/import-export-cli/docs/apimcli_set.md
+++ b/import-export-cli/docs/apimcli_set.md
@@ -24,7 +24,7 @@ apimcli set --http-request-timeout 5000
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/kasun/.wso2apimcli/exported")
+      --export-directory string    Path to directory where APIs should be saved (default on Unix, including macOS "$HOME/.wso2apimcli/exported", default on Windows "%HOME%\.wso2apimcli\exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
 ```


### PR DESCRIPTION
- Mistakes in example URLs for add-env command corrected
- Markdown documentation for 'add-env' generated
- Markdown documentation for 'set' corrected to reflect
  default export directory for various platforms

## Purpose
Solves unreported issues

## Goals
To ensure correct information to users, when they ask for help in the different commands

## Approach

## User stories

## Release note
Example URLs for add-env corrected. Markdown doc updated.

## Documentation
N/A - the changes are for the documentation of commands themselves.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A