### PR TITLE
Improving the method to decide the context and context template in api.yaml when executing apictl init

### DIFF
--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -21,6 +21,7 @@ package v2
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 
@@ -216,6 +217,14 @@ func Swagger2Populate(def *APIDefinition, document *loads.Document) error {
 	if basepath, ok := swagger2XWO2BasePath(document); ok {
 		def.Context = path.Clean(basepath)
 		def.ContextTemplate = path.Clean(basepath)
+		if !strings.Contains(basepath, "{version}") {
+			def.Context = path.Clean(basepath + "/" + def.ID.Version)
+			def.ContextTemplate = path.Clean(basepath + "/{version}")
+			def.IsDefaultVersion = true
+		} else {
+			def.ContextTemplate = path.Clean(basepath)
+			def.Context = path.Clean(strings.ReplaceAll(basepath, "{version}", def.ID.Version))
+		}
 	}
 
 	cors, ok, err := swagger2XWSO2Cors(document)

--- a/import-export-cli/specs/v2/swagger2_test.go
+++ b/import-export-cli/specs/v2/swagger2_test.go
@@ -67,6 +67,30 @@ func TestSwagger2Populate(t *testing.T) {
 	err = Swagger2Populate(&def, doc)
 	assert.Nil(t, err, "err should be nil")
 
-	assert.Equal(t, "SwaggerPetstore", def.ID.APIName, "Should return correct api name")
+	assert.Equal(t, "Swagger Petstore", def.ID.APIName, "Should return correct api name")
 	assert.Equal(t, "/petstore/v1/1.0.0", def.Context)
+}
+
+func TestSwagger2PopulateWithBasePath(t *testing.T) {
+	var def1,def2 APIDefinition
+
+	// Basepath without {version}
+	doc1, err1 := loads.Spec("testdata/petstore_with_basepath1.yaml")
+	assert.Nil(t, err1, "err should be nil")
+	err1 = Swagger2Populate(&def1, doc1)
+	assert.Nil(t, err1, "err should be nil")
+
+	assert.Equal(t, "/petstore/v1/1.0.0", def1.Context)
+	assert.Equal(t, "/petstore/v1/{version}", def1.ContextTemplate)
+	assert.Equal(t, true, def1.IsDefaultVersion)
+
+	// Basepath with {version}
+	doc2, err2 := loads.Spec("testdata/petstore_with_basepath2.yaml")
+	assert.Nil(t, err2, "err should be nil")
+	err1 = Swagger2Populate(&def2, doc2)
+	assert.Nil(t, err2, "err should be nil")
+
+	assert.Equal(t, "/petstore/v1/1.0.0", def2.Context)
+	assert.Equal(t, "/petstore/v1/{version}", def2.ContextTemplate)
+	assert.Equal(t, false, def2.IsDefaultVersion)
 }

--- a/import-export-cli/specs/v2/testdata/petstore_with_basepath1.yaml
+++ b/import-export-cli/specs/v2/testdata/petstore_with_basepath1.yaml
@@ -1,0 +1,186 @@
+---
+openapi: 3.0.0
+servers:
+- url: https://petstore.swagger.io/v2
+- url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+x-wso2-basePath: /petstore/v1
+x-wso2-production-endpoints:
+  urls:
+   - https://petstore.swagger.io/v2
+paths:
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      security:
+        - basicAuth: []
+        - api_key: []
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: true
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - available
+            - pending
+            - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      security:
+        - petstore_auth:
+          - 'write'
+          - 'read'
+        - basicAuth: []
+        - api_key: []
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+    basicAuth:     # <-- arbitrary name for the security scheme
+      type: http
+      scheme: basic
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+      - name
+      - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+      xml:
+        name: Pet
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+

--- a/import-export-cli/specs/v2/testdata/petstore_with_basepath2.yaml
+++ b/import-export-cli/specs/v2/testdata/petstore_with_basepath2.yaml
@@ -1,0 +1,186 @@
+---
+openapi: 3.0.0
+servers:
+- url: https://petstore.swagger.io/v2
+- url: http://petstore.swagger.io/v2
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+x-wso2-basePath: /petstore/v1/{version}
+x-wso2-production-endpoints:
+  urls:
+   - https://petstore.swagger.io/v2
+paths:
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      security:
+        - basicAuth: []
+        - api_key: []
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: true
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - available
+            - pending
+            - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      security:
+        - petstore_auth:
+          - 'write'
+          - 'read'
+        - basicAuth: []
+        - api_key: []
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+    basicAuth:     # <-- arbitrary name for the security scheme
+      type: http
+      scheme: basic
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+      - name
+      - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+      xml:
+        name: Pet
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/196

## Goals
Change the context and context template in api.yaml file when **_apictl init_** command is executed, based on the x-wso2-basepath in the swagger file.

## Approach
- Take a swagger file of an API from microgateway.
- When the **_apictl init_** command is executed, check whether the x-wso2-basepath has "{version}" or not.
- Change the context and context template in api.yaml for the user stories described in the next section.

## User stories
- If x-wso2-basepath does not contain {version}, then _context_ should be "basepath/api_version" and _context template_ should be "basepath/{version}". The _isDefaultVersion_ field should be true here.
- If x-wso2-basepath contains {version}, then the _context_ should be the basepath where the {version} is replaced by api_version and _context template_ should be just "basepath". The _isDefaultVersion_ field should not be considered here.

PS: _api_version_ is the value of the version field in the swagger file and _{version}_ is just a string.

## Automation tests
 - Unit tests 
   Wrote two tests for the above two user stories in swagger2_test.go file

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64