### PR TITLE
Remove file name in config maps for java interceptors

### DIFF
--- a/import-export-cli/cmd/addApi.go
+++ b/import-export-cli/cmd/addApi.go
@@ -73,9 +73,7 @@ func handleAddApi(nameSuffix string) {
 
 	for i, flagSwaggerFilePath := range flagSwaggerFilePaths {
 		// log processing only if there are more projects
-		if len(flagSwaggerFilePaths) > 1 {
-			fmt.Println(fmt.Sprintf("Processing swagger %v: %v", i+1, flagSwaggerFilePath))
-		}
+		utils.Logln(fmt.Sprintf("%sProcessing swagger %v: %v", utils.LogPrefixInfo, i+1, flagSwaggerFilePath))
 
 		flagApiName = strings.ToLower(flagApiName)
 		swaggerCmNames[i] = fmt.Sprintf("%v-%v-swagger%s", flagApiName, i+1, nameSuffix)
@@ -287,7 +285,8 @@ func handleJavaInterceptors(nameSuffix string, path string, operation string, na
 	const jarExt = ".jar"
 	for _, filePath := range interceptors {
 		if filepath.Ext(filePath) == jarExt {
-			//creating kubernetes configmap for each java interceptor
+			// creating kubernetes configmap for each java interceptor
+			// added the random number instead of file name to omit lengthy names and k8s resource name constraints
 			cmName := fmt.Sprintf("%s-%v-jar-interceptors%s", cmPrefixName, rand.Intn(10000), nameSuffix)
 			javaInterceptorsConfNames = append(javaInterceptorsConfNames, cmName)
 

--- a/import-export-cli/cmd/addApi.go
+++ b/import-export-cli/cmd/addApi.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -71,7 +72,12 @@ func handleAddApi(nameSuffix string) {
 	var javaInterceptorsCmNames []string
 
 	for i, flagSwaggerFilePath := range flagSwaggerFilePaths {
-		fmt.Println(fmt.Sprintf("Processing swagger %v: %v", i+1, flagSwaggerFilePath))
+		// log processing only if there are more projects
+		if len(flagSwaggerFilePaths) > 1 {
+			fmt.Println(fmt.Sprintf("Processing swagger %v: %v", i+1, flagSwaggerFilePath))
+		}
+
+		flagApiName = strings.ToLower(flagApiName)
 		swaggerCmNames[i] = fmt.Sprintf("%v-%v-swagger%s", flagApiName, i+1, nameSuffix)
 
 		fi, _ := os.Stat(flagSwaggerFilePath) // error already handled and ignore error
@@ -282,8 +288,7 @@ func handleJavaInterceptors(nameSuffix string, path string, operation string, na
 	for _, filePath := range interceptors {
 		if filepath.Ext(filePath) == jarExt {
 			//creating kubernetes configmap for each java interceptor
-			fileName := strings.Replace(filepath.Base(filePath), jarExt, "", 1)
-			cmName := fmt.Sprintf("%s-%s%s", cmPrefixName, fileName, nameSuffix)
+			cmName := fmt.Sprintf("%s-%v-jar-interceptors%s", cmPrefixName, rand.Intn(10000), nameSuffix)
 			javaInterceptorsConfNames = append(javaInterceptorsConfNames, cmName)
 
 			fmt.Println("creating configmap with java interceptor " + cmName)


### PR DESCRIPTION
fix wso2/k8s-api-operator#333
- Remove file name in config maps for java interceptors
- For more info visit the issue