### PR TITLE
Added new Flag (limit) to list apis and apps and fixed formatting issue in apps

### DIFF
--- a/import-export-cli/cmd/apis.go
+++ b/import-export-cli/cmd/apis.go
@@ -76,6 +76,12 @@ var apisCmd = &cobra.Command{
 		if err != nil {
 			utils.HandleErrorAndExit("Error getting credentials", err)
 		}
+		//Since other flags does not use args[], query flag will own this
+		if len(args) != 0 && listApisCmdQuery != "" {
+			for _, argument := range args {
+				listApisCmdQuery +=  " " + argument
+			}
+		}
 		executeApisCmd(cred)
 	},
 }

--- a/import-export-cli/cmd/apis.go
+++ b/import-export-cli/cmd/apis.go
@@ -248,6 +248,6 @@ func init() {
 	apisCmd.Flags().StringVarP(&listApisCmdLimit, "limit", "l",
 		"", "Maximum number of apis to return")
 	apisCmd.Flags().StringVarP(&listApisCmdFormat, "format", "", "", "Pretty-print apis "+
-		"using Go Templates. Use {{ jsonPretty . }} to list all fields")
+		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
 	_ = apisCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/apps.go
+++ b/import-export-cli/cmd/apps.go
@@ -93,6 +93,11 @@ func (a app) GroupId() string {
 	return a.groupId
 }
 
+// MarshalJSON marshals api using custom marshaller which uses methods instead of fields
+func (a *app) MarshalJSON() ([]byte, error) {
+	return formatter.MarshalJSON(a)
+}
+
 const appsCmdLongDesc = "Display a list of Applications of the user in the environment specified by the flag --environment, -e"
 
 const appsCmdExamples = utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e dev 
@@ -216,7 +221,7 @@ func printApps(apps []utils.Application, format string) {
 
 func init() {
 	ListCmd.AddCommand(appsCmd)
-	
+
 	appsCmd.Flags().StringVarP(&listAppsCmdAppOwner, "owner", "o", "",
 		"Owner of the Application")
 	appsCmd.Flags().StringVarP(&listAppsCmdEnvironment, "environment", "e",
@@ -224,6 +229,6 @@ func init() {
 	appsCmd.Flags().StringVarP(&listAppsCmdLimit, "limit", "l",
 		"", "Maximum number of applications to return")
 	appsCmd.Flags().StringVarP(&listAppsCmdFormat, "format", "", "", "Pretty-print output"+
-		"using Go templates. Use {{jsonPretty .}} to list all fields")
+		"using Go templates. Use \"{{jsonPretty .}}\" to list all fields")
 	_ = appsCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/apps.go
+++ b/import-export-cli/cmd/apps.go
@@ -48,6 +48,7 @@ const (
 var listAppsCmdEnvironment string
 var listAppsCmdAppOwner string
 var listAppsCmdFormat string
+var listAppsCmdLimit string
 
 // appsCmd related info
 const appsCmdLiteral = "apps"
@@ -98,6 +99,7 @@ const appsCmdExamples = utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmd
 ` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e dev -o sampleUser
 ` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e prod -o sampleUser
 ` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e staging -o sampleUser
+` + utils.ProjectName + ` ` + listCmdLiteral + ` ` + appsCmdLiteral + ` -e dev -l 40
 NOTE: The flag (--environment (-e)) is mandatory`
 
 // appsCmd represents the apps command
@@ -124,7 +126,7 @@ func executeAppsCmd(credential credentials.Credential, appOwner string) {
 	}
 
 	applicationListEndpoint := utils.GetAdminApplicationListEndpointOfEnv(listAppsCmdEnvironment, utils.MainConfigFilePath)
-	_, apps, err := GetApplicationList(appOwner, accessToken, applicationListEndpoint)
+	_, apps, err := GetApplicationList(appOwner, accessToken, applicationListEndpoint, listAppsCmdLimit)
 
 	if err == nil {
 		// Printing the list of available Applications
@@ -141,11 +143,15 @@ func executeAppsCmd(credential credentials.Credential, appOwner string) {
 // @return array of Application objects
 // @return error
 
-func GetApplicationList(appOwner, accessToken, applicationListEndpoint string) (count int32, apps []utils.Application,
+func GetApplicationList(appOwner, accessToken, applicationListEndpoint, limit string) (count int32, apps []utils.Application,
 	err error) {
 
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	if limit != "" {
+		applicationListEndpoint += "?limit=" + limit
+	}
 
 	var resp *resty.Response
 	if appOwner == "" {
@@ -215,6 +221,8 @@ func init() {
 		"Owner of the Application")
 	appsCmd.Flags().StringVarP(&listAppsCmdEnvironment, "environment", "e",
 		"", "Environment to be searched")
+	appsCmd.Flags().StringVarP(&listAppsCmdLimit, "limit", "l",
+		"", "Maximum number of applications to return")
 	appsCmd.Flags().StringVarP(&listAppsCmdFormat, "format", "", "", "Pretty-print output"+
 		"using Go templates. Use {{jsonPretty .}} to list all fields")
 	_ = appsCmd.MarkFlagRequired("environment")

--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -264,7 +264,7 @@ func getAPIList() (count int32, apis []utils.API) {
 		if cmdResourceTenantDomain != "" {
 			apiListEndpoint += "&tenantDomain=" + cmdResourceTenantDomain
 		}
-		count, apis, err := GetAPIList("", accessToken, apiListEndpoint)
+		count, apis, err := GetAPIList("", "", accessToken, apiListEndpoint)
 		if err == nil {
 			return count, apis
 		} else {

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -548,7 +548,7 @@ func getApiID(name, version, provider, environment, accessOAuthToken string) (st
 	if provider != "" {
 		apiQuery += " provider:" + provider
 	}
-	count, apis, err := GetAPIList(url.QueryEscape(apiQuery), accessOAuthToken,
+	count, apis, err := GetAPIList(url.QueryEscape(apiQuery), "", accessOAuthToken,
 		utils.GetApiListEndpointOfEnv(environment, utils.MainConfigFilePath))
 	if err != nil {
 		return "", err

--- a/import-export-cli/cmd/list_test.go
+++ b/import-export-cli/cmd/list_test.go
@@ -74,7 +74,7 @@ func TestGetAPIListOK(t *testing.T) {
 	}))
 	defer server.Close()
 
-	count, apiList, err := GetAPIList("", "access_token", server.URL)
+	count, apiList, err := GetAPIList("", "", "access_token", server.URL)
 	fmt.Println("Count:", count)
 	fmt.Println("List:", apiList)
 
@@ -99,7 +99,7 @@ func TestGetAPIListUnreachable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	count, list, err := GetAPIList("", "access_token", server.URL)
+	count, list, err := GetAPIList("", "", "access_token", server.URL)
 	if count != 0 {
 		t.Errorf("Incorrect Count. Expected %d, got %d\n", 0, count)
 	}
@@ -150,7 +150,7 @@ func TestGetApplicationListOK(t *testing.T) {
 	}))
 	defer server.Close()
 
-	count, appList, err := GetApplicationList("admin", "access_token", server.URL)
+	count, appList, err := GetApplicationList("admin", "access_token", server.URL, "")
 	fmt.Println("Count:", count)
 	fmt.Println("List:", appList)
 
@@ -172,7 +172,7 @@ func TestGetApplicationListUnreachable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	count, list, err := GetAPIList("", "access_token", server.URL)
+	count, list, err := GetAPIList("", "", "access_token", server.URL)
 	if count != 0 {
 		t.Errorf("Incorrect Count. Expected %d, got %d\n", 0, count)
 	}


### PR DESCRIPTION
This PR 
1. Added a new flag as ```limit``` to ```list apis``` and ```list apps``` (Git issue: https://github.com/wso2/product-apim-tooling/issues/265)
2. Fixed formating issue in apps when ```json``` or ```jsonPretty``` templates used. (Git issue: https://github.com/wso2/product-apim-tooling/issues/280)
3. Support entering query arguments of ```list apis``` without wrapped in quotes (Git issue : https://github.com/wso2/product-apim-tooling/issues/266)
