### PR TITLE
Add change-api-status command support

### DIFF
--- a/import-export-cli/cmd/changeAPIStatus.go
+++ b/import-export-cli/cmd/changeAPIStatus.go
@@ -1,0 +1,173 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/go-resty/resty"
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"net/http"
+)
+
+var apiStateChangeEnvironment string
+var apiNameForStateChange string
+var apiVersionForStateChange string
+var apiProviderForStateChange string
+var apiStateChangeAction string
+
+// ChangeAPIStatus command related usage info
+const changeAPIStatusCmdLiteral = "change-api-status"
+const changeAPIStatusCmdShortDesc = "Change API Status"
+const changeAPIStatusCmdLongDesc = "Change the lifecycle status of an API in an environment"
+
+const changeAPIStatusCmdExamples = utils.ProjectName + ` ` + changeAPIStatusCmdLiteral + ` -a Publish -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + changeAPIStatusCmdLiteral + ` -a Publish -n FacebookAPI -v 2.1.0 -e production
+NOTE: All the 4 flags (--action (-a), --name (-n), --version (-v), and --environment (-e)) are mandatory.
+If the --provider (-r) is not specified, the logged-in user will be considered as the provider.`
+
+// changeAPIStatusCmd represents the change-api-status command
+var changeAPIStatusCmd = &cobra.Command{
+	Use:   changeAPIStatusCmdLiteral + " (--action <action-of-the-api-state-change> --name <name-of-the-api> --version <version-of-the-api> --provider " +
+		"<provider-of-the-api> --environment <environment-from-which-the-api-state-should-be-changed>)",
+	Short: changeAPIStatusCmdShortDesc,
+	Long: changeAPIStatusCmdLongDesc,
+	Example: changeAPIStatusCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + changeAPIStatusCmdLiteral + " called")
+		cred, err := getCredentials(apiStateChangeEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials ", err)
+		}
+		executeChangeAPIStatusCmd(cred)
+	},
+}
+
+// executeChangeAPIStatusCmd executes the change api status command
+func executeChangeAPIStatusCmd(credential credentials.Credential)  {
+	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, apiStateChangeEnvironment)
+	if preCommandErr == nil {
+		changeAPIStatusEndpoint := utils.GetApiListEndpointOfEnv(apiStateChangeEnvironment, utils.MainConfigFilePath)
+		resp, err := getChangeAPIStatusResponse(changeAPIStatusEndpoint, accessToken, credential)
+		if err != nil {
+			utils.HandleErrorAndExit("Error while changing the API status", err)
+		}
+		// Print info on response
+		utils.Logf(utils.LogPrefixInfo + "ResponseStatus: %v\n", resp.Status())
+		if resp.StatusCode() == http.StatusOK {
+			// 200 OK
+			fmt.Println(apiNameForStateChange + " API state changed successfully!")
+		} else if resp.StatusCode() == http.StatusInternalServerError {
+			// 500 Internal Server Error
+			fmt.Println(string(resp.Body()))
+		} else {
+			// Neither 200 nor 500
+			fmt.Println("Error while changing API Status: ", resp.Status(), "\n", string(resp.Body()))
+		}
+	} else {
+		// Error changing the API status
+		fmt.Println("Error getting OAuth tokens while changing status of the API:" + preCommandErr.Error())
+	}
+}
+
+// getChangeAPIStatusResponse
+// @param changeAPIStatusEndpoint : API Manager Publisher REST API Endpoint for the environment
+// @param accessToken : Access Token for the resource
+// @param credential : Credentials of the logged-in user
+// @return response Response in the form of *resty.Response
+func getChangeAPIStatusResponse(changeAPIStatusEndpoint, accessToken string, credential credentials.Credential) (*resty.Response, error) {
+	changeAPIStatusEndpoint = utils.AppendSlashToString(changeAPIStatusEndpoint)
+	apiId, err := getAPIIdForStateChange(accessToken, credential)
+	if err != nil {
+		utils.HandleErrorAndExit("Error while getting API Id for state change ", err)
+	}
+	url := changeAPIStatusEndpoint + "change-lifecycle?action=" + apiStateChangeAction + "&apiId=" + apiId
+	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	resp, err := utils.InvokePOSTRequest(url, headers, "")
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Get the ID of an API if available
+// @param accessToken : Token to call the Publisher Rest API
+// @return apiId, error
+func getAPIIdForStateChange(accessToken string, credential credentials.Credential) (string, error) {
+	// API endpoint of the environment from the config file
+	apiEndpoint := utils.GetApiListEndpointOfEnv(apiStateChangeEnvironment, utils.MainConfigFilePath)
+
+	// Prepping headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	var queryVal string
+	if apiProviderForStateChange == "" {
+		apiProviderForStateChange = credential.Username
+	}
+	queryVal = "name:\"" + apiNameForStateChange + "\" version:\"" + apiVersionForStateChange + "\" provider:\"" + apiProviderForStateChange + "\""
+	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, apiEndpoint, headers)
+	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+		// 200 OK or 201 Created
+		apiData := &utils.ApiSearch{}
+		data := []byte(resp.Body())
+		err = json.Unmarshal(data, &apiData)
+		if apiData.Count != 0 {
+			apiId := apiData.List[0].ID
+			return apiId, err
+		}
+		return "", errors.New("Requested API is not available in the Publisher. API: " + apiNameForStateChange +
+			" Version: " + apiVersionForStateChange + " Provider: " + apiProviderForStateChange)
+	} else {
+		utils.Logf("Error: %s\n", resp.Error())
+		utils.Logf("Body: %s\n", resp.Body())
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthorized
+			return "", fmt.Errorf("Authorization failed while searching API: " + apiNameForStateChange)
+		}
+		return "", errors.New("Request didn't respond 200 OK for searching APIs. Status: " + resp.Status())
+	}
+}
+
+func init() {
+	RootCmd.AddCommand(changeAPIStatusCmd)
+	changeAPIStatusCmd.Flags().StringVarP(&apiStateChangeAction, "action", "a", "",
+		"Name of the API to be state changed")
+	changeAPIStatusCmd.Flags().StringVarP(&apiNameForStateChange, "name", "n", "",
+		"Name of the API to be state changed")
+	changeAPIStatusCmd.Flags().StringVarP(&apiVersionForStateChange, "version", "v", "",
+		"Version of the API to be state changed")
+	changeAPIStatusCmd.Flags().StringVarP(&apiProviderForStateChange, "provider", "r", "",
+		"Provider of the API")
+	changeAPIStatusCmd.Flags().StringVarP(&apiStateChangeEnvironment, "environment", "e",
+		"", "Environment of which the API state should be changed")
+	// Mark required flags
+	_ = changeAPIStatusCmd.MarkFlagRequired("action")
+	_ = changeAPIStatusCmd.MarkFlagRequired("name")
+	_ = changeAPIStatusCmd.MarkFlagRequired("version")
+	_ = changeAPIStatusCmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -91,11 +91,9 @@ func executeDeleteAPICmd(credential credentials.Credential)  {
 }
 
 // DeleteAPI
-// @param name : Name of the API to be deleted
-// @param version : Version of the API to be deleted
-// @param provider : Provider of the API to be deleted
 // @param deleteEndpoint : API Manager Publisher REST API Endpoint for the environment
 // @param accessToken : Access Token for the resource
+// @param credential : Credentials of the logged-in user
 // @return response Response in the form of *resty.Response
 func getDeleteAPIResponse(deleteEndpoint, accessToken string, credential credentials.Credential) (*resty.Response, error) {
 	deleteEndpoint = utils.AppendSlashToString(deleteEndpoint)
@@ -148,7 +146,7 @@ func getAPIId(accessToken string, credential credentials.Credential) (string, er
 		utils.Logf("Body: %s\n", resp.Body())
 		if resp.StatusCode() == http.StatusUnauthorized {
 			// 401 Unauthorized
-			return "", fmt.Errorf("Authorization failed while searching API: " + apiName)
+			return "", fmt.Errorf("Authorization failed while searching API: " + deleteAPIName)
 		}
 		return "", errors.New("Request didn't respond 200 OK for searching APIs. Status: " + resp.Status())
 	}

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -90,7 +90,7 @@ func executeDeleteAPICmd(credential credentials.Credential)  {
 	}
 }
 
-// DeleteAPI
+// getDeleteAPIResponse
 // @param deleteEndpoint : API Manager Publisher REST API Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @param credential : Credentials of the logged-in user

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -24,6 +24,7 @@ apictl [flags]
 * [apictl add](apictl_add.md)	 - Add an API to the kubernetes cluster
 * [apictl add-env](apictl_add-env.md)	 - Add Environment to Config file
 * [apictl change](apictl_change.md)	 - Change a configuration
+* [apictl change-api-status](apictl_change-api-status.md)	 - Change API Status
 * [apictl delete-api](apictl_delete-api.md)	 - Delete API
 * [apictl delete-api-product](apictl_delete-api-product.md)	 - Delete API Product
 * [apictl export-api](apictl_export-api.md)	 - Export API

--- a/import-export-cli/docs/apictl_change-api-status.md
+++ b/import-export-cli/docs/apictl_change-api-status.md
@@ -16,13 +16,12 @@ apictl change-api-status (--action <action-of-the-api-state-change> --name <name
 apictl change-api-status -a Publish -n TwitterAPI -v 1.0.0 -r admin -e dev
 apictl change-api-status -a Publish -n FacebookAPI -v 2.1.0 -e production
 NOTE: All the 4 flags (--action (-a), --name (-n), --version (-v), and --environment (-e)) are mandatory.
-If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
 ```
 
 ### Options
 
 ```
-  -a, --action string        Name of the API to be state changed
+  -a, --action string        Action to be taken to change the status of the API
   -e, --environment string   Environment of which the API state should be changed
   -h, --help                 help for change-api-status
   -n, --name string          Name of the API to be state changed

--- a/import-export-cli/docs/apictl_change-api-status.md
+++ b/import-export-cli/docs/apictl_change-api-status.md
@@ -1,0 +1,43 @@
+## apictl change-api-status
+
+Change API Status
+
+### Synopsis
+
+Change the lifecycle status of an API in an environment
+
+```
+apictl change-api-status (--action <action-of-the-api-state-change> --name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment <environment-from-which-the-api-state-should-be-changed>) [flags]
+```
+
+### Examples
+
+```
+apictl change-api-status -a Publish -n TwitterAPI -v 1.0.0 -r admin -e dev
+apictl change-api-status -a Publish -n FacebookAPI -v 2.1.0 -e production
+NOTE: All the 4 flags (--action (-a), --name (-n), --version (-v), and --environment (-e)) are mandatory.
+If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
+```
+
+### Options
+
+```
+  -a, --action string        Name of the API to be state changed
+  -e, --environment string   Environment of which the API state should be changed
+  -h, --help                 help for change-api-status
+  -n, --name string          Name of the API to be state changed
+  -r, --provider string      Provider of the API
+  -v, --version string       Version of the API to be state changed
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+

--- a/import-export-cli/docs/apictl_delete-api.md
+++ b/import-export-cli/docs/apictl_delete-api.md
@@ -16,7 +16,6 @@ apictl delete-api (--name <name-of-the-api> --version <version-of-the-api> --pro
 apictl delete-api -n TwitterAPI -v 1.0.0 -r admin -e dev
 apictl delete-api -n FacebookAPI -v 2.1.0 -e production
 NOTE: All the 3 flags (--name (-n), --version (-v), and --environment (-e)) are mandatory.
-If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
 ```
 
 ### Options
@@ -25,7 +24,7 @@ If the --provider (-r) is not specified, the logged-in user will be considered a
   -e, --environment string   Environment from which the API should be deleted
   -h, --help                 help for delete-api
   -n, --name string          Name of the API to be deleted
-  -r, --provider string      Provider of the API
+  -r, --provider string      Provider of the API to be deleted
   -v, --version string       Version of the API to be deleted
 ```
 

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -28,7 +28,7 @@ apictl set --mode default
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/wasura/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/naduni/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
   -m, --mode string                mode of apictl

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -280,3 +280,21 @@
 </code></pre>
     </li>
 </ul>
+<ul>
+    <li><h4 id="change-api-status">change-api-status</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --action, -a
+           --name, -n
+           --version, -v
+           --environment, -e
+       Optional:
+           --provider, -r
+           NOTE: User will be prompted to enter credentials if the user is not logged in to the environment.
+                 If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
+   Examples:
+       apictl change-api-status -a Publish -n TestAPI -v 1.0.0 -r admin -e staging
+       apictl change-api-status -a Publish -n TestAPI -v 1.0.0 -e production
+</code></pre>
+    </li>
+</ul>

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -273,7 +273,6 @@
        Optional:
            --provider, -r
            NOTE: User will be prompted to enter credentials if the user is not logged in to the environment.
-                 If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
    Examples:
        apictl delete-api -n TestAPI -v 1.0.0 -r admin -e staging
        apictl delete-api -n TestAPI -v 1.0.0 -e production
@@ -291,7 +290,6 @@
        Optional:
            --provider, -r
            NOTE: User will be prompted to enter credentials if the user is not logged in to the environment.
-                 If the --provider (-r) is not specified, the logged-in user will be considered as the provider.
    Examples:
        apictl change-api-status -a Publish -n TestAPI -v 1.0.0 -r admin -e staging
        apictl change-api-status -a Publish -n TestAPI -v 1.0.0 -e production

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -428,6 +428,55 @@ _apictl_change()
     noun_aliases=()
 }
 
+_apictl_change-api-status()
+{
+    last_command="apictl_change-api-status"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--action=")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--action=")
+    flags+=("--environment=")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    flags+=("--name=")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name=")
+    flags+=("--provider=")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider=")
+    flags+=("--version=")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version=")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--action=")
+    must_have_one_flag+=("-a")
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--version=")
+    must_have_one_flag+=("-v")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_delete-api()
 {
     last_command="apictl_delete-api"
@@ -1402,6 +1451,7 @@ _apictl_root_command()
     commands+=("add")
     commands+=("add-env")
     commands+=("change")
+    commands+=("change-api-status")
     commands+=("delete-api")
     commands+=("delete-api-product")
     commands+=("export-api")

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -17,6 +17,12 @@ case $state in
   ;;
   level2)
     case $words[2] in
+      add)
+        _arguments '2: :(api help)'
+      ;;
+      change)
+        _arguments '2: :(help registry)'
+      ;;
       install)
         _arguments '2: :(api-operator help wso2am-operator)'
       ;;
@@ -28,12 +34,6 @@ case $state in
       ;;
       update)
         _arguments '2: :(api help)'
-      ;;
-      add)
-        _arguments '2: :(api help)'
-      ;;
-      change)
-        _arguments '2: :(help registry)'
       ;;
       *)
         _arguments '*: :_files'

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -8,7 +8,7 @@ case $state in
   level1)
     case $words[1] in
       apictl)
-        _arguments '1: :(add add-env change delete-api delete-api-product export-api export-apis export-app get-keys help import-api import-app init install list login logout remove-env set uninstall update version)'
+        _arguments '1: :(add add-env change change-api-status delete-api delete-api-product export-api export-apis export-app get-keys help import-api import-app init install list login logout remove-env set uninstall update version)'
       ;;
       *)
         _arguments '*: :_files'
@@ -17,6 +17,12 @@ case $state in
   ;;
   level2)
     case $words[2] in
+      install)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      list)
+        _arguments '2: :(api-products apis apps envs help)'
+      ;;
       uninstall)
         _arguments '2: :(api-operator help wso2am-operator)'
       ;;
@@ -28,12 +34,6 @@ case $state in
       ;;
       change)
         _arguments '2: :(help registry)'
-      ;;
-      install)
-        _arguments '2: :(api-operator help wso2am-operator)'
-      ;;
-      list)
-        _arguments '2: :(api-products apis apps envs help)'
       ;;
       *)
         _arguments '*: :_files'


### PR DESCRIPTION
## Purpose
This PR contains the implementation to add support for change-api-status command in APICTL.

Please refer https://github.com/wso2/product-apim-tooling/issues/278 for more details.

## Documentation
https://github.com/wso2/product-apim-tooling/issues/290

## Samples
Sample API state change commands are like:
```
apictl change-api-status -a Publish -n TwitterAPI -v 1.0.0 -r admin -e dev
apictl change-api-status -a Publish -n FacebookAPI -v 2.1.0 -e production
```

## Test environment
Tested in Linux OS