### PR TITLE
Modying the usage of appropiate throttling tiers when creating/updating an application while generating keys

### DIFF
--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -57,6 +57,7 @@ const defaultApiApplicationImportExportSuffix = "api/am/admin/v0.16"
 const defaultApiListEndpointSuffix = "api/am/publisher/v1/apis"
 const defaultAdminApplicationListEndpointSuffix = "api/am/admin/v0.16/applications"
 const defaultDevPortalApplicationListEndpointSuffix = "api/am/store/v1/applications"
+const defaultDevPortalThrottlingPoliciesEndpointSuffix = "api/am/store/v1/throttling-policies"
 const defaultClientRegistrationEndpointSuffix = "client-registration/v0.16/register"
 
 const DefaultEnvironmentName = "default"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -210,6 +210,19 @@ func GetDevPortalApplicationListEndpointOfEnv(env, filePath string) string {
 	}
 }
 
+// Get ThrottlingPoliciesEndpoint of a given environment
+func GetDevPortalThrottlingPoliciesEndpointOfEnv(env, filePath string) string {
+	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)
+	if !(envEndpoints.DevPortalEndpoint == "" || envEndpoints == nil) {
+		envEndpoints.DevPortalEndpoint = AppendSlashToString(envEndpoints.DevPortalEndpoint)
+		return envEndpoints.DevPortalEndpoint + defaultDevPortalThrottlingPoliciesEndpointSuffix
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint + defaultDevPortalThrottlingPoliciesEndpointSuffix
+	}
+}
+
 // Get TokenEndpoint of a given environment
 func GetTokenEndpointOfEnv(env, filePath string) string {
 	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -48,8 +48,8 @@ type EnvKeys struct {
 
 type EnvEndpoints struct {
 	ApiManagerEndpoint   string `yaml:"apim"`
-	PublisherEndpoint      string `yaml:"publisher"`
-	DevPortalEndpoint      string `yaml:"devportal"`
+	PublisherEndpoint    string `yaml:"publisher"`
+	DevPortalEndpoint    string `yaml:"devportal"`
 	RegistrationEndpoint string `yaml:"registration"`
 	AdminEndpoint        string `yaml:"admin"`
 	TokenEndpoint        string `yaml:"token"`
@@ -58,11 +58,11 @@ type EnvEndpoints struct {
 // ---------------- End of Structs for YAML Config Files ---------------------------------
 
 type API struct {
-	ID       		string `json:"id"`
-	Name     		string `json:"name"`
-	Context  		string `json:"context"`
-	Version  		string `json:"version"`
-	Provider 		string `json:"provider"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Context         string `json:"context"`
+	Version         string `json:"version"`
+	Provider        string `json:"provider"`
 	LifeCycleStatus string `json:"lifeCycleStatus"`
 }
 
@@ -139,7 +139,7 @@ type KeygenResponse struct {
 
 //Application Keys
 type AppKeyList struct {
-	Count int `json:"count"`
+	Count int              `json:"count"`
 	List  []ApplicationKey `json:"list"`
 }
 
@@ -246,25 +246,46 @@ type Subscription struct {
 	RedirectionParams interface{} `json:"redirectionParams"`
 }
 
+//Throttling Policies List response struct
+type ThrottlingPoliciesList struct {
+	Count      int                `json:"count"`
+	List       []ThrottlingPolicy `json:"list"`
+	Pagination interface{}        `json:"pagination"`
+}
+
+//ThrottlingPolicy
+type ThrottlingPolicy struct {
+	Name                        string      `json:"name"`
+	Description                 string      `json:"description"`
+	PolicyLevel                 string      `json:"policyLevel"`
+	Attributes                  interface{} `json:"attributes"`
+	RequestCount                int         `json:"requestCount"`
+	UnitTime                    int         `json:"unitTime"`
+	TierPlan                    string      `json:"tierPlan"`
+	StopOnQuotaReach            bool        `json:"stopOnQuotaReach"`
+	MonetizationAttributes      interface{}
+	throttlingPolicyPermissions interface{}
+}
+
 //Subscription creation request
 type SubscriptionCreateRequest struct {
-	ApplicationID  string `json:"applicationId"`
-	APIID          string `json:"apiId"`
-	ThrottlingPolicy  string      `json:"throttlingPolicy"`
+	ApplicationID    string `json:"applicationId"`
+	APIID            string `json:"apiId"`
+	ThrottlingPolicy string `json:"throttlingPolicy"`
 }
 
 //API Search response struct. This includes common attributes for both store and publisher REST API search
 type ApiSearch struct {
 	Count int `json:"count"`
 	List  []struct {
-		ID                 string        `json:"id"`
-		Name               string        `json:"name"`
-		Description        interface{}   `json:"description"`
-		Context            string        `json:"context"`
-		Version            string        `json:"version"`
-		Provider           string        `json:"provider"`
-		Type               string        `json:"type"`
-		LifeCycleStatus    string        `json:"lifeCycleStatus"`
+		ID              string      `json:"id"`
+		Name            string      `json:"name"`
+		Description     interface{} `json:"description"`
+		Context         string      `json:"context"`
+		Version         string      `json:"version"`
+		Provider        string      `json:"provider"`
+		Type            string      `json:"type"`
+		LifeCycleStatus string      `json:"lifeCycleStatus"`
 	} `json:"list"`
 	Pagination struct {
 		Offset   int    `json:"offset"`
@@ -277,25 +298,25 @@ type ApiSearch struct {
 
 //get detailed API response
 type APIData struct {
-	ID                      string        `json:"id"`
-	Name                    string        `json:"name"`
-	Description             string        `json:"description"`
-	Context                 string        `json:"context"`
-	Version                 string        `json:"version"`
-	Provider                string        `json:"provider"`
-	LifeCycleStatus         string        `json:"lifeCycleStatus"`
-	HasThumbnail            interface{}   `json:"hasThumbnail"`
-	Policies                []string      `json:"policies"`
+	ID                  string      `json:"id"`
+	Name                string      `json:"name"`
+	Description         string      `json:"description"`
+	Context             string      `json:"context"`
+	Version             string      `json:"version"`
+	Provider            string      `json:"provider"`
+	LifeCycleStatus     string      `json:"lifeCycleStatus"`
+	HasThumbnail        interface{} `json:"hasThumbnail"`
+	Policies            []string    `json:"policies"`
 	BusinessInformation struct {
 		BusinessOwner       string `json:"businessOwner"`
 		BusinessOwnerEmail  string `json:"businessOwnerEmail"`
 		TechnicalOwner      string `json:"technicalOwner"`
 		TechnicalOwnerEmail string `json:"technicalOwnerEmail"`
 	} `json:"businessInformation"`
-	WsdlInfo                interface{}   `json:"wsdlInfo"`
-	WsdlURL                 interface{}   `json:"wsdlUrl"`
-	IsDefaultVersion        bool          `json:"isDefaultVersion"`
-	EndpointConfig  struct {
+	WsdlInfo         interface{} `json:"wsdlInfo"`
+	WsdlURL          interface{} `json:"wsdlUrl"`
+	IsDefaultVersion bool        `json:"isDefaultVersion"`
+	EndpointConfig   struct {
 		EndpointType     string `json:"endpoint_type"`
 		SandboxEndpoints struct {
 			URL string `json:"url"`
@@ -304,6 +325,6 @@ type APIData struct {
 			URL string `json:"url"`
 		} `json:"production_endpoints"`
 	} `json:"endpointConfig"`
-	Transport               []string      `json:"transport"`
-	Tags                    []string      `json:"tags"`
+	Transport []string `json:"transport"`
+	Tags      []string `json:"tags"`
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/274

## Goals
Eliminate the limitation in generating keys for APIs which have the business plan(s) as Gold, Silver or Bronze.

## Approach
When generating keys for an API (using **_apictl get-keys_**), first, an application should be created to get subscribed to that API. Here, when creating the application, we have tried to use the throttling tiers associated with the API, which is wrong. As the solution, we need to retrieve the throttling policies (tiers) that can be used when creating an application from the dev portal. The following steps have been taken here.
1. Created a new function named **getApplicationThrottlingPolicy(accessToken string)**
2. Using that function, the REST API call ```https://<APIM_Host>:<APIM_Port>/api/am/store/v1/throttling-policies/application``` and retrieved all the throttling policies that can be used when creating an application.
3. Get the first throttling policy from the retrieved list. 
4. Use it when creating and updating the default-apictl-app.
5. Made sure to use the tiers which are associated with the API when subscribing the application, NOT during the creation.
    - Changed the comments
    - Renamed the variables
6. Additionally, fixed formatting issues.

## User stories
When generating keys using **_apictl get-keys_**, use the appropriate set of throttling tiers in the below scenarios.
  - When creating application
  - When updating the application
  - When subscribing to an API using the application

## Test environment
- go version go1.14 linux/amd64