### PR TITLE
Fix wrong error code given when executing export-apis command again after executing for the first time

### DIFF
--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strconv"
 
@@ -178,7 +177,6 @@ func prepareResumption() {
 				exportRelatedFilesPath, apiListOffset)
 		} else {
 			fmt.Println("Command: export-apis execution completed !")
-			os.Exit(1)
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-apim-tooling/issues/147