### PR TITLE
Modify API Product delete flag descriptions

### DIFF
--- a/import-export-cli/cmd/deleteAPIProduct.go
+++ b/import-export-cli/cmd/deleteAPIProduct.go
@@ -160,11 +160,11 @@ func getAPIProductId(accessToken string, credential credentials.Credential) (str
 func init() {
 	RootCmd.AddCommand(DeleteAPIProductCmd)
 	DeleteAPIProductCmd.Flags().StringVarP(&deleteAPIProductName, "name", "n", "",
-		"Name of the API to be deleted")
+		"Name of the API Product to be deleted")
 	DeleteAPIProductCmd.Flags().StringVarP(&deleteAPIProductProvider, "provider", "r", "",
-		"Provider of the API to be deleted")
+		"Provider of the API Product to be deleted")
 	DeleteAPIProductCmd.Flags().StringVarP(&deleteAPIProductEnvironment, "environment", "e",
-		"", "Environment from which the API should be deleted")
+		"", "Environment from which the API Product should be deleted")
 	// Mark required flags
 	_ = DeleteAPIProductCmd.MarkFlagRequired("name")
 	_ = DeleteAPIProductCmd.MarkFlagRequired("environment")

--- a/import-export-cli/docs/apictl_delete-api-product.md
+++ b/import-export-cli/docs/apictl_delete-api-product.md
@@ -21,10 +21,10 @@ NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory.
 ### Options
 
 ```
-  -e, --environment string   Environment from which the API should be deleted
+  -e, --environment string   Environment from which the API Product should be deleted
   -h, --help                 help for delete-api-product
-  -n, --name string          Name of the API to be deleted
-  -r, --provider string      Provider of the API to be deleted
+  -n, --name string          Name of the API Product to be deleted
+  -r, --provider string      Provider of the API Product to be deleted
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -28,7 +28,7 @@ apictl set --mode default
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/Users/chaminduwso2/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/wasura/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
   -m, --mode string                mode of apictl

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -17,12 +17,6 @@ case $state in
   ;;
   level2)
     case $words[2] in
-      update)
-        _arguments '2: :(api help)'
-      ;;
-      add)
-        _arguments '2: :(api help)'
-      ;;
       change)
         _arguments '2: :(help registry)'
       ;;
@@ -37,6 +31,12 @@ case $state in
       ;;
       uninstall)
         _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      update)
+        _arguments '2: :(api help)'
+      ;;
+      add)
+        _arguments '2: :(api help)'
       ;;
       *)
         _arguments '*: :_files'


### PR DESCRIPTION
## Purpose
The flag descriptions of current API Product delete command consists the word "API" not "API Product".

## Goals
Correct the flag description of API Product delete.

## Approach
Modified the flag descriptions as follows.
```
Flags:
  -e, --environment string   Environment from which the API Product should be deleted
  -h, --help                 help for delete-api-product
  -n, --name string          Name of the API Product to be deleted
  -r, --provider string      Provider of the API Product to be deleted
```