### PR TITLE
Add environment variable support for project files

### DIFF
--- a/import-export-cli/box/resources/init/api_params.tmpl
+++ b/import-export-cli/box/resources/init/api_params.tmpl
@@ -2,10 +2,7 @@ environments:{{- range $name, $elem := . }}
   - name: {{ $name }}
     endpoints:
       production:
+        url:
       sandbox:
-    security:
-      enabled: 
-      type: 
-      username: 
-      password: 
+        url:
 {{- end }}

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -211,7 +211,7 @@ func NewAppFileUploadRequest(uri string, params map[string]string, paramName, pa
 func init() {
 	RootCmd.AddCommand(ImportAppCmd)
 	ImportAppCmd.Flags().StringVarP(&importAppFile, "file", "f", "",
-		"Name of the Application to be imported")
+		"Name of the ZIP file of the Application to be imported")
 	ImportAppCmd.Flags().StringVarP(&importAppOwner, "owner", "o", "",
 		"Name of the target owner of the Application as desired by the Importer")
 	ImportAppCmd.Flags().StringVarP(&importAppEnvironment, "environment", "e",
@@ -221,9 +221,9 @@ func init() {
 	ImportAppCmd.Flags().BoolVarP(&skipSubscriptions, "skipSubscriptions", "s", false,
 		"Skip subscriptions of the Application")
 	ImportAppCmd.Flags().BoolVarP(&importAppSkipKeys, "skipKeys", "", false,
-		"Skip importing keys of application")
+		"Skip importing keys of the Application")
 	ImportAppCmd.Flags().BoolVarP(&importAppUpdateApplication, "update", "", false,
-		"Update application or create new")
+		"Update the Application if it is already imported")
 	_ = ImportAppCmd.MarkFlagRequired("file")
 	_ = ImportAppCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/init.go
+++ b/import-export-cli/cmd/init.go
@@ -201,15 +201,8 @@ func executeInitCmd() error {
 			return err
 		}
 
-		// substitute all env variables with ${var} format only
-		utils.Logln(utils.LogPrefixInfo + "Substituting environment variables")
-		yamlSwaggerString, err := utils.EnvSubstituteForCurlyBraces(string(yamlSwagger))
-		if err != nil {
-			return err
-		}
-
 		// write to file
-		err = ioutil.WriteFile(swaggerSavePath, []byte (yamlSwaggerString), os.ModePerm)
+		err = ioutil.WriteFile(swaggerSavePath, yamlSwagger, os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/import-export-cli/cmd/init.go
+++ b/import-export-cli/cmd/init.go
@@ -201,8 +201,15 @@ func executeInitCmd() error {
 			return err
 		}
 
+		// substitute all env variables with ${var} format only
+		utils.Logln(utils.LogPrefixInfo + "Substituting environment variables")
+		yamlSwaggerString, err := utils.EnvSubstituteForCurlyBraces(string(yamlSwagger))
+		if err != nil {
+			return err
+		}
+
 		// write to file
-		err = ioutil.WriteFile(swaggerSavePath, yamlSwagger, os.ModePerm)
+		err = ioutil.WriteFile(swaggerSavePath, []byte (yamlSwaggerString), os.ModePerm)
 		if err != nil {
 			return err
 		}

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -112,5 +112,14 @@ const DefaultTokenType = "JWT"
 
 var ValidInitialStates = []string{"CREATED", "PUBLISHED"}
 
+var EnvReplaceFilePaths  = []string{
+	"Docs" + string(os.PathSeparator) + "docs.yaml",
+	"Docs" + string(os.PathSeparator) + "InlineContents",
+	"Meta-information",
+	"WSDL",
+	"Sequences",
+	"SoapToRest",
+}
+
 const PrivateJetModeConst = "privateJet"
 const SidecarModeConst = "sidecar"

--- a/import-export-cli/utils/envSubstituteUtils.go
+++ b/import-export-cli/utils/envSubstituteUtils.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 )
 
-// Match for $VAR and capture VAR inside a group
-var re = regexp.MustCompile(`\$(\w+)`)
+// Match for $VAR or ${VAR} and capture VAR inside a group
+var re = regexp.MustCompile(`\$?{(\w+)?}`)
 
 // Match for ${VAR} and capture VAR inside a group
 var recb = regexp.MustCompile(`\${(\w+)}`)

--- a/import-export-cli/utils/envSubstituteUtils.go
+++ b/import-export-cli/utils/envSubstituteUtils.go
@@ -2,14 +2,19 @@ package utils
 
 import (
 	"fmt"
-	"os"
-	"regexp"
-
 	"github.com/hashicorp/go-multierror"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
 // Match for $VAR and capture VAR inside a group
 var re = regexp.MustCompile(`\$(\w+)`)
+
+// Match for ${VAR} and capture VAR inside a group
+var recb = regexp.MustCompile(`\${(\w+)}`)
 
 // ErrRequiredEnvKeyMissing represents error used for indicate environment key missing
 type ErrRequiredEnvKeyMissing struct {
@@ -45,3 +50,74 @@ func EnvSubstitute(content string) (string, error) {
 	return expanded, nil
 }
 
+// EnvSubstituteForCurlyBraces substitutes variables from environment to the content.
+// It uses regex to match in ${var} format for variables and look up them in the environment before processing.
+// returns an error if anything happen
+func EnvSubstituteForCurlyBraces(content string) (string, error) {
+	var errorResults error
+	missingEnvKeys := false
+	matches := recb.FindAllStringSubmatch(content, -1) // matches is [][]string
+
+	for _, match := range matches {
+		Logln(LogPrefixInfo + "Looking for:", match[0])
+		if os.Getenv(match[1]) == "" {
+			missingEnvKeys = true
+			errorResults = multierror.Append(errorResults, &ErrRequiredEnvKeyMissing{Key: match[0]})
+		} else {
+			content = strings.ReplaceAll(content, match[0], os.Getenv(match[1]))
+		}
+	}
+
+	if missingEnvKeys {
+		return "", errorResults
+	}
+
+	return content, nil
+}
+
+// Substitutes all the environment variables added in the file specified in the 'file' input and changes are
+// updated in the file.
+// If any required environment variable is not set will throw an error.
+func EnvSubstituteInFile(file string) error {
+	content, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	substitutedContent, err := EnvSubstituteForCurlyBraces(string(content))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(file, []byte(substitutedContent), 0644)
+	if err != nil {
+		return err
+	}
+	return nil;
+}
+
+// Walks through all the files in the given folder and substitutes all the environment variables added in
+// those files. The files will be updated with the substituted values.
+// If any required environment variable is not set will throw an error.
+func EnvSubstituteInFolder(folderPath string) error {
+	err := filepath.Walk(folderPath,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			fi, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if fi.Mode().IsRegular() {
+				Logln(LogPrefixInfo + "Substituting env variables in: ", path)
+				err = EnvSubstituteInFile(path)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+	return nil;
+}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/207

From this, we support environment variable substitution in files in the project in below folders:
1. Meta-information (includes api.yaml, swagger file)
2. Sequences (all the custom sequences)
3. Docs (inline documents)
4. Soap2Rest (conversion policies)
5. WSDL

The environment variables in such files should have the format `${var}`.

This also adds the support for using `${var}` in `api-params.yaml` file. It previously supported `$var` format only.


Eg: 

1. `PetstoreYaml-1.0/Sequences/in-sequence/Custom/sample_seq_in_2.xml` has the `ENV_IN_2` env variable.
```xml
<sequence xmlns="http://ws.apache.org/ns/synapse" name="sample_seq_in_2">      
    <property name="messageType" value="application/xml" scope="axis2"/>
    <property name="sampleIn" value="${ENV_IN_2}" scope="default"/>
</sequence>
```

2. export ENV_IN_2=samplevalue
3. apictl import-api -f PetstoreYaml-1.0 -e dev --update 

In the added API, sample_seq_in_2.xml in-sequence will have the substituted value:
```xml
<sequence xmlns="http://ws.apache.org/ns/synapse" name="sample_seq_in_2">      
    <property name="messageType" value="application/xml" scope="axis2"/>
    <property name="sampleIn" value="samplevalue" scope="default"/>
</sequence>
```
