### PR TITLE
Adding integration tests for API Products related functionalities

### DIFF
--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/loads v0.19.2
 	github.com/go-resty/resty v0.0.0-20171018191538-8b5e3f91fbea
+	github.com/google/go-cmp v0.3.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/magiconair/properties v1.7.6
@@ -21,6 +22,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apimachinery v0.0.0-20190913075813-344bcc0201c9 // indirect
 	sigs.k8s.io/controller-runtime v0.2.1 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )
 
 module github.com/wso2/product-apim-tooling/import-export-cli

--- a/import-export-cli/go.sum
+++ b/import-export-cli/go.sum
@@ -191,6 +191,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
@@ -391,6 +392,7 @@ github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7Sr
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -104,13 +104,6 @@ func TestExportImportApiProductAdminSuperTenantUserWithImportApis(t *testing.T) 
 		updateApiProductFlag: false,
 	}
 
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
-		}
-	})
-
 	// Import the API Product with the dependent APIs to env2
 	validateAPIProductExportImportPreserveProvider(t, args)
 }
@@ -256,13 +249,6 @@ func TestExportImportApiProductAdminSuperTenantUserWithUpdateApiProduct(t *testi
 		updateApiProductFlag: false,
 	}
 
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
-		}
-	})
-
 	// Export the API Product from env 1 and import it to env 2
 	validateAPIProductExportImportPreserveProvider(t, args)
 
@@ -272,7 +258,7 @@ func TestExportImportApiProductAdminSuperTenantUserWithUpdateApiProduct(t *testi
 	args.updateApiProductFlag = true
 
 	// Re-import the API Product to env 1 while updating it
-	validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t, args)
+	validateAPIProductImportUpdatePreserveProvider(t, args)
 }
 
 // Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin
@@ -319,13 +305,6 @@ func TestExportImportApiProductAdminSuperTenantUserWithUpdateApisAndApiProduct(t
 		updateApiProductFlag: false,
 	}
 
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
-		}
-	})
-
 	// Export the API Product from env 1 and import it to env 2
 	validateAPIProductExportImportPreserveProvider(t, args)
 
@@ -336,7 +315,7 @@ func TestExportImportApiProductAdminSuperTenantUserWithUpdateApisAndApiProduct(t
 	// You can make updateApiProductFlag true too - The same behaviour will happen
 
 	// Re-import the API Product to env 1 while updating the API Product and APIs
-	validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t, args)
+	validateAPIProductImportUpdatePreserveProvider(t, args)
 }
 
 // Export an API Product with its dependent APIs from one environment and import to another environment freshly as cross tenant admin
@@ -386,13 +365,6 @@ func TestExportImportApiProductCrossTenantUserWithImportApis(t *testing.T) {
 
 	// Export the API Product as super tenant admin
 	validateAPIProductExport(t, args)
-
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, tenantAdminUsername, tenantAdminPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, tenantAdminUsername, tenantAdminPassword)
-		}
-	})
 
 	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
 	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
@@ -451,13 +423,6 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApiProduct(t *testing.T)
 	// Export the API Product as super tenant admin
 	validateAPIProductExport(t, args)
 
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
-		}
-	})
-
 	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
 	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
 	args.ctlUser = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
@@ -471,7 +436,7 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApiProduct(t *testing.T)
 	args.updateApiProductFlag = true
 
 	// Re-import the API Product to env 1 while updating it
-	validateAPIProductImportWithoutCleaningImportedApiProduct(t, args)
+	validateAPIProductImportUpdate(t, args)
 }
 
 // Export an API Product with its dependent APIs from one environment as super admin and import to another environment freshly as tenant admin
@@ -524,13 +489,6 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApisAndApiProduct(t *tes
 	// Export the API Product as super tenant admin
 	validateAPIProductExport(t, args)
 
-	t.Cleanup(func() {
-		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
-		for _, api := range apiList.List {
-			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
-		}
-	})
-
 	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
 	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
 	args.ctlUser = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
@@ -544,7 +502,7 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApisAndApiProduct(t *tes
 	args.updateApisFlag = true
 
 	// Re-import the API Product to env 1 while updating the API Product and APIs
-	validateAPIProductImportWithoutCleaningImportedApiProduct(t, args)
+	validateAPIProductImportUpdate(t, args)
 }
 
 func TestListApiProductsAdminSuperTenantUser(t *testing.T) {

--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -1,0 +1,774 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package integration
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+)
+
+// Export an API Product with its dependent APIs from one environment as a super tenant non admin user
+func TestExportApiProductNonAdminSuperTenantUser(t *testing.T) {
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider: credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:            credentials{username: apiCreator, password: apiCreatorPassword},
+		apiProduct:         apiProduct,
+		srcAPIM:            dev,
+	}
+
+	validateAPIProductExportFailure(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin
+func TestExportImportApiProductAdminSuperTenantUserWithImportApis(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
+		}
+	})
+
+	// Import the API Product with the dependent APIs to env2
+	validateAPIProductExportImportPreserveProvider(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import it as super tenant admin
+// when dependent APIs are already in that environment and you do not want to update those APIs.
+func TestExportImportApiProductAdminSuperTenantUserWithoutImportApis(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1 and env2
+	dependentAPI1ofEnv1, dependentAPI1ofEnv2 := addAPIToTwoEnvs(t, dev, prod, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1ofEnv1.ID)
+	publishAPI(prod, apiPublisher, apiPublisherPassword, dependentAPI1ofEnv2.ID)
+
+	// Add the second dependent API to env1 and env2
+	dependentAPI2ofEnv1, dependentAPI2ofEnv2 := addAPIFromOpenAPIDefinitionToTwoEnvs(t, dev, prod, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2ofEnv1.ID)
+	publishAPI(prod, apiPublisher, apiPublisherPassword, dependentAPI2ofEnv2.ID)
+
+	// Map the real name of the APIs with the APIs of env1
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1ofEnv1,
+		"SwaggerPetstore": dependentAPI2ofEnv1,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       false,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	// Import the API Product without importing the dependent APIs to env2
+	validateAPIProductExportImportPreserveProvider(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import it as super tenant admin
+// when dependent APIs are already in that environment and you want to update those APIs.
+func TestExportImportApiProductAdminSuperTenantUserWithUpdateApis(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1 and env2
+	dependentAPI1ofEnv1, dependentAPI1ofEnv2 := addAPIToTwoEnvs(t, dev, prod, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1ofEnv1.ID)
+	publishAPI(prod, apiPublisher, apiPublisherPassword, dependentAPI1ofEnv2.ID)
+
+	// Add the second dependent API to env1 and env2
+	dependentAPI2ofEnv1, dependentAPI2ofEnv2 := addAPIFromOpenAPIDefinitionToTwoEnvs(t, dev, prod, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2ofEnv1.ID)
+	publishAPI(prod, apiPublisher, apiPublisherPassword, dependentAPI2ofEnv2.ID)
+
+	// Map the real name of the APIs with the APIs of env1
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1ofEnv1,
+		"SwaggerPetstore": dependentAPI2ofEnv1,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       false,
+		updateApisFlag:       true,
+		updateApiProductFlag: false,
+	}
+
+	// Import the API Product without importing the dependent APIs to env2 but updating those
+	validateAPIProductExportImportPreserveProvider(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin
+// and try to update that API Product (without updating dependent APIs)
+func TestExportImportApiProductAdminSuperTenantUserWithUpdateApiProduct(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
+		}
+	})
+
+	// Export the API Product from env 1 and import it to env 2
+	validateAPIProductExportImportPreserveProvider(t, args)
+
+	// Set the --update-api-product flag to update the existing API Product while importing
+	// and make the importApisFlag false
+	args.importApisFlag = false
+	args.updateApiProductFlag = true
+
+	// Re-import the API Product to env 1 while updating it
+	validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin
+// and try to update that API Product and dependent APIs.
+// This same command can be used to update only the dependent APIs as well.
+func TestExportImportApiProductAdminSuperTenantUserWithUpdateApisAndApiProduct(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
+		}
+	})
+
+	// Export the API Product from env 1 and import it to env 2
+	validateAPIProductExportImportPreserveProvider(t, args)
+
+	// Set the --update-apis flag to update the APIs (it will update the API Product_as well)
+	// and make the importApisFlag false
+	args.importApisFlag = false
+	args.updateApisFlag = true
+	// You can make updateApiProductFlag true too - The same behaviour will happen
+
+	// Re-import the API Product to env 1 while updating the API Product and APIs
+	validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment and import to another environment freshly as cross tenant admin
+func TestExportImportApiProductCrossTenantUserWithImportApis(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	// Export the API Product as super tenant admin
+	validateAPIProductExport(t, args)
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, tenantAdminUsername, tenantAdminPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, tenantAdminUsername, tenantAdminPassword)
+		}
+	})
+
+	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
+	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+	args.ctlUser = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+
+	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
+	validateAPIProductImport(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment as super tenant admin and import to another environment freshly
+// as cross tenant admin and try to update that API Product (without updating dependent APIs)
+func TestExportImportApiProductCrossTenantUserWithUpdateApiProduct(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	// Export the API Product as super tenant admin
+	validateAPIProductExport(t, args)
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
+		}
+	})
+
+	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
+	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+	args.ctlUser = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+
+	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
+	validateAPIProductImport(t, args)
+
+	// Set the --update-api-product flag to update the existing API Product while importing
+	// and make the importApisFlag false
+	args.importApisFlag = false
+	args.updateApiProductFlag = true
+
+	// Re-import the API Product to env 1 while updating it
+	validateAPIProductImportWithoutCleaningImportedApiProduct(t, args)
+}
+
+// Export an API Product with its dependent APIs from one environment as super admin and import to another environment freshly as tenant admin
+// and try to update that API Product and dependent APIs.
+// This same command can be used to update only the dependent APIs as well.
+func TestExportImportApiProductCrossTenantUserWithUpdateApisAndApiProduct(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiProductImportExportTestArgs{
+		apiProductProvider:   credentials{username: apiPublisher, password: apiPublisherPassword},
+		ctlUser:              credentials{username: adminUsername, password: adminPassword},
+		apiProduct:           apiProduct,
+		srcAPIM:              dev,
+		destAPIM:             prod,
+		importApisFlag:       true,
+		updateApisFlag:       false,
+		updateApiProductFlag: false,
+	}
+
+	// Export the API Product as super tenant admin
+	validateAPIProductExport(t, args)
+
+	t.Cleanup(func() {
+		apiList := getAPIs(prod, apiCreator, apiCreatorPassword)
+		for _, api := range apiList.List {
+			deleteAPI(t, prod, api.ID, apiCreator, apiCreatorPassword)
+		}
+	})
+
+	// Since --preserve-provider=false both the apiProductProvider and the ctlUser is tenant admin
+	args.apiProductProvider = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+	args.ctlUser = credentials{username: tenantAdminUsername, password: tenantAdminPassword}
+
+	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
+	validateAPIProductImport(t, args)
+
+	// Set the --update-api-product flag to update the existing API Product while importing
+	// and make the importApisFlag false
+	args.importApisFlag = false
+	args.updateApisFlag = true
+
+	// Re-import the API Product to env 1 while updating the API Product and APIs
+	validateAPIProductImportWithoutCleaningImportedApiProduct(t, args)
+}
+
+func TestListApiProductsAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add a random number (< 10) of API Products (same copy)
+	randomNumber := rand.Intn(10)
+	for apiProductCount := 0; apiProductCount <= randomNumber; apiProductCount++ {
+		// Add the API Product to env1
+		addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &apiProductImportExportTestArgs{
+		ctlUser: credentials{username: adminUsername, password: adminPassword},
+		srcAPIM: dev,
+	}
+
+	validateAPIProductsList(t, args)
+}
+
+func TestListApiProductsAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add a random number (< 10) of API Products (same copy)
+	randomNumber := rand.Intn(10)
+	for apiProductCount := 0; apiProductCount <= randomNumber; apiProductCount++ {
+		// Add the API Product to env1
+		addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &apiProductImportExportTestArgs{
+		ctlUser: credentials{username: tenantAdminUsername, password: tenantAdminPassword},
+		srcAPIM: dev,
+	}
+
+	validateAPIProductsList(t, args)
+}
+
+func TestDeleteApiProductAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add a random number (< 10) of API Products (same copy)
+	randomNumber := rand.Intn(10)
+
+	var apiProduct *apim.APIProduct
+	for apiProductCount := 0; apiProductCount <= randomNumber; apiProductCount++ {
+		// Add the API Product to env1 (Since we are deleting an API Product later, if the auto clean is enabled an error may occur when
+		// trying to delete the already deleted API. So the auto cleaning will be disabled.)
+		apiProduct = addAPIProductFromJSONWithoutCleaning(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &apiProductImportExportTestArgs{
+		ctlUser:    credentials{username: adminUsername, password: adminPassword},
+		apiProduct: apiProduct, // Choose the last API Product from the loop to delete it
+		srcAPIM:    dev,
+	}
+
+	t.Cleanup(func() {
+		apiProductList := getAPIProducts(dev, adminUsername, adminPassword)
+		for _, apiProduct := range apiProductList.List {
+			deleteAPIProduct(t, dev, apiProduct.ID, adminUsername, adminPassword)
+		}
+	})
+
+	validateAPIProductDelete(t, args)
+}
+
+func TestDeleteApiProductAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add a random number (< 10) of API Products (same copy)
+	randomNumber := rand.Intn(10)
+
+	var apiProduct *apim.APIProduct
+	for apiProductCount := 0; apiProductCount <= randomNumber; apiProductCount++ {
+		// Add the API Product to env1 (Since we are deleting an API Product later, if the auto clean is enabled an error may occur when
+		// trying to delete the already deleted API. So the auto cleaning will be disabled.)
+		apiProduct = addAPIProductFromJSONWithoutCleaning(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &apiProductImportExportTestArgs{
+		ctlUser:    credentials{username: tenantAdminUsername, password: tenantAdminPassword},
+		apiProduct: apiProduct, // Choose the last API Product from the loop to delete it
+		srcAPIM:    dev,
+	}
+
+	t.Cleanup(func() {
+		apiProductList := getAPIProducts(dev, tenantAdminUsername, tenantAdminPassword)
+		for _, apiProduct := range apiProductList.List {
+			deleteAPIProduct(t, dev, apiProduct.ID, tenantAdminUsername, tenantAdminPassword)
+		}
+	})
+
+	validateAPIProductDelete(t, args)
+}
+
+func TestDeleteApiProductSuperTenantUser(t *testing.T) {
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add a random number (< 10) of API Products (same copy)
+	randomNumber := rand.Intn(10)
+
+	var apiProduct *apim.APIProduct
+	for apiProductCount := 0; apiProductCount <= randomNumber; apiProductCount++ {
+		apiProduct = addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &apiProductImportExportTestArgs{
+		ctlUser:    credentials{username: apiCreator, password: apiCreatorPassword},
+		apiProduct: apiProduct, // Choose the last API Product from the loop to delete it
+		srcAPIM:    dev,
+	}
+
+	validateAPIProductDeleteFailure(t, args)
+}

--- a/import-export-cli/integration/apim/apiProductDTO.go
+++ b/import-export-cli/integration/apim/apiProductDTO.go
@@ -1,0 +1,57 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apim
+
+// APIProduct : API Product DTO
+type APIProduct struct {
+	ID                           string               `json:"id"`
+	Name                         string               `json:"name"`
+	Description                  string               `json:"description"`
+	Context                      string               `json:"context"`
+	Provider                     string               `json:"provider"`
+	HasThumbnail                 bool                 `json:"hasThumbnail"`
+	State                        string               `json:"state"`
+	EnableSchemaValidation       bool                 `json:"enableSchemaValidation"`
+	ResponseCacheEnabled         bool                 `json:"responseCachingEnabled"`
+	CacheTimeout                 int32                `json:"cacheTimeout"`
+	Visibility                   string               `json:"visibility"`
+	VisibleRoles                 []string             `json:"visibleRoles"`
+	VisibleTenants               []string             `json:"visibleTenants"`
+	AccessControl                string               `json:"accessControl"`
+	AccessControlRoles           []string             `json:"accessControlRoles"`
+	GatewayEnvironments          []string             `json:"gatewayEnvironments"`
+	APIType                      string               `json:"apiType"`
+	Transport                    []string             `json:"transport"`
+	Tags                         []string             `json:"tags"`
+	Policies                     []string             `json:"policies"`
+	APIThrottlingPolicy          string               `json:"apiThrottlingPolicy"`
+	AuthorizationHeader          string               `json:"authorizationHeader"`
+	SecurityScheme               []string             `json:"securityScheme"`
+	SubscriptionAvailability     string               `json:"subscriptionAvailability"`
+	SubscriptionAvailableTenants []string             `json:"subscriptionAvailableTenants"`
+	AdditionalProperties         map[string]string    `json:"additionalProperties"`
+	Monetization                 APIMonetization      `json:"monetization,omitempty"`
+	BusinessInformation          BusinessInfo         `json:"businessInformation,omitempty"`
+	CorsConfiguration            APICorsConfiguration `json:"corsConfiguration,omitempty"`
+	CreatedTime                  string               `json:"createdTime"`
+	LastUpdatedTime              string               `json:"lastUpdatedTime"`
+	APIs                         []interface{}        `json:"apis"`
+	Scopes                       []interface{}        `json:"scopes"`
+	Categories                   []interface{}        `json:"categories"`
+}

--- a/import-export-cli/integration/apim/apiProductListDTO.go
+++ b/import-export-cli/integration/apim/apiProductListDTO.go
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apim
+
+// APIProductList : API Product List DTO
+type APIProductList struct {
+	Count      int              `json:"count"`
+	List       []APIProductInfo `json:"list"`
+	Pagination interface{}      `json:"pagination"`
+}
+
+// APIProductInfo : API Product Info DTO
+type APIProductInfo struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Context        string   `json:"context"`
+	Provider       string   `json:"provider"`
+	State          string   `json:"state"`
+	HasThumbnail   bool     `json:"hasThumbnail"`
+	SecurityScheme []string `json:"securityScheme"`
+}

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -74,7 +74,7 @@ func SetupEnv(t *testing.T, env string, apim string, tokenEp string) {
 	Execute(t, "add-env", "-e", env, "--apim", apim, "--token", tokenEp)
 
 	t.Cleanup(func() {
-		Execute(t, "remove-env", "-e", env)
+		Execute(t, "remove", "env", env)
 	})
 }
 

--- a/import-export-cli/integration/base/httpClient.go
+++ b/import-export-cli/integration/base/httpClient.go
@@ -83,6 +83,12 @@ func SetDefaultRestAPIHeaders(token string, request *http.Request) {
 	request.Header.Set("Content-Type", "application/json")
 }
 
+// SetDefaultRestAPIHeadersToConsumeFormData : Set HTTP headers required for APIM REST calls to consume form data
+func SetDefaultRestAPIHeadersToConsumeFormData(token string, request *http.Request) {
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "multipart/form-data")
+}
+
 // SetTokenAPIHeaders : Set HTTP headers for token API invocation
 func SetTokenAPIHeaders(clientID string, clientSecret string, request *http.Request) {
 	authHeader := clientID + ":" + clientSecret

--- a/import-export-cli/integration/getkeys_test.go
+++ b/import-export-cli/integration/getkeys_test.go
@@ -20,6 +20,8 @@ package integration
 
 import (
 	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 )
 
 func TestGetKeysNonAdminSuperTenantUser(t *testing.T) {
@@ -164,4 +166,150 @@ func TestGetKeysNonPublishedAPI(t *testing.T) {
 	}
 
 	validateGetKeysFailure(t, args)
+}
+
+func TestGetKeysForAPIProductNonAdminSuperTenantUser(t *testing.T) {
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiGetKeyTestArgs{
+		ctlUser:    credentials{username: apiPublisher, password: apiPublisherPassword},
+		apiProduct: apiProduct,
+		apim:       dev,
+	}
+
+	validateGetKeysFailure(t, args)
+}
+
+func TestGetKeysForAPIProductNonAdminTenantUser(t *testing.T) {
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiGetKeyTestArgs{
+		ctlUser:    credentials{username: apiPublisher, password: apiPublisherPassword},
+		apiProduct: apiProduct,
+		apim:       dev,
+	}
+
+	validateGetKeysFailure(t, args)
+}
+
+func TestGetKeysForAPIProductAdminSuperTenantUser(t *testing.T) {
+	adminUser := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiGetKeyTestArgs{
+		ctlUser:    credentials{username: adminUser, password: adminPassword},
+		apiProduct: apiProduct,
+		apim:       dev,
+	}
+
+	validateGetKeys(t, args)
+}
+
+func TestGetKeysForAPIProductAdminTenantUser(t *testing.T) {
+	adminUser := superAdminUser + "@" + TENANT1
+	adminPassword := superAdminPassword
+
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := addAPI(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := addAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	publishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	// Add the API Product to env1
+	apiProduct := addAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	args := &apiGetKeyTestArgs{
+		ctlUser:    credentials{username: adminUser, password: adminPassword},
+		apiProduct: apiProduct,
+		apim:       dev,
+	}
+
+	validateGetKeys(t, args)
 }

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -263,13 +263,13 @@ func deleteApiProducts() {
 	publishers := Users["publisher"]
 	for _, publisher := range publishers {
 		for _, client := range apimClients {
-			client.Login(creator.UserName, publisher.Password)
+			client.Login(publisher.UserName, publisher.Password)
 			client.DeleteAllAPIProducts()
 		}
 
 		for _, tenant := range tenants {
 			for _, client := range apimClients {
-				client.Login(creator.UserName+"@"+tenant.Domain, publisher.Password)
+				client.Login(publisher.UserName+"@"+tenant.Domain, publisher.Password)
 				client.DeleteAllAPIProducts()
 			}
 		}

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -140,6 +140,7 @@ func addUsersAndTenants() {
 
 func cleanupAPIM() {
 	deleteApps()
+	deleteApiProducts()
 	deleteApis()
 }
 
@@ -254,6 +255,35 @@ func deleteApis() {
 		for _, client := range apimClients {
 			client.Login(tenant.AdminUserName+"@"+tenant.Domain, tenant.AdminPassword)
 			client.DeleteAllAPIs()
+		}
+	}
+}
+
+func deleteApiProducts() {
+	publishers := Users["publisher"]
+	for _, publisher := range publishers {
+		for _, client := range apimClients {
+			client.Login(creator.UserName, publisher.Password)
+			client.DeleteAllAPIProducts()
+		}
+
+		for _, tenant := range tenants {
+			for _, client := range apimClients {
+				client.Login(creator.UserName+"@"+tenant.Domain, publisher.Password)
+				client.DeleteAllAPIProducts()
+			}
+		}
+	}
+
+	for _, client := range apimClients {
+		client.Login(superAdminUser, superAdminPassword)
+		client.DeleteAllAPIProducts()
+	}
+
+	for _, tenant := range tenants {
+		for _, client := range apimClients {
+			client.Login(tenant.AdminUserName+"@"+tenant.Domain, tenant.AdminPassword)
+			client.DeleteAllAPIProducts()
 		}
 	}
 }

--- a/import-export-cli/integration/testTypes.go
+++ b/import-export-cli/integration/testTypes.go
@@ -33,6 +33,17 @@ type apiImportExportTestArgs struct {
 	destAPIM    *apim.Client
 }
 
+type apiProductImportExportTestArgs struct {
+	apiProductProvider   credentials
+	ctlUser              credentials
+	apiProduct           *apim.APIProduct
+	srcAPIM              *apim.Client
+	destAPIM             *apim.Client
+	importApisFlag       bool
+	updateApisFlag       bool
+	updateApiProductFlag bool
+}
+
 type appImportExportTestArgs struct {
 	appOwner    credentials
 	ctlUser     credentials
@@ -42,7 +53,8 @@ type appImportExportTestArgs struct {
 }
 
 type apiGetKeyTestArgs struct {
-	ctlUser credentials
-	api     *apim.API
-	apim    *apim.Client
+	ctlUser    credentials
+	api        *apim.API
+	apiProduct *apim.APIProduct
+	apim       *apim.Client
 }

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -356,7 +356,7 @@ func importAPIProductPreserveProvider(t *testing.T, args *apiProductImportExport
 	return output, err
 }
 
-func importAPIProductPreserveProviderWithoutCleaning(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+func importUpdateAPIProductPreserveProvider(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
 	var output string
 	var err error
 
@@ -394,7 +394,7 @@ func importAPIProduct(t *testing.T, args *apiProductImportExportTestArgs) (strin
 	return output, err
 }
 
-func importAPIProductWithoutCleaning(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+func importUpdateAPIProduct(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
 	var output string
 	var err error
 
@@ -597,7 +597,7 @@ func validateAPIProductExportImportPreserveProvider(t *testing.T, args *apiProdu
 	validateAPIProductsEqual(t, args.apiProduct, importedAPIProduct)
 }
 
-func validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t *testing.T, args *apiProductImportExportTestArgs) {
+func validateAPIProductImportUpdatePreserveProvider(t *testing.T, args *apiProductImportExportTestArgs) {
 	t.Helper()
 
 	// Setup apictl envs
@@ -606,9 +606,9 @@ func validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t
 	// Import api to env 2
 	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	// This is used when you have previously imported an API Product and validated it.
-	// So when the cleaning you do not need to clean twice. For that, importAPIProductWithoutCleaning will not do cleaning again.
-	importAPIProductPreserveProviderWithoutCleaning(t, args)
+	// This is used when you have previously imported an API Product (with preserving the provider) and validated it.
+	// So when doing the cleaning you do not need to clean twice. For that, importUpdateAPIProductPreserveProvider will not be doing cleaning again.
+	importUpdateAPIProductPreserveProvider(t, args)
 
 	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
 	time.Sleep(1 * time.Second)
@@ -656,7 +656,7 @@ func validateAPIProductImport(t *testing.T, args *apiProductImportExportTestArgs
 	validateAPIProductsEqualCrossTenant(t, args.apiProduct, importedAPIProduct)
 }
 
-func validateAPIProductImportWithoutCleaningImportedApiProduct(t *testing.T, args *apiProductImportExportTestArgs) {
+func validateAPIProductImportUpdate(t *testing.T, args *apiProductImportExportTestArgs) {
 	t.Helper()
 
 	// Setup apictl envs
@@ -665,7 +665,9 @@ func validateAPIProductImportWithoutCleaningImportedApiProduct(t *testing.T, arg
 	// Import API Product to env 2
 	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	importAPIProductWithoutCleaning(t, args)
+	// This is used when you have previously imported an API Product and validated it.
+	// So when doing the cleaning you do not need to clean twice. For that, importUpdateAPIProduct will not be doing cleaning again.
+	importUpdateAPIProduct(t, args)
 
 	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
 	time.Sleep(1 * time.Second)

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -20,12 +20,16 @@ package integration
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"log"
 	"net/http"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
@@ -58,6 +62,27 @@ func invokeAPI(t *testing.T, url string, key string, expectedCode int) {
 	assert.Equal(t, expectedCode, response.StatusCode, "API Invocation failed")
 }
 
+func invokeAPIProduct(t *testing.T, url string, key string, expectedCode int) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequest("GET", url, nil)
+
+	assert.Nil(t, err, "Error while generating GET")
+
+	authHeader := "Bearer " + key
+	req.Header.Set("Authorization", authHeader)
+
+	t.Log("invokeAPIProduct() url", url)
+
+	response, err := client.Do(req)
+
+	assert.Nil(t, err, "Error while invoking API Product")
+	assert.Equal(t, expectedCode, response.StatusCode, "API Product Invocation failed")
+}
+
 func addAPI(t *testing.T, client *apim.Client, username string, password string) *apim.API {
 	client.Login(username, password)
 	api := client.GenerateSampleAPIData(username)
@@ -66,10 +91,92 @@ func addAPI(t *testing.T, client *apim.Client, username string, password string)
 	return api
 }
 
+func addAPIToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
+	client1.Login(username, password)
+	api := client1.GenerateSampleAPIData(username)
+	id1 := client1.AddAPI(t, api, username, password)
+	api1 := client1.GetAPI(id1)
+
+	client2.Login(username, password)
+	id2 := client2.AddAPI(t, api, username, password)
+	api2 := client2.GetAPI(id2)
+
+	return api1, api2
+}
+
+func addAPIFromOpenAPIDefinition(t *testing.T, client *apim.Client, username string, password string) *apim.API {
+	path := "testdata/petstore.yaml"
+	client.Login(username, password)
+	additionalProperties := client.GenerateAdditionalProperties(username)
+	id := client.AddAPIFromOpenAPIDefinition(t, path, additionalProperties, username, password)
+	api := client.GetAPI(id)
+	return api
+}
+
+func addAPIFromOpenAPIDefinitionToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
+	path := "testdata/petstore.yaml"
+	client1.Login(username, password)
+	additionalProperties := client1.GenerateAdditionalProperties(username)
+	id1 := client1.AddAPIFromOpenAPIDefinition(t, path, additionalProperties, username, password)
+	api1 := client1.GetAPI(id1)
+
+	client2.Login(username, password)
+	id2 := client2.AddAPIFromOpenAPIDefinition(t, path, additionalProperties, username, password)
+	api2 := client2.GetAPI(id2)
+
+	return api1, api2
+}
+
+func addAPIProductFromJSON(t *testing.T, client *apim.Client, username string, password string, apisList map[string]*apim.API) *apim.APIProduct {
+	client.Login(username, password)
+	path := "testdata/SampleAPIProduct.json"
+	doClean := true
+	id := client.AddAPIProductFromJSON(t, path, username, password, apisList, doClean)
+	apiProduct := client.GetAPIProduct(id)
+	return apiProduct
+}
+
+func addAPIProductFromJSONWithoutCleaning(t *testing.T, client *apim.Client, username string, password string, apisList map[string]*apim.API) *apim.APIProduct {
+	client.Login(username, password)
+	path := "testdata/SampleAPIProduct.json"
+	doClean := false
+	id := client.AddAPIProductFromJSON(t, path, username, password, apisList, doClean)
+	apiProduct := client.GetAPIProduct(id)
+	return apiProduct
+}
+
 func getAPI(t *testing.T, client *apim.Client, name string, username string, password string) *apim.API {
 	client.Login(username, password)
 	apiInfo := client.GetAPIByName(name)
 	return client.GetAPI(apiInfo.ID)
+}
+
+func getAPIs(client *apim.Client, username string, password string) *apim.APIList {
+	client.Login(username, password)
+	return client.GetAPIs()
+}
+
+func deleteAPI(t *testing.T, client *apim.Client, apiID string, username string, password string) {
+	time.Sleep(2000 * time.Millisecond)
+	client.Login(username, password)
+	client.DeleteAPI(apiID)
+}
+
+func getAPIProduct(t *testing.T, client *apim.Client, name string, username string, password string) *apim.APIProduct {
+	client.Login(username, password)
+	apiProductInfo := client.GetAPIProductByName(name)
+	return client.GetAPIProduct(apiProductInfo.ID)
+}
+
+func getAPIProducts(client *apim.Client, username string, password string) *apim.APIProductList {
+	client.Login(username, password)
+	return client.GetAPIProducts()
+}
+
+func deleteAPIProduct(t *testing.T, client *apim.Client, apiProductID string, username string, password string) {
+	time.Sleep(2000 * time.Millisecond)
+	client.Login(username, password)
+	client.DeleteAPIProduct(apiProductID)
 }
 
 func publishAPI(client *apim.Client, username string, password string, apiID string) {
@@ -88,13 +195,26 @@ func getResourceURL(apim *apim.Client, api *apim.API) string {
 	return "http://" + apim.GetHost() + ":" + strconv.Itoa(port) + api.Context + "/" + api.Version + "/menu"
 }
 
+func getResourceURLForAPIProduct(apim *apim.Client, apiProduct *apim.APIProduct) string {
+	port := 8280 + apim.GetPortOffset()
+	return "http://" + apim.GetHost() + ":" + strconv.Itoa(port) + apiProduct.Context + "/menu"
+}
+
 func validateGetKeysFailure(t *testing.T, args *apiGetKeyTestArgs) {
 	t.Helper()
 
 	base.SetupEnv(t, args.apim.GetEnvName(), args.apim.GetApimURL(), args.apim.GetTokenURL())
 	base.Login(t, args.apim.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	result, err := getKeys(t, args.api.Provider, args.api.Name, args.api.Version, args.apim.GetEnvName())
+	var err error
+	var result string
+	if args.api != nil {
+		result, err = getKeys(t, args.api.Provider, args.api.Name, args.api.Version, args.apim.GetEnvName())
+	}
+
+	if args.apiProduct != nil {
+		result, err = getKeys(t, args.apiProduct.Provider, args.apiProduct.Name, utils.DefaultApiProductVersion, args.apim.GetEnvName())
+	}
 
 	assert.NotNil(t, err, "Expected error was not returned")
 	assert.Equal(t, "Exit status 1", base.GetValueOfUniformResponse(result))
@@ -106,16 +226,31 @@ func validateGetKeys(t *testing.T, args *apiGetKeyTestArgs) {
 	base.SetupEnv(t, args.apim.GetEnvName(), args.apim.GetApimURL(), args.apim.GetTokenURL())
 	base.Login(t, args.apim.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	result, err := getKeys(t, args.api.Provider, args.api.Name, args.api.Version, args.apim.GetEnvName())
+	var err error
+	var result string
+	if args.api != nil {
+		result, err = getKeys(t, args.api.Provider, args.api.Name, args.api.Version, args.apim.GetEnvName())
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	if err != nil {
-		log.Fatal(err)
+		assert.Nil(t, err, "Error while getting key")
+
+		invokeAPI(t, getResourceURL(args.apim, args.api), base.GetValueOfUniformResponse(result), 200)
+		unsubscribeAPI(args.apim, args.ctlUser.username, args.ctlUser.password, args.api.ID)
 	}
 
-	assert.Nil(t, err, "Error while getting key")
+	if args.apiProduct != nil {
+		result, err = getKeys(t, args.apiProduct.Provider, args.apiProduct.Name, utils.DefaultApiProductVersion, args.apim.GetEnvName())
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	invokeAPI(t, getResourceURL(args.apim, args.api), base.GetValueOfUniformResponse(result), 200)
-	unsubscribeAPI(args.apim, args.ctlUser.username, args.ctlUser.password, args.api.ID)
+		assert.Nil(t, err, "Error while getting key")
+
+		invokeAPIProduct(t, getResourceURLForAPIProduct(args.apim, args.apiProduct), base.GetValueOfUniformResponse(result), 200)
+		unsubscribeAPI(args.apim, args.ctlUser.username, args.ctlUser.password, args.apiProduct.ID)
+	}
 }
 
 func addApp(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
@@ -142,6 +277,10 @@ func getEnvAppExportPath(envName string) string {
 
 func getEnvAPIExportPath(envName string) string {
 	return filepath.Join(utils.DefaultExportDirPath, utils.ExportedApisDirName, envName)
+}
+
+func getEnvAPIProductExportPath(envName string) string {
+	return filepath.Join(utils.DefaultExportDirPath, utils.ExportedApiProductsDirName, envName)
 }
 
 func exportApp(t *testing.T, name string, owner string, env string) (string, error) {
@@ -175,6 +314,16 @@ func exportAPI(t *testing.T, name string, version string, provider string, env s
 	return output, err
 }
 
+func exportAPIProduct(t *testing.T, name string, version string, env string) (string, error) {
+	output, err := base.Execute(t, "export", "api-product", "-n", name, "-e", env, "-k", "--verbose")
+
+	t.Cleanup(func() {
+		base.RemoveAPIArchive(t, getEnvAPIProductExportPath(env), name, version)
+	})
+
+	return output, err
+}
+
 func importAPIPreserveProvider(t *testing.T, sourceEnv string, api *apim.API, client *apim.Client) (string, error) {
 	fileName := base.GetAPIArchiveFilePath(t, sourceEnv, api.Name, api.Version)
 	output, err := base.Execute(t, "import-api", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
@@ -183,6 +332,92 @@ func importAPIPreserveProvider(t *testing.T, sourceEnv string, api *apim.API, cl
 		client.DeleteAPIByName(api.Name)
 	})
 
+	return output, err
+}
+
+func importAPIProductPreserveProvider(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	var output string
+	var err error
+
+	fileName := base.GetAPIArchiveFilePath(t, args.srcAPIM.GetEnvName(), args.apiProduct.Name, utils.DefaultApiProductVersion)
+
+	if args.importApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--import-apis")
+	} else if args.updateApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-apis")
+	} else {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose")
+	}
+
+	t.Cleanup(func() {
+		args.destAPIM.DeleteAPIProductByName(args.apiProduct.Name)
+	})
+
+	return output, err
+}
+
+func importAPIProductPreserveProviderWithoutCleaning(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	var output string
+	var err error
+
+	fileName := base.GetAPIArchiveFilePath(t, args.srcAPIM.GetEnvName(), args.apiProduct.Name, utils.DefaultApiProductVersion)
+
+	if args.updateApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-apis")
+	} else if args.updateApiProductFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-api-product")
+	} else {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose")
+	}
+
+	return output, err
+}
+
+func importAPIProduct(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	var output string
+	var err error
+
+	fileName := base.GetAPIArchiveFilePath(t, args.srcAPIM.GetEnvName(), args.apiProduct.Name, utils.DefaultApiProductVersion)
+
+	if args.importApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--import-apis", "--preserve-provider=false")
+	} else if args.updateApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-apis", "--preserve-provider=false")
+	} else {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--preserve-provider=false")
+	}
+
+	t.Cleanup(func() {
+		args.destAPIM.DeleteAPIProductByName(args.apiProduct.Name)
+	})
+
+	return output, err
+}
+
+func importAPIProductWithoutCleaning(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	var output string
+	var err error
+
+	fileName := base.GetAPIArchiveFilePath(t, args.srcAPIM.GetEnvName(), args.apiProduct.Name, utils.DefaultApiProductVersion)
+
+	if args.updateApisFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-apis", "--preserve-provider=false")
+	} else if args.updateApiProductFlag {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--update-api-product", "--preserve-provider=false")
+	} else {
+		output, err = base.Execute(t, "import", "api-product", "-f", fileName, "-e", args.destAPIM.EnvName, "-k", "--verbose", "--preserve-provider=false")
+	}
+
+	return output, err
+}
+
+func listAPIProducts(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "list", "api-products", "-e", args.srcAPIM.EnvName, "-k", "--verbose")
+	return output, err
+}
+
+func deleteAPIProductByCtl(t *testing.T, args *apiProductImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "delete", "api-product", "-n", args.apiProduct.Name, "-e", args.srcAPIM.EnvName, "-k", "--verbose")
 	return output, err
 }
 
@@ -314,4 +549,323 @@ func validateAPIsEqual(t *testing.T, api1 *apim.API, api2 *apim.API) {
 
 	assert.Equal(t, api1Copy, api2Copy, "API obejcts are not equal")
 
+}
+
+func validateAPIProductExportFailure(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl env
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+
+	// Attempt exporting API Product from env
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	exportAPIProduct(t, args.apiProduct.Name, utils.DefaultApiProductVersion, args.srcAPIM.GetEnvName())
+
+	// Validate that export failed
+	assert.False(t, base.IsAPIArchiveExists(t, getEnvAPIProductExportPath(args.srcAPIM.GetEnvName()),
+		args.apiProduct.Name, utils.DefaultApiProductVersion))
+}
+
+func validateAPIProductExportImportPreserveProvider(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+	base.SetupEnv(t, args.destAPIM.GetEnvName(), args.destAPIM.GetApimURL(), args.destAPIM.GetTokenURL())
+
+	// Export API Product from env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	exportAPIProduct(t, args.apiProduct.Name, utils.DefaultApiProductVersion, args.srcAPIM.GetEnvName())
+
+	assert.True(t, base.IsAPIArchiveExists(t, getEnvAPIProductExportPath(args.srcAPIM.GetEnvName()),
+		args.apiProduct.Name, utils.DefaultApiProductVersion))
+
+	// Import API Product to env 2
+	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	importAPIProductPreserveProvider(t, args)
+
+	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
+	time.Sleep(1 * time.Second)
+
+	// Get API Product from env 2
+	importedAPIProduct := getAPIProduct(t, args.destAPIM, args.apiProduct.Name, args.apiProductProvider.username, args.apiProductProvider.password)
+
+	// Validate env 1 and env 2 API Products are equal
+	validateAPIProductsEqual(t, args.apiProduct, importedAPIProduct)
+}
+
+func validateAPIProductImportPreserveProviderWithoutCleaningImportedAPIProduct(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.destAPIM.GetEnvName(), args.destAPIM.GetApimURL(), args.destAPIM.GetTokenURL())
+
+	// Import api to env 2
+	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	// This is used when you have previously imported an API Product and validated it.
+	// So when the cleaning you do not need to clean twice. For that, importAPIProductWithoutCleaning will not do cleaning again.
+	importAPIProductPreserveProviderWithoutCleaning(t, args)
+
+	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
+	time.Sleep(1 * time.Second)
+
+	// Get API Product from env 2
+	importedAPIProduct := getAPIProduct(t, args.destAPIM, args.apiProduct.Name, args.apiProductProvider.username, args.apiProductProvider.password)
+
+	// Validate env 1 and env 2 API Products are equal
+	validateAPIProductsEqual(t, args.apiProduct, importedAPIProduct)
+}
+
+func validateAPIProductExport(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+
+	// Export API Product from env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	exportAPIProduct(t, args.apiProduct.Name, utils.DefaultApiProductVersion, args.srcAPIM.GetEnvName())
+
+	assert.True(t, base.IsAPIArchiveExists(t, getEnvAPIProductExportPath(args.srcAPIM.GetEnvName()),
+		args.apiProduct.Name, utils.DefaultApiProductVersion))
+}
+
+func validateAPIProductImport(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.destAPIM.GetEnvName(), args.destAPIM.GetApimURL(), args.destAPIM.GetTokenURL())
+
+	// Import API Product to env 2
+	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	importAPIProduct(t, args)
+
+	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
+	time.Sleep(1 * time.Second)
+
+	// Get API Product from env 2
+	importedAPIProduct := getAPIProduct(t, args.destAPIM, args.apiProduct.Name, args.apiProductProvider.username, args.apiProductProvider.password)
+
+	// Validate env 1 and env 2 API Products are equal
+	validateAPIProductsEqualCrossTenant(t, args.apiProduct, importedAPIProduct)
+}
+
+func validateAPIProductImportWithoutCleaningImportedApiProduct(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.destAPIM.GetEnvName(), args.destAPIM.GetApimURL(), args.destAPIM.GetTokenURL())
+
+	// Import API Product to env 2
+	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	importAPIProductWithoutCleaning(t, args)
+
+	// Give time for newly imported API Product to get indexed, or else getAPIProduct by name will fail
+	time.Sleep(1 * time.Second)
+
+	// Get API Product from env 2
+	importedAPIProduct := getAPIProduct(t, args.destAPIM, args.apiProduct.Name, args.apiProductProvider.username, args.apiProductProvider.password)
+
+	// Validate env 1 and env 2 API Products are equal
+	validateAPIProductsEqualCrossTenant(t, args.apiProduct, importedAPIProduct)
+}
+
+func validateAPIProductsEqual(t *testing.T, apiProduct1 *apim.APIProduct, apiProduct2 *apim.APIProduct) {
+	t.Helper()
+
+	apiProduct1Copy := apim.CopyAPIProduct(apiProduct1)
+	apiProduct2Copy := apim.CopyAPIProduct(apiProduct2)
+
+	same := "override_with_same_value"
+	// Since the API Products are from too different envs, their respective ID will defer.
+	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	apiProduct1Copy.ID = same
+	apiProduct2Copy.ID = same
+
+	apiProduct1Copy.CreatedTime = same
+	apiProduct2Copy.CreatedTime = same
+
+	apiProduct1Copy.LastUpdatedTime = same
+	apiProduct2Copy.LastUpdatedTime = same
+
+	// Check the validity of the operations in the APIs array of the two API Products
+	err := validateOperations(&apiProduct1Copy, &apiProduct2Copy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sort member collections to make equality check possible
+	apim.SortAPIProductMembers(&apiProduct1Copy)
+	apim.SortAPIProductMembers(&apiProduct2Copy)
+
+	assert.Equal(t, apiProduct1Copy, apiProduct2Copy, "API Product obejcts are not equal")
+}
+
+func validateAPIProductsEqualCrossTenant(t *testing.T, apiProduct1 *apim.APIProduct, apiProduct2 *apim.APIProduct) {
+	t.Helper()
+
+	apiProduct1Copy := apim.CopyAPIProduct(apiProduct1)
+	apiProduct2Copy := apim.CopyAPIProduct(apiProduct2)
+
+	same := "override_with_same_value"
+	// Since the API Products are from too different envs, their respective ID will defer.
+	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	apiProduct1Copy.ID = same
+	apiProduct2Copy.ID = same
+
+	apiProduct1Copy.CreatedTime = same
+	apiProduct2Copy.CreatedTime = same
+
+	apiProduct1Copy.LastUpdatedTime = same
+	apiProduct2Copy.LastUpdatedTime = same
+
+	// The contexts and providers will differ since this is a cross tenant import
+	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	apiProduct1Copy.Context = same
+	apiProduct2Copy.Context = same
+
+	apiProduct1Copy.Provider = same
+	apiProduct2Copy.Provider = same
+
+	// Check the validity of the operations in the APIs array of the two API Products
+	err := validateOperations(&apiProduct1Copy, &apiProduct2Copy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sort member collections to make equality check possible
+	apim.SortAPIProductMembers(&apiProduct1Copy)
+	apim.SortAPIProductMembers(&apiProduct2Copy)
+
+	assert.Equal(t, apiProduct1Copy, apiProduct2Copy, "API Product obejcts are not equal")
+}
+
+func validateOperations(apiProduct1Copy, apiProduct2Copy *apim.APIProduct) error {
+
+	// To store the validity of each dependent API operation
+	var isOperationsValid []bool
+
+	// Iterate thorugh the APIs array of API Product 1
+	for index, apiInProduct1 := range apiProduct1Copy.APIs {
+		// Iterate thorugh the APIs array of API Product 2
+		for _, apiInProduct2 := range apiProduct2Copy.APIs {
+			// If the name of the APIs in the two API Products are same, those should be compared
+			if apiInProduct1.(map[string]interface{})["name"] == apiInProduct2.(map[string]interface{})["name"] {
+
+				// Convert the maps to APIOperations array structs (so that the structs can be compared easily)
+				var operationsList []apim.APIOperations
+				operationsInApiInProduct1, _ := json.Marshal(apiInProduct1.(map[string]interface{})["operations"])
+				err := json.Unmarshal(operationsInApiInProduct1, &operationsList)
+				if err != nil {
+					return err
+				}
+				operationsInApiInProduct2, _ := json.Marshal(apiInProduct2.(map[string]interface{})["operations"])
+				err = json.Unmarshal(operationsInApiInProduct2, &operationsList)
+				if err != nil {
+					return err
+				}
+
+				// Compare the two APIOperations array structs, whether they are equal
+				if cmp.Equal(operationsInApiInProduct1, operationsInApiInProduct2) {
+					// If the operations are equal, it is valid
+					isOperationsValid = append(isOperationsValid, true)
+
+					// Since the apiIds of the dependent APIs in the environments differ, those will be assigned integer values (index value in the loop)
+					// Same APIs in both apiInProduct2 and apiInProduct2 will be assigned same integer values based on the order they are in APIs array
+					apiInProduct2.(map[string]interface{})["apiId"] = index
+					apiInProduct1.(map[string]interface{})["apiId"] = index
+					break
+				}
+				// If the operations are not equal, it is not valid
+				isOperationsValid = append(isOperationsValid, false)
+			}
+		}
+	}
+
+	// To store the overall result of whether the operations are valid.
+	isAllOperationsValid := true
+	for _, value := range isOperationsValid {
+		// If any of the value in isOperationsValid array is false, the overall result should be false
+		if value == false {
+			isAllOperationsValid = false
+		}
+	}
+
+	if isAllOperationsValid {
+		// If all the operations in both of the APIs arrays are equal, make those two APIs arrays equals
+		apiProduct2Copy.APIs = apiProduct1Copy.APIs
+	}
+	return nil
+}
+
+func validateAPIProductsList(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+
+	// List API Products of env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	output, _ := listAPIProducts(t, args)
+
+	apiProductsList := args.srcAPIM.GetAPIProducts()
+
+	validateListAPIProductsEqual(t, output, apiProductsList)
+}
+
+func validateListAPIProductsEqual(t *testing.T, apiProductsListFromCtl string, apiProductsList *apim.APIProductList) {
+
+	for _, apiProduct := range apiProductsList.List {
+		// If the output string contains the same API Product ID, then decrement the count
+		if strings.Contains(apiProductsListFromCtl, apiProduct.ID) {
+			apiProductsList.Count = apiProductsList.Count - 1
+		}
+	}
+
+	// Count == 0 means that all the API Products from apiProductsList were in apiProductsListFromCtl
+	assert.Equal(t, apiProductsList.Count, 0, "API Product lists are not equal")
+}
+
+func validateAPIProductDelete(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+
+	// Delete an API Product of env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	apiProductsListBeforeDelete := args.srcAPIM.GetAPIProducts()
+
+	deleteAPIProductByCtl(t, args)
+
+	apiProductsListAfterDelete := args.srcAPIM.GetAPIProducts()
+
+	assert.Equal(t, apiProductsListBeforeDelete.Count, apiProductsListAfterDelete.Count+1, "API Product delete is not successful")
+}
+
+func validateAPIProductDeleteFailure(t *testing.T, args *apiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+
+	// Delete an API Product of env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	apiProductsListBeforeDelete := args.srcAPIM.GetAPIProducts()
+
+	deleteAPIProductByCtl(t, args)
+
+	apiProductsListAfterDelete := args.srcAPIM.GetAPIProducts()
+
+	assert.Equal(t, apiProductsListBeforeDelete.Count, apiProductsListAfterDelete.Count, "API Product delete is successful")
 }

--- a/import-export-cli/integration/testdata/SampleAPIProduct.json
+++ b/import-export-cli/integration/testdata/SampleAPIProduct.json
@@ -1,0 +1,162 @@
+{
+   "id": "e62c19bf-51b8-4767-b8b8-690085241f26",
+   "name": "SampleAPIProduct",
+   "context": "/sampleapiproduct",
+   "description": null,
+   "provider": "admin",
+   "hasThumbnail": null,
+   "state": "PUBLISHED",
+   "enableSchemaValidation": false,
+   "responseCachingEnabled": false,
+   "cacheTimeout": 300,
+   "visibility": "PUBLIC",
+   "visibleRoles": [],
+   "visibleTenants": [],
+   "accessControl": "NONE",
+   "accessControlRoles": [],
+   "gatewayEnvironments": [
+     "Production and Sandbox"
+   ],
+   "apiType": "APIProduct",
+   "transport": [
+     "http",
+     "https"
+   ],
+   "tags": [],
+   "policies": [
+     "Bronze",
+     "Gold"
+   ],
+   "apiThrottlingPolicy": null,
+   "authorizationHeader": "Authorization",
+   "securityScheme": [
+     "oauth2",
+     "oauth_basic_auth_api_key_mandatory"
+   ],
+   "subscriptionAvailability": "ALL_TENANTS",
+   "subscriptionAvailableTenants": [],
+   "additionalProperties": {},
+   "monetization": null,
+   "businessInformation": {
+     "businessOwner": null,
+     "businessOwnerEmail": null,
+     "technicalOwner": null,
+     "technicalOwnerEmail": null
+   },
+   "corsConfiguration": {
+     "corsConfigurationEnabled": false,
+     "accessControlAllowOrigins": [
+       "*"
+     ],
+     "accessControlAllowCredentials": false,
+     "accessControlAllowHeaders": [
+       "authorization",
+       "Access-Control-Allow-Origin",
+       "Content-Type",
+       "SOAPAction",
+       "apikey"
+     ],
+     "accessControlAllowMethods": [
+       "GET",
+       "PUT",
+       "POST",
+       "DELETE",
+       "PATCH",
+       "OPTIONS"
+     ]
+   },
+   "createdTime": "2020-05-23 20:06:33.931",
+   "lastUpdatedTime": "2020-05-23 20:06:34.097",
+   "apis": [
+     {
+       "name": "PizzaShackAPI",
+       "apiId": "4df14bdd-5934-47ab-9afe-4704d5a1cb2b",
+       "operations": [
+         {
+           "id": "",
+           "target": "/menu",
+           "verb": "GET",
+           "authType": "Application & Application User",
+           "throttlingPolicy": "Unlimited",
+           "scopes": [],
+           "usedProductIds": [],
+           "amznResourceName": null,
+           "amznResourceTimeout": null
+         },
+         {
+           "id": "",
+           "target": "/order/{orderId}",
+           "verb": "PUT",
+           "authType": "Application & Application User",
+           "throttlingPolicy": "Unlimited",
+           "scopes": [],
+           "usedProductIds": [],
+           "amznResourceName": null,
+           "amznResourceTimeout": null
+         }
+       ]
+     },
+     {
+       "name": "SwaggerPetstore",
+       "apiId": "a2479626-453b-4204-b502-9b372a3ef29f",
+       "operations": [
+         {
+           "id": "",
+           "target": "/pet/{petId}/uploadImage",
+           "verb": "POST",
+           "authType": "Application & Application User",
+           "throttlingPolicy": "Unlimited",
+           "scopes": [],
+           "usedProductIds": [],
+           "amznResourceName": null,
+           "amznResourceTimeout": null
+         },
+         {
+           "id": "",
+           "target": "/pet/findByStatus",
+           "verb": "GET",
+           "authType": "Application & Application User",
+           "throttlingPolicy": "Unlimited",
+           "scopes": [],
+           "usedProductIds": [],
+           "amznResourceName": null,
+           "amznResourceTimeout": null
+         },
+         {
+           "id": "",
+           "target": "/pet/findByTags",
+           "verb": "GET",
+           "authType": "Application & Application User",
+           "throttlingPolicy": "Unlimited",
+           "scopes": [],
+           "usedProductIds": [],
+           "amznResourceName": null,
+           "amznResourceTimeout": null
+         }
+       ]
+     }
+   ],
+   "scopes": [
+     {
+       "scope": {
+         "id": null,
+         "name": "read:pets",
+         "displayName": "read:pets",
+         "description": "read your pets",
+         "bindings": []
+       },
+       "shared": false
+     },
+     {
+       "scope": {
+         "id": null,
+         "name": "write:pets",
+         "displayName": "write:pets",
+         "description": "modify pets in your account",
+         "bindings": []
+       },
+       "shared": false
+     }
+   ],
+   "categories": []
+ }

--- a/import-export-cli/integration/testdata/petstore.yaml
+++ b/import-export-cli/integration/testdata/petstore.yaml
@@ -1,0 +1,716 @@
+swagger: "2.0"
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.5
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /v2
+tags:
+- name: pet
+  description: Everything about your Pets
+  externalDocs:
+    description: Find out more
+    url: http://swagger.io
+- name: store
+  description: Access to Petstore orders
+- name: user
+  description: Operations about user
+  externalDocs:
+    description: Find out more about our store
+    url: http://swagger.io
+schemes:
+- https
+- http
+paths:
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+      - pet
+      summary: uploads an image
+      description: ""
+      operationId: uploadFile
+      consumes:
+      - multipart/form-data
+      produces:
+      - application/json
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to update
+        required: true
+        type: integer
+        format: int64
+      - name: additionalMetadata
+        in: formData
+        description: Additional data to pass to server
+        required: false
+        type: string
+      - name: file
+        in: formData
+        description: file to upload
+        required: false
+        type: file
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: '#/definitions/ApiResponse'
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  /pet:
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: Pet object that needs to be added to the store
+        required: true
+        schema:
+          $ref: '#/definitions/Pet'
+      responses:
+        "405":
+          description: Invalid input
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      consumes:
+      - application/json
+      - application/xml
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: Pet object that needs to be added to the store
+        required: true
+        schema:
+          $ref: '#/definitions/Pet'
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "405":
+          description: Validation exception
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  /pet/findByStatus:
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: true
+        type: array
+        items:
+          type: string
+          enum:
+          - available
+          - pending
+          - sold
+          default: available
+        collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        "400":
+          description: Invalid status value
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by tags
+      description: Multiple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: true
+        type: array
+        items:
+          type: string
+        collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Pet'
+        "400":
+          description: Invalid tag value
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+      deprecated: true
+  /pet/{petId}:
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        type: integer
+        format: int64
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Pet'
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+      - api_key: []
+    post:
+      tags:
+      - pet
+      summary: Updates a pet in the store with form data
+      description: ""
+      operationId: updatePetWithForm
+      consumes:
+      - application/x-www-form-urlencoded
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet that needs to be updated
+        required: true
+        type: integer
+        format: int64
+      - name: name
+        in: formData
+        description: Updated name of the pet
+        required: false
+        type: string
+      - name: status
+        in: formData
+        description: Updated status of the pet
+        required: false
+        type: string
+      responses:
+        "405":
+          description: Invalid input
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    delete:
+      tags:
+      - pet
+      summary: Deletes a pet
+      description: ""
+      operationId: deletePet
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: api_key
+        in: header
+        required: false
+        type: string
+      - name: petId
+        in: path
+        description: Pet id to delete
+        required: true
+        type: integer
+        format: int64
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  /store/order:
+    post:
+      tags:
+      - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: order placed for purchasing the pet
+        required: true
+        schema:
+          $ref: '#/definitions/Order'
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Order'
+        "400":
+          description: Invalid Order
+  /store/order/{orderId}:
+    get:
+      tags:
+      - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other
+        values will generated exceptions
+      operationId: getOrderById
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of pet that needs to be fetched
+        required: true
+        type: integer
+        maximum: 10
+        minimum: 1
+        format: int64
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: '#/definitions/Order'
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+    delete:
+      tags:
+      - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value.
+        Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of the order that needs to be deleted
+        required: true
+        type: integer
+        minimum: 1
+        format: int64
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Order not found
+  /store/inventory:
+    get:
+      tags:
+      - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+      security:
+      - api_key: []
+  /user/createWithArray:
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithArrayInput
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: List of user object
+        required: true
+        schema:
+          type: array
+          items:
+            $ref: '#/definitions/User'
+      responses:
+        default:
+          description: successful operation
+  /user/createWithList:
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: ""
+      operationId: createUsersWithListInput
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: List of user object
+        required: true
+        schema:
+          type: array
+          items:
+            $ref: '#/definitions/User'
+      responses:
+        default:
+          description: successful operation
+  /user/{username}:
+    get:
+      tags:
+      - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: username
+        in: path
+        description: 'The name that needs to be fetched. Use user1 for testing. '
+        required: true
+        type: string
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            $ref: '#/definitions/User'
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+    put:
+      tags:
+      - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: username
+        in: path
+        description: name that need to be updated
+        required: true
+        type: string
+      - in: body
+        name: body
+        description: Updated user object
+        required: true
+        schema:
+          $ref: '#/definitions/User'
+      responses:
+        "400":
+          description: Invalid user supplied
+        "404":
+          description: User not found
+    delete:
+      tags:
+      - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: username
+        in: path
+        description: The name that needs to be deleted
+        required: true
+        type: string
+      responses:
+        "400":
+          description: Invalid username supplied
+        "404":
+          description: User not found
+  /user/login:
+    get:
+      tags:
+      - user
+      summary: Logs user into the system
+      description: ""
+      operationId: loginUser
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - name: username
+        in: query
+        description: The user name for login
+        required: true
+        type: string
+      - name: password
+        in: query
+        description: The password for login in clear text
+        required: true
+        type: string
+      responses:
+        "200":
+          description: successful operation
+          headers:
+            X-Expires-After:
+              type: string
+              format: date-time
+              description: date in UTC when token expires
+            X-Rate-Limit:
+              type: integer
+              format: int32
+              description: calls per hour allowed by the user
+          schema:
+            type: string
+        "400":
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+      - user
+      summary: Logs out current logged in user session
+      description: ""
+      operationId: logoutUser
+      produces:
+      - application/json
+      - application/xml
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  /user:
+    post:
+      tags:
+      - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      - application/xml
+      parameters:
+      - in: body
+        name: body
+        description: Created user object
+        required: true
+        schema:
+          $ref: '#/definitions/User'
+      responses:
+        default:
+          description: successful operation
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: https://petstore.swagger.io/oauth/authorize
+    flow: implicit
+    scopes:
+      read:pets: read your pets
+      write:pets: modify pets in your account
+definitions:
+  ApiResponse:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      type:
+        type: string
+      message:
+        type: string
+  Category:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Category
+  Pet:
+    type: object
+    required:
+    - name
+    - photoUrls
+    properties:
+      id:
+        type: integer
+        format: int64
+      category:
+        $ref: '#/definitions/Category'
+      name:
+        type: string
+        example: doggie
+      photoUrls:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          type: string
+          xml:
+            name: photoUrl
+      tags:
+        type: array
+        xml:
+          wrapped: true
+        items:
+          xml:
+            name: tag
+          $ref: '#/definitions/Tag'
+      status:
+        type: string
+        description: pet status in the store
+        enum:
+        - available
+        - pending
+        - sold
+    xml:
+      name: Pet
+  Tag:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: Tag
+  Order:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      petId:
+        type: integer
+        format: int64
+      quantity:
+        type: integer
+        format: int32
+      shipDate:
+        type: string
+        format: date-time
+      status:
+        type: string
+        description: Order Status
+        enum:
+        - placed
+        - approved
+        - delivered
+      complete:
+        type: boolean
+    xml:
+      name: Order
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      phone:
+        type: string
+      userStatus:
+        type: integer
+        format: int32
+        description: User Status
+    xml:
+      name: User
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io


### PR DESCRIPTION
## Purpose
Adding integration tests to API Products related to use case scenarios from the API Controller.

## Goals
Write integration tests to import/export, list, delete, get-keys for API Products.

## Approach
- Wrote integration tests to import/export API Products by identifying the scenarios from use cases.
- Wrote integration tests to list and delete API Products. (The same approach can be used to write integration tests for listing and deleting APIs and Apps as well)
- Modified existing tests which are written for get-keys functionality, by also writing new tests for get-keys with API Products.

## User stories
- Integration tests for import/export API Products
  - Export an API Product with its dependent APIs from one environment as a super tenant non admin user
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin
  - Export an API Product with its dependent APIs from one environment and import it as super tenant admin when dependent APIs are already in that environment and you do not want to update those APIs
  - Export an API Product with its dependent APIs from one environment and import it as super tenant admin when dependent APIs are already in that environment and you want to update those APIs
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin and try to update that API Product (without updating dependent APIs)
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant admin and try to update that API Product and dependent APIs. (This same command can be used to update only the dependent APIs as well.)
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as cross tenant admin
  - Export an API Product with its dependent APIs from one environment as super tenant admin and import to another environment freshly as cross tenant admin and try to update that API Product (without updating dependent APIs)
  - Export an API Product with its dependent APIs from one environment as super admin and import to another environment freshly as tenant admin and try to update that API Product and dependent APIs (This same command can be used to update only the dependent APIs as well)
- Integration tests for listing API Products
  - List API Products as super tenant admin
  - List API Products as tenant admin
- Integration tests for deleting an API Product
  - Delete an API Product as super tenant admin   
  - Delete an API Product as tenant admin  
  - Delete an API Product as super tenant user
- Integration tests for get-keys with API Products
  - Get keys for API Product as non admin super tenant user
  - Get keys for API Product as non admin tenant user
  - Get keys for API Product as admin super tenant user
  - Get keys for API Product as admin tenant user

## Release note
Integration tests for API Products are added for WSO2 API Controller.

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/306
- https://github.com/wso2/carbon-apimgt/pull/8500

## Test environment
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64