### PR TITLE
Update the helper commands to make --provider (-r) flag optional

### DIFF
--- a/import-export-cli/cmd/exportAPI.go
+++ b/import-export-cli/cmd/exportAPI.go
@@ -47,13 +47,13 @@ const exportAPICmdShortDesc = "Export API"
 
 const exportAPICmdLongDesc = "Export APIs from an environment"
 
-const exportAPICmdExamples = utils.ProjectName + ` ` + exportAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev --provider admin
-` + utils.ProjectName + ` ` + exportAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -e production --provider admin
-NOTE: all three flags (--name (-n), --version (-v), --provider (-r)) are mandatory`
+const exportAPICmdExamples = utils.ProjectName + ` ` + exportAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + exportAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -r admin -e production
+NOTE: Both the flags (--name (-n), --version (-v)) are mandatory`
 
 // ExportAPICmd represents the exportAPI command
 var ExportAPICmd = &cobra.Command{
-	Use: exportAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --environment " +
+	Use: exportAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
 		"<environment-from-which-the-api-should-be-exported>)",
 	Short:   exportAPICmdShortDesc,
 	Long:    exportAPICmdLongDesc,
@@ -131,6 +131,7 @@ func WriteToZip(exportAPIName, exportAPIVersion, zipLocationPath string, resp *r
 // ExportAPI
 // @param name : Name of the API to be exported
 // @param version : Version of the API to be exported
+// @param provider : Provider of the API 
 // @param adminEndpoint : API Manager Admin Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
@@ -153,7 +154,7 @@ func getExportApiResponse(name, version, provider, format, adminEndpoint, access
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return resp, nil
 }
 


### PR DESCRIPTION
## Purpose
The --provider (-r) flag is not mandatory after the fix that has been done to resolve the issue https://github.com/wso2/product-apim-tooling/issues/173. So this PR will modify the helper commands associated with that.
 
## Goals
Modify the helper command related to "apictl export-api" command

## Approach
- Earlier API name, version and provider name were mandatory flags when exporting an API. But now, only the API name and version are mandatory.

## Release note
Refer https://github.com/wso2/carbon-apimgt/pull/8359

## Documentation
Same changes to be done as mentioned in https://github.com/wso2/carbon-apimgt/pull/8359

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/8359

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS