### PR TITLE
Multiple swagger api project

### DIFF
--- a/import-export-cli/box/resources/kubernetes_resources/api_cr.yaml
+++ b/import-export-cli/box/resources/kubernetes_resources/api_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name:
 spec:
   definition:
-    swaggerconfigmapName:
+    swaggerconfigmapNames:
     type: swagger
   replicas:
   mode: privateJet

--- a/import-export-cli/cmd/addApi.go
+++ b/import-export-cli/cmd/addApi.go
@@ -106,12 +106,13 @@ var addApiCmd = &cobra.Command{
 					utils.HandleErrorAndExit("Error creating configmap", errConf)
 				}
 			}
-
-			//handle interceptors
-			handleBalInterceptors(balInterceptorsCmName, balInterceptorsTempDir, "create", flagNamespace)
-			//create API
-			createAPI(flagApiName, flagNamespace, swaggerCmNames, flagReplicas, "", balInterceptorsCmName, flagOverride, javaInterceptorsCmNames, flagApiMode, flagApiVersion)
 		}
+		//handle interceptors
+		fmt.Println("creating configmap with ballerina interceptors")
+		handleBalInterceptors(balInterceptorsCmName, balInterceptorsTempDir, "create", flagNamespace)
+		//create API
+		fmt.Println("creating API definition")
+		createAPI(flagApiName, flagNamespace, swaggerCmNames, flagReplicas, "", balInterceptorsCmName, flagOverride, javaInterceptorsCmNames, flagApiMode, flagApiVersion)
 	},
 }
 

--- a/import-export-cli/cmd/addApi.go
+++ b/import-export-cli/cmd/addApi.go
@@ -110,7 +110,7 @@ var addApiCmd = &cobra.Command{
 			//handle interceptors
 			handleBalInterceptors(balInterceptorsCmName, balInterceptorsTempDir, "create", flagNamespace)
 			//create API
-			createAPI(flagApiName, flagNamespace, swaggerCmNames, flagReplicas, "", balInterceptorsCmName, flagOverride, javaInterceptorsCmNames)
+			createAPI(flagApiName, flagNamespace, swaggerCmNames, flagReplicas, "", balInterceptorsCmName, flagOverride, javaInterceptorsCmNames, flagApiMode, flagApiVersion)
 		}
 	},
 }
@@ -192,7 +192,7 @@ func createConfigMapWithNamespace(configMapName string, filePath string, namespa
 	return nil
 }
 
-func createAPI(name string, namespace string, configMapNames []string, replicas int, timestamp string, balInterceptors string, override bool, javaInterceptors []string) {
+func createAPI(name string, namespace string, configMapNames []string, replicas int, timestamp string, balInterceptors string, override bool, javaInterceptors []string, apiMode string, apiVersion string) {
 	//get API definition from file
 	apiConfigMapData, _ := box.Get("/kubernetes_resources/api_cr.yaml")
 	apiConfigMap := &wso2v1alpha1.API{}
@@ -220,6 +220,13 @@ func createAPI(name string, namespace string, configMapNames []string, replicas 
 	} else {
 		apiConfigMap.Spec.Definition.Interceptors.Java = []string{}
 	}
+	if apiMode != "" {
+		apiConfigMap.Spec.Mode = wso2v1alpha1.Mode(apiMode)
+	}
+	if apiVersion != "" {
+		apiConfigMap.Spec.Version = apiVersion
+	}
+
 	byteVal, errMarshal := yaml.Marshal(apiConfigMap)
 	if errMarshal != nil {
 		utils.HandleErrorAndExit("Error marshal api configmap ", errMarshal)

--- a/import-export-cli/cmd/updateApi.go
+++ b/import-export-cli/cmd/updateApi.go
@@ -89,7 +89,7 @@ var updateApiCmd = &cobra.Command{
 					}
 					//handle interceptors
 					updatedInterceptorConfName = updateflagApiName + "-interceptors-up-" + timestamp
-					//updatedBalInterceptors = handleBalInterceptors(updatedInterceptorConfName, updateflagSwaggerFilePath, "create", updateflagNamespace)
+					handleBalInterceptors(updatedInterceptorConfName, updateflagSwaggerFilePath, "create", updateflagNamespace)
 					updatedJavaInterceptors = handleJavaInterceptors(updateflagSwaggerFilePath, "create", updateflagNamespace, updateflagApiName)
 
 				case mode.IsRegular():
@@ -102,7 +102,7 @@ var updateApiCmd = &cobra.Command{
 				}
 				//update the API
 				fmt.Println("updating the API Kind")
-				createAPI(updateflagApiName, updateflagNamespace, []string{updateConfigMapName}, updateflagReplicas, timestamp, updatedBalInterceptors, false, updatedJavaInterceptors)
+				createAPI(updateflagApiName, updateflagNamespace, []string{updateConfigMapName}, updateflagReplicas, timestamp, updatedBalInterceptors, false, updatedJavaInterceptors, flagApiMode, flagApiMode)
 			}
 		} else {
 			utils.HandleErrorAndExit("set mode to kubernetes with command: apictl set --mode kubernetes",
@@ -119,4 +119,7 @@ func init() {
 	updateApiCmd.Flags().StringVarP(&updateflagSwaggerFilePath, "from-file", "f", "", "Path to swagger file")
 	updateApiCmd.Flags().IntVar(&updateflagReplicas, "replicas", 1, "replica set")
 	updateApiCmd.Flags().StringVar(&updateflagNamespace, "namespace", "", "namespace of API")
+	updateApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", utils.DefaultApiVersion, "Property to override the existing docker image with same name and version")
+	updateApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", utils.PrivateJetModeConst,
+		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v", utils.PrivateJetModeConst, utils.SidecarModeConst))
 }

--- a/import-export-cli/cmd/updateApi.go
+++ b/import-export-cli/cmd/updateApi.go
@@ -89,7 +89,7 @@ var updateApiCmd = &cobra.Command{
 					}
 					//handle interceptors
 					updatedInterceptorConfName = updateflagApiName + "-interceptors-up-" + timestamp
-					updatedBalInterceptors = handleBalInterceptors(updatedInterceptorConfName, updateflagSwaggerFilePath, "create", updateflagNamespace)
+					//updatedBalInterceptors = handleBalInterceptors(updatedInterceptorConfName, updateflagSwaggerFilePath, "create", updateflagNamespace)
 					updatedJavaInterceptors = handleJavaInterceptors(updateflagSwaggerFilePath, "create", updateflagNamespace, updateflagApiName)
 
 				case mode.IsRegular():

--- a/import-export-cli/cmd/updateApi.go
+++ b/import-export-cli/cmd/updateApi.go
@@ -102,7 +102,7 @@ var updateApiCmd = &cobra.Command{
 				}
 				//update the API
 				fmt.Println("updating the API Kind")
-				createAPI(updateflagApiName, updateflagNamespace, updateConfigMapName, updateflagReplicas, timestamp, updatedBalInterceptors, false, updatedJavaInterceptors)
+				createAPI(updateflagApiName, updateflagNamespace, []string{updateConfigMapName}, updateflagReplicas, timestamp, updatedBalInterceptors, false, updatedJavaInterceptors)
 			}
 		} else {
 			utils.HandleErrorAndExit("set mode to kubernetes with command: apictl set --mode kubernetes",

--- a/import-export-cli/cmd/updateApi.go
+++ b/import-export-cli/cmd/updateApi.go
@@ -43,7 +43,7 @@ const updateCmdExamples = utils.ProjectName + " " + updateCmdLiteral + " " + add
 
 var updatedInterceptorConfName string
 var updatedJavaInterceptors []string
-var updatedBalInterceptors string
+var updatedBalInterceptors []string
 
 // updateCmd represents the update command
 var updateCmd = &cobra.Command{
@@ -119,7 +119,7 @@ func init() {
 	updateApiCmd.Flags().StringVarP(&updateflagSwaggerFilePath, "from-file", "f", "", "Path to swagger file")
 	updateApiCmd.Flags().IntVar(&updateflagReplicas, "replicas", 1, "replica set")
 	updateApiCmd.Flags().StringVar(&updateflagNamespace, "namespace", "", "namespace of API")
-	updateApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", utils.DefaultApiVersion, "Property to override the existing docker image with same name and version")
-	updateApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", utils.PrivateJetModeConst,
+	updateApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Property to override the existing docker image with same name and version")
+	updateApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
 		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v", utils.PrivateJetModeConst, utils.SidecarModeConst))
 }

--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -1,5 +1,8 @@
 go 1.12
 
+// remove this; for testing purpose
+replace github.com/wso2/k8s-apim-operator/apim-operator => /Users/renuka/go/src/github.com/wso2/k8s-apim-operator/apim-operator
+
 require (
 	github.com/Jeffail/gabs v1.2.0
 	github.com/getkin/kin-openapi v0.2.0

--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -1,8 +1,5 @@
 go 1.12
 
-// remove this; for testing purpose
-replace github.com/wso2/k8s-apim-operator/apim-operator => /Users/renuka/go/src/github.com/wso2/k8s-apim-operator/apim-operator
-
 require (
 	github.com/Jeffail/gabs v1.2.0
 	github.com/getkin/kin-openapi v0.2.0

--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cast v1.2.0
 	github.com/spf13/cobra v0.0.3
 	github.com/stretchr/testify v1.4.0
-	github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200316103033-a89a8f35bcf2
+	github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200321092350-0205cf84c08c
 	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0-20190913075813-344bcc0201c9 // indirect

--- a/import-export-cli/go.sum
+++ b/import-export-cli/go.sum
@@ -415,6 +415,8 @@ github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200311050056-f5e35cdbb3
 github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200311050056-f5e35cdbb37c/go.mod h1:8w7JhtPk+1DuRjc6C33yCQBdqDE4IaDQ1P9JVUUz04o=
 github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200316103033-a89a8f35bcf2 h1:2vs1FOpG/89rvs6QQzHmgGLewVW36ldz+C/1gvNYGzY=
 github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200316103033-a89a8f35bcf2/go.mod h1:8Ee65tUOf1I/qYkqsvgTPGWbIjpibmdOLoLsiKo3lN8=
+github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200321092350-0205cf84c08c h1:91SLTYTcAke4WiXYM1akWCZiAOlhCISKBnJGQ/BovsQ=
+github.com/wso2/k8s-apim-operator/apim-operator v0.0.0-20200321092350-0205cf84c08c/go.mod h1:htsQYwyeclFmxPvIE/tpQRf6rGJ0ywR3A3jiEvRIdBc=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -108,6 +108,6 @@ const DefaultCliApp = "default-apictl-app"
 const DefaultTokenType = "JWT"
 
 var ValidInitialStates = []string{"CREATED", "PUBLISHED"}
-var PrivateJetModeConst = "privateJet"
-var SidecarModeConst = "sidecar"
-var DefaultApiVersion = "v1.0.0"
+
+const PrivateJetModeConst = "privateJet"
+const SidecarModeConst = "sidecar"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -108,3 +108,6 @@ const DefaultCliApp = "default-apictl-app"
 const DefaultTokenType = "JWT"
 
 var ValidInitialStates = []string{"CREATED", "PUBLISHED"}
+var PrivateJetModeConst = "privateJet"
+var SidecarModeConst = "sidecar"
+var DefaultApiVersion = "v1.0.0"


### PR DESCRIPTION
fix #204 

#### Description:
Deploy multiple swagger files (multiple API Projects) as one micro-gateway image by creating one API CRD.

- API CRD should supports multiple swagger-configmaps.

```sh
apictl add api -n pets \
-f scenarios/scenario-6/swagger.yaml \
-f scenarios/scenario-10/petstore-int \
-f scenarios/scenario-3/swagger.yaml \
--mode privateJet \
--version v2.1.2
```

- will refactor `apictl update` command in another PR