### PR TITLE
Change "apictl export-apis" examples

### DIFF
--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -33,10 +33,10 @@ import (
 const exportAPIsCmdLiteral = "export-apis"
 const exportAPIsCmdShortDesc = "Export APIs for migration"
 
-const exportAPIsCmdLongDesc = "Export all the APIs of a tenant from an APIM 2.6.0 environment environment, to be imported " +
-	"into 3.0.0 environment"
-const exportAPIsCmdExamples = utils.ProjectName + ` ` + exportAPIsCmdLiteral + ` -e production-2.6.0 -u wso2admin@wso2.org -p 12345 -t wso2.org -k --force
-` + utils.ProjectName + ` ` + exportAPIsCmdLiteral + ` -e production-2.6.0 -u admin -p admin -k
+const exportAPIsCmdLongDesc = "Export all the APIs of a tenant from one environment, to be imported " +
+"into another environment"
+const exportAPIsCmdExamples = utils.ProjectName + ` ` + exportAPIsCmdLiteral + ` -e production -t wso2.org --force
+` + utils.ProjectName + ` ` + exportAPIsCmdLiteral + ` -e production
 NOTE: The flag (--environment (-e)) is mandatory`
 
 var apiExportDir string
@@ -54,8 +54,8 @@ var mainConfigFilePath string
 var credential credentials.Credential
 
 var ExportAPIsCmd = &cobra.Command{
-	Use: exportAPIsCmdLiteral + " [--environment " +
-		"<environment-from-which-artifacts-should-be-exported>] -u <user_name> -p <password> [-t <Tenant-domain-of-the-resources-to-be-exported>] [--force]",
+	Use: exportAPIsCmdLiteral + " (--environment " +
+		"<environment-from-which-artifacts-should-be-exported> -t <Tenant-domain-of-the-resources-to-be-exported> --force)",
 	Short:   exportAPIsCmdShortDesc,
 	Long:    exportAPIsCmdLongDesc,
 	Example: exportAPIsCmdExamples,

--- a/import-export-cli/docs/apictl_export-apis.md
+++ b/import-export-cli/docs/apictl_export-apis.md
@@ -4,17 +4,17 @@ Export APIs for migration
 
 ### Synopsis
 
-Export all the APIs of a tenant from an APIM 2.6.0 environment environment, to be imported into 3.0.0 environment
+Export all the APIs of a tenant from one environment, to be imported into another environment
 
 ```
-apictl export-apis [--environment <environment-from-which-artifacts-should-be-exported>] -u <user_name> -p <password> [-t <Tenant-domain-of-the-resources-to-be-exported>] [--force] [flags]
+apictl export-apis (--environment <environment-from-which-artifacts-should-be-exported> -t <Tenant-domain-of-the-resources-to-be-exported> --force) [flags]
 ```
 
 ### Examples
 
 ```
-apictl export-apis -e production-2.6.0 -u wso2admin@wso2.org -p 12345 -t wso2.org -k --force
-apictl export-apis -e production-2.6.0 -u admin -p admin -k
+apictl export-apis -e production -t wso2.org --force
+apictl export-apis -e production
 NOTE: The flag (--environment (-e)) is mandatory
 ```
 

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -28,7 +28,7 @@ apictl set --mode default
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/naduni/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/wasura/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
   -m, --mode string                mode of apictl

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -17,6 +17,12 @@ case $state in
   ;;
   level2)
     case $words[2] in
+      change)
+        _arguments '2: :(help registry)'
+      ;;
+      install)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
       list)
         _arguments '2: :(apis apps envs help)'
       ;;
@@ -28,12 +34,6 @@ case $state in
       ;;
       add)
         _arguments '2: :(api help)'
-      ;;
-      change)
-        _arguments '2: :(help registry)'
-      ;;
-      install)
-        _arguments '2: :(api-operator help wso2am-operator)'
       ;;
       *)
         _arguments '*: :_files'


### PR DESCRIPTION
## Purpose
Change the usage and examples of "apictl export-apis".

## Goals
Modify the flags in examples

## User stories
- Modify the usage as below:
```
  apictl export-apis (--environment <environment-from-which-artifacts-should-be-exported> -t <Tenant-domain-of-the-resources-to-be-exported> --force) [flags]
```

- Modify the examples as below:
```
apictl export-apis -e production -t wso2.org --force
apictl export-apis -e production
NOTE: The flag (--environment (-e)) is mandatory
```

## Documentation
Refer https://github.com/wso2/docs-apim/issues/964

## Test environment
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64