### PR TITLE
Changing API version to v0.15 from v0.14

### DIFF
--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -39,19 +39,19 @@ const addEnvCmdLiteral = "add-env"
 const addEnvCmdShortDesc = "Add Environment to Config file"
 const addEnvCmdLongDesc = "Add new environment and its related endpoints to the config file"
 const addEnvCmdExamples = utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n production \
---registration https://localhost:9443/client-registration/v0.14/register \
+--registration https://localhost:9443/client-registration/v0.15/register \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 ` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n test \
---registration https://localhost:9443/client-registration/v0.14/register \
---api_list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--registration https://localhost:9443/client-registration/v0.15/register \
+--api_list https://localhsot:9443/api/am/publisher/v0.15/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 ` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -n dev --apim https://localhost:9443 \
 --token	https://localhost:8243/token \
---registration http://localhost:9763/client-registration/v0.14/register`
+--registration http://localhost:9763/client-registration/v0.15/register`
 
 // addEnvCmd represents the addEnv command
 var addEnvCmd = &cobra.Command{

--- a/import-export-cli/docs/apimcli_add-env.md
+++ b/import-export-cli/docs/apimcli_add-env.md
@@ -15,19 +15,19 @@ apimcli add-env [flags]
 
 ```
 apimcli add-env -n production \
---registration https://localhost:9443/client-registration/v0.14/register \
+--registration https://localhost:9443/client-registration/v0.15/register \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 apimcli add-env -n test \
---registration https://localhost:9443/client-registration/v0.14/register \
---api_list https://localhsot:9443/api/am/publisher/v0.14/apis \
+--registration https://localhost:9443/client-registration/v0.15/register \
+--api_list https://localhsot:9443/api/am/publisher/v0.15/apis \
 --apim  https://localhost:9443 \
 --token https://localhost:8243/token
 
 apimcli add-env -n dev --apim https://localhost:9443 \
 --token	https://localhost:8243/token \
---registration http://localhost:9763/client-registration/v0.14/register
+--registration http://localhost:9763/client-registration/v0.15/register
 ```
 
 ### Options

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -174,14 +174,14 @@
         Examples:
         apimcli add-env -n dev \
             --apim https://localhost:9443 \ 
-            --registration https://localhost:9443/client-registration/v0.14/register \
+            --registration https://localhost:9443/client-registration/v0.15/register \
             --token https://localhost:9443/oauth2/token
             
         apimcli add-env -n prod \
             --apim https://localhost:9443 \ 
-            --registration https://localhost:9443/client-registration/v0.14/register \
-            --api_list https://localhost:9443/api/am/publisher/v0.14/apis \
-            --app_list https://localhost:9443/api/am/admin/v0.14/applications \
+            --registration https://localhost:9443/client-registration/v0.15/register \
+            --api_list https://localhost:9443/api/am/publisher/v0.15/apis \
+            --app_list https://localhost:9443/api/am/admin/v0.15/applications \
             --token https://localhost:9443/oauth2/token
 </code></pre>
     </li>

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -54,8 +54,8 @@ const ExportedMigrationArtifactsDirName = "migration"
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
 
 const defaultApiApplicationImportExportSuffix = "api/am/admin/v0.15"
-const defaultApiListEndpointSuffix = "api/am/publisher/v0.14/apis"
-const defaultApplicationListEndpointSuffix = "api/am/admin/v0.14/applications"
+const defaultApiListEndpointSuffix = "api/am/publisher/v0.15/apis"
+const defaultApplicationListEndpointSuffix = "api/am/admin/v0.15/applications"
 
 const DefaultEnvironmentName = "default"
 


### PR DESCRIPTION
Changing the README and helper texts to update the mentioned API version of API Manager from 0.14 to 0.15.