### PR TITLE
Create secrets in 'wso2-system' namespace when installing api-operator

### DIFF
--- a/import-export-cli/operator/registry/amazon_ecr.go
+++ b/import-export-cli/operator/registry/amazon_ecr.go
@@ -52,7 +52,7 @@ var AmazonEcrRegistry = &Registry{
 	},
 	Run: func() {
 		createAmazonEcrConfig()
-		k8sUtils.K8sCreateSecretFromFile(k8sUtils.AwsCredentialsVolume, amazonEcrValues.credFile, "credentials")
+		k8sUtils.K8sCreateSecretFromFile(k8sUtils.AwsCredentialsVolume, k8sUtils.ApiOpWso2Namespace, amazonEcrValues.credFile, "credentials")
 	},
 	Flags: Flags{
 		RequiredFlags: &map[string]bool{k8sUtils.FlagBmRepository: true, k8sUtils.FlagBmKeyFile: true},
@@ -112,6 +112,7 @@ func createAmazonEcrConfig() {
 	configMap, err := k8sUtils.GetCommandOutput(
 		k8sUtils.Kubectl, k8sUtils.K8sCreate, k8sUtils.K8sConfigMap,
 		k8sUtils.ConfigJsonVolume, "--from-file=config.json="+tempFile,
+		"-n", k8sUtils.ApiOpWso2Namespace,
 		"--dry-run", "-o", "yaml",
 	)
 	if err != nil {

--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -93,7 +93,7 @@ var DockerHubRegistry = &Registry{
 		dockerHubValues.repository = repository
 	},
 	Run: func() {
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, k8sUtils.ApiOpWso2Namespace, dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
 		dockerHubValues.password = "" // clear password
 	},
 	Flags: Flags{

--- a/import-export-cli/operator/registry/gcr.go
+++ b/import-export-cli/operator/registry/gcr.go
@@ -67,8 +67,8 @@ var GcrRegistry = &Registry{
 			utils.HandleErrorAndExit("Error reading GCR service account key json file", err)
 		}
 
-		k8sUtils.K8sCreateSecretFromFile(k8sUtils.GcrSvcAccKeyVolume, gcrValues.svcAccKeyFile, k8sUtils.GcrSvcAccKeyFile)
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, "gcr.io", "_json_key", string(data))
+		k8sUtils.K8sCreateSecretFromFile(k8sUtils.GcrSvcAccKeyVolume, k8sUtils.ApiOpWso2Namespace, gcrValues.svcAccKeyFile, k8sUtils.GcrSvcAccKeyFile)
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, k8sUtils.ApiOpWso2Namespace, "gcr.io", "_json_key", string(data))
 	},
 	Flags: Flags{
 		RequiredFlags: &map[string]bool{k8sUtils.FlagBmKeyFile: true},

--- a/import-export-cli/operator/registry/http.go
+++ b/import-export-cli/operator/registry/http.go
@@ -82,7 +82,7 @@ var HttpRegistry = &Registry{
 		httpValues.password = password
 	},
 	Run: func() {
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, getRegistryUrl(httpValues.repository), httpValues.username, httpValues.password)
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.ConfigJsonVolume, k8sUtils.ApiOpWso2Namespace, getRegistryUrl(httpValues.repository), httpValues.username, httpValues.password)
 		httpValues.password = "" // clear password
 	},
 	Flags: Flags{

--- a/import-export-cli/operator/utils/k8sUtils.go
+++ b/import-export-cli/operator/utils/k8sUtils.go
@@ -55,7 +55,7 @@ func K8sWaitForResourceType(maxTimeSec int, resourceTypes ...string) error {
 }
 
 // K8sCreateSecretFromInputs creates K8S secret with credentials
-func K8sCreateSecretFromInputs(secretName string, server string, username string, password string) {
+func K8sCreateSecretFromInputs(secretName string, namespace string, server string, username string, password string) {
 	if username == "" {
 		username = "N/A"
 		password = "N/A"
@@ -65,6 +65,7 @@ func K8sCreateSecretFromInputs(secretName string, server string, username string
 		"--docker-server", server,
 		"--docker-username", username,
 		"--docker-password", password,
+		"-n", namespace,
 		"--dry-run", "-o", "yaml",
 	)
 
@@ -78,7 +79,7 @@ func K8sCreateSecretFromInputs(secretName string, server string, username string
 	}
 }
 
-func K8sCreateSecretFromFile(secretName string, filePath string, renamedFile string) {
+func K8sCreateSecretFromFile(secretName string, namespace string, filePath string, renamedFile string) {
 	var fromFile string
 	if renamedFile == "" {
 		fromFile = fmt.Sprintf("--from-file=%s", filePath)
@@ -90,6 +91,7 @@ func K8sCreateSecretFromFile(secretName string, filePath string, renamedFile str
 	secret, err := GetCommandOutput(
 		Kubectl, K8sCreate, K8sSecret, "generic",
 		secretName, fromFile,
+		"-n", namespace,
 		"--dry-run", "-o", "yaml",
 	)
 	if err != nil {


### PR DESCRIPTION
wso2/K8s-api-operator#234

- Create secrets in 'wso2-system' namespace when installing api-operator
- Operator should copy the secrets to the relevant namespace when api created