### PR TITLE
Fix api.yaml context issue for x-wso2-basepath

### DIFF
--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -20,8 +20,9 @@ package v2
 
 import (
 	"fmt"
-	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 	"path"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 
 	"github.com/Jeffail/gabs"
 	"github.com/go-openapi/loads"
@@ -213,8 +214,8 @@ func Swagger2Populate(def *APIDefinition, document *loads.Document) error {
 
 	// override basepath if wso2 extension provided
 	if basepath, ok := swagger2XWO2BasePath(document); ok {
-		def.Context = path.Clean(fmt.Sprintf("/%s/%s", basepath, def.ID.Version))
-		def.ContextTemplate = path.Clean(fmt.Sprintf("/%s/{version}", basepath))
+		def.Context = path.Clean(basepath)
+		def.ContextTemplate = path.Clean(basepath)
 	}
 
 	cors, ok, err := swagger2XWSO2Cors(document)


### PR DESCRIPTION
## Purpose
> This PR fixes the issue https://github.com/wso2/product-apim-tooling/issues/128

The context field of the api.yaml in the created project does not get created properly when using swaggers with x-wso2-basepath

The context in the api.yaml of the project is taken as a combination of the basepath and the version of the given swagger. That context is directly assigned to x-wso2-basepath when importing the project to API Manager.

In the case of the swagger which already has x-wso2-basepath, the context of the api.yaml is taken as a combination of x-wso2-basepath and version. This combined value is assigned to x-wso2-basepath when importing to API Manager, which results in x-wso2-basepath having an additional version part appended.

This results in the following error when invoking the API through the microgateway using OAuth token
{"fault":{"code":900908, "message":"Resource forbidden ", "description":"Resource forbidden . Unclassified Authentication Failure"}}

In this PR if the swagger has x-wso2-basepath extension, it directly assigns the value to the context in api.yaml

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.