### PR TITLE
Support endpoint security parameters in api_params.yaml

### DIFF
--- a/import-export-cli/box/resources/init/api_params.tmpl
+++ b/import-export-cli/box/resources/init/api_params.tmpl
@@ -3,8 +3,9 @@ environments:{{- range $name, $elem := . }}
     endpoints:
       production:
       sandbox:
-      endpointSecured: 
-      endpointUTUsername: 
-      endpointUTPassword: 
-      endpointAuthDigest:
+    security:
+      enabled: 
+      type: 
+      username: 
+      password: 
 {{- end }}

--- a/import-export-cli/box/resources/init/api_params.tmpl
+++ b/import-export-cli/box/resources/init/api_params.tmpl
@@ -3,4 +3,8 @@ environments:{{- range $name, $elem := . }}
     endpoints:
       production:
       sandbox:
+      endpointSecured: 
+      endpointUTUsername: 
+      endpointUTPassword: 
+      endpointAuthDigest:
 {{- end }}

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -178,8 +178,8 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		return err
 	}
 
-	// Set security parameters
-	err = setSecurityEndpointsParams(environmentParams.Endpoints, api)
+	// Handle security parameters in api_params.yaml
+	err = handleSecurityEndpointsParams(environmentParams.Security, api)
 	if (err != nil) {
 		return err
 	}
@@ -198,50 +198,31 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	return nil
 }
 
-// Set security parameters 
-// @param environmentParamsEndpoints : Environment endpoint parameters from api_params.yaml
+// Handle security parameters in api_params.yaml
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
 // @param api : Parameters from api.yaml
 // @return error 
-func setSecurityEndpointsParams(environmentParamsEndpoints *params.EndpointData, api *gabs.Container) error {
-	// If the user has set (either true or false) the endpointSecured field in api_params.yaml the 
+func handleSecurityEndpointsParams(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// If the user has set (either true or false) the enabled field under security in api_params.yaml, the 
 	// following code should be executed. (if not set, the security endpoint settings will be made 
 	// according to the api.yaml file as usually)
 	// In Go, irrespective of whether a boolean value is "" or false, it will contain false by default.
 	// That is why, here a string comparison was  made since strings can have both "" and "false"
-	if environmentParamsEndpoints.EndpointSecured != "" {
-		// Convert the string endpointSecured to boolean
-		boolEndpointSecured, err := strconv.ParseBool(environmentParamsEndpoints.EndpointSecured)
+	if envSecurityEndpointParams.Enabled != "" {
+		// Convert the string enabled to boolean
+		boolEnabled, err := strconv.ParseBool(envSecurityEndpointParams.Enabled)
 		if err != nil {
 			return err
 		}
-		if _, err := api.SetP(boolEndpointSecured, "endpointSecured"); err != nil {
+		if _, err := api.SetP(boolEnabled, "endpointSecured"); err != nil {
 			return err
 		}
-		if boolEndpointSecured {
-			// If endpoint security is enabled, check whether the username and password has set in api_params.yaml
-			if environmentParamsEndpoints.EndpointUTUsername == "" {
-				return errors.New("You have enabled endpoint security but the username is not found in the api_params.yaml")
-			} else if environmentParamsEndpoints.EndpointUTPassword == "" {
-				return errors.New("You have enabled endpoint security but the password is not found in the api_params.yaml")
-			} else {
-				if _, err := api.SetP(environmentParamsEndpoints.EndpointUTUsername, "endpointUTUsername"); err != nil {
-					return err
-				}
-				if _, err := api.SetP(environmentParamsEndpoints.EndpointUTPassword, "endpointUTPassword"); err != nil {
-					return err
-				}
-			}
-			// If endpointAuthDigest is set in api_params.yaml, 
-			// override the corresponding fields in api.yaml with those values
-			if environmentParamsEndpoints.EndpointAuthDigest != "" {
-				// Convert the string endpointAuthDigest to boolean
-				boolEndpointAuthDigest, err := strconv.ParseBool(environmentParamsEndpoints.EndpointAuthDigest)
-				if err != nil {
-					return err
-				}
-				if _, err := api.SetP(boolEndpointAuthDigest, "endpointAuthDigest"); err != nil {
-					return err
-				}
+		// If endpoint security is enabled
+		if boolEnabled {
+			// Set the security endpoint parameters when the enabled field is set to true
+			err := setSecurityEndpointsParams(envSecurityEndpointParams, api)
+			if (err != nil) {
+				return err
 			}
 		} else {
 			// If endpoint security is not enabled, the username and password should be empty.
@@ -254,6 +235,57 @@ func setSecurityEndpointsParams(environmentParamsEndpoints *params.EndpointData,
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// Set the security endpoint parameters when the enabled field is set to true
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
+// @param api : Parameters from api.yaml
+// @return error 
+func setSecurityEndpointsParams(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// Check whether the username, password and type fields have set in api_params.yaml
+	if envSecurityEndpointParams.Username == "" {
+		return errors.New("You have enabled endpoint security but the username is not found in the api_params.yaml")
+	} else if envSecurityEndpointParams.Password == "" {
+		return errors.New("You have enabled endpoint security but the password is not found in the api_params.yaml")
+	} else if envSecurityEndpointParams.Type == "" {
+		return errors.New("You have enabled endpoint security but the type is not found in the api_params.yaml")
+	} else {
+		// Override the username in api.yaml with the value in api_params.yaml
+		if _, err := api.SetP(envSecurityEndpointParams.Username, "endpointUTUsername"); err != nil {
+			return err
+		}
+		// Override the password in api.yaml with the value in api_params.yaml
+		if _, err := api.SetP(envSecurityEndpointParams.Password, "endpointUTPassword"); err != nil {
+			return err
+		}
+		// Set the fields in api.yaml according to the type field in api_params.yaml
+		err := setEndpointSecurityType(envSecurityEndpointParams, api)
+		if (err != nil) {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set the fields in api.yaml according to the type field in api_params.yaml
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
+// @param api : Parameters from api.yaml
+// @return error 
+func setEndpointSecurityType(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// Check whether the type is either basic or digest
+	if envSecurityEndpointParams.Type == "digest" {
+		if _, err := api.SetP(true, "endpointAuthDigest"); err != nil {
+			return err
+		}
+	} else if envSecurityEndpointParams.Type == "basic" {
+		if _, err := api.SetP(false, "endpointAuthDigest"); err != nil {
+			return err
+		}
+	} else {
+		// If the type is not either basic or digest, return an error
+		return errors.New("Invalid endpoint security type found in the api_params.yaml. Should be either basic or digest")
 	}
 	return nil
 }

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -34,11 +34,18 @@ type EndpointData struct {
 	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
 	// Sandbox endpoint
 	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
-	// Endpoint security
-	EndpointSecured string `yaml:"endpointSecured" json:"endpointSecured,omitempty"`
-	EndpointAuthDigest string `yaml:"endpointAuthDigest" json:"endpointAuthDigest,omitempty"`
-	EndpointUTUsername string `yaml:"endpointUTUsername" json:"endpointUTUsername,omitempty"`
-	EndpointUTPassword string `yaml:"endpointUTPassword" json:"endpointUTPassword,omitempty"`
+}
+
+// SecurityData contains the details about endpoint security from api_params.yaml
+type SecurityData struct {
+	// Decides whether the endpoint security is enabled
+	Enabled string `yaml:"enabled" json:"enabled,omitempty"`
+	// Type of the endpoint security (can be Basic or Digest)
+	Type string `yaml:"type" json:"type,omitempty"`
+	// Username for the endpoint
+	Username string `yaml:"username" json:"username,omitempty"`
+	// Password for the endpoint
+	Password string `yaml:"password" json:"password,omitempty"`
 }
 
 // Cert stores certificate details
@@ -59,6 +66,8 @@ type Environment struct {
 	Name string `yaml:"name"`
 	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
+	// Security contains the details about endpoint security
+	Security *SecurityData `yaml:"security"`
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -34,6 +34,11 @@ type EndpointData struct {
 	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
 	// Sandbox endpoint
 	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Endpoint security
+	EndpointSecured string `yaml:"endpointSecured" json:"endpointSecured,omitempty"`
+	EndpointAuthDigest string `yaml:"endpointAuthDigest" json:"endpointAuthDigest,omitempty"`
+	EndpointUTUsername string `yaml:"endpointUTUsername" json:"endpointUTUsername,omitempty"`
+	EndpointUTPassword string `yaml:"endpointUTPassword" json:"endpointUTPassword,omitempty"`
 }
 
 // Cert stores certificate details


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/162

## Goals
Enhance the current capability of defining endpoint security parameters in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.

## Approach
This procedure modiied the template of api_params.yaml as shown in the below example. The fields endpointSecured, endpointUTUsername, endpointUTPassword and endpointAuthDigest have been included in it for a particular environment.
```
environments:
  - name: test
    endpoints:
     production:
       url: 'http://dev.doo.com'
       config:
         retryTimeOut: 60
         retryDelay: 70
         factor: 2
     sandbox:
        url: 'http://test.foo.sandbox.com'
     security:
         enabled: true
         type: basic ( or digest )
         username: admin
         password: admin
```

When assigning the security parameters, following procedure has taken place.
- Checked whether endpointSecured field is there in api_params.yaml. If not, the old procedure was taken place by getting the values from api.yaml file.
- If endpointSecured was set (can either be true or false) in api_params.yaml, that value in api.yaml file was overridden and the steps below were followed.
  - Checked whether endpointSecured == true,
    - If endpointSecured == true, checked whether endpointUTUsername and endpointUTPassword was set in api_params.yaml file. If those were not set, show the user an error asking to set those. When those were set, used those values as security parameters (by overriding the values in api.yaml) when importing the API.
    - If endpointAuthDigest was set (can either be true or false), that value in api.yaml was overridden. If not set, used the value in the api.yaml as in default procedure.
  - If endpointSecured == false,
    - Overrided the endpointUTUsername and the endpointUTPassword as empty in api.yaml file so that endpoint security will not be enabled for sure.

## User stories
-  If endpoint security parameters were set in api_params.yaml file, override the values in api.yaml file.
- If endpoint security parameters were  not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)

## Release note
Enhance the current capability of defining endpoint security parameters in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.

## Documentation
Documentation changes should be done. 

## Test environment
-  JDK 1.8.0_241
- Ubuntu 18.04.4 LTS