### PR TITLE
[2.x] Handling load balance and fail over endpoints through api_params.yaml file from APIMCLI 2.x.x

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -174,7 +174,7 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		if environmentParams.EndpointsList.EndpointType == "failover" {
 			environmentParams.EndpointsList.Failover = true
 		} else {
-			// If the endpoint type is load_balance make Failover false and
+			// If the endpoint type is load_balance, make Failover false and
 			// make ProductionFailovers and SandboxFailovers nil if the user has mistakenly specify those
 			environmentParams.EndpointsList.Failover = false
 			environmentParams.EndpointsList.ProductionFailovers = nil

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -158,9 +158,9 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		return err
 	}
 
-	if environmentParams.Endpoints != nil && environmentParams.EndpointsList != nil {
-		return errors.New("Both endpoints and endpointsList fields are specified in the api_params.yaml file for " +
-			environmentParams.Name + ". Please remove one field and continue...")
+	if !isEndpointsFieldsValid(environmentParams.Endpoints, environmentParams.LoadBalanceEndpoints, environmentParams.FailoverEndpoints) {
+		return errors.New("Please specify only one field from endpoints, loadBalanceEndpoints or failOverEndpoints in the api_params.yaml file for " +
+			environmentParams.Name + " and continue...")
 	}
 
 	configData, err := json.Marshal(environmentParams.Endpoints)
@@ -168,21 +168,22 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		return err
 	}
 
-	// If the user wants to have load balancing or failover endpoints, environmentParams.EndpointsList will not be null
-	if environmentParams.EndpointsList != nil {
-		// Check whether the endpoint type is failover
-		if environmentParams.EndpointsList.EndpointType == "failover" {
-			environmentParams.EndpointsList.Failover = true
-		} else {
-			// If the endpoint type is load_balance, make Failover false and
-			// make ProductionFailovers and SandboxFailovers nil if the user has mistakenly specify those
-			environmentParams.EndpointsList.Failover = false
-			environmentParams.EndpointsList.ProductionFailovers = nil
-			environmentParams.EndpointsList.SandboxFailovers = nil
-			// The default class of the algorithm to be used should be set to RoundRobin
-			environmentParams.EndpointsList.AlgorithmClassName = "org.apache.synapse.endpoints.algorithms.RoundRobin"
+	// If the user wants to have load balancing, environmentParams.LoadBalanceEndpoints will not be null
+	if environmentParams.LoadBalanceEndpoints != nil {
+		environmentParams.LoadBalanceEndpoints.EndpointType = "load_balance"
+		// The default class of the algorithm to be used should be set to RoundRobin
+		environmentParams.LoadBalanceEndpoints.AlgorithmClassName = "org.apache.synapse.endpoints.algorithms.RoundRobin"
+		configData, err = json.Marshal(environmentParams.LoadBalanceEndpoints)
+		if err != nil {
+			return err
 		}
-		configData, err = json.Marshal(environmentParams.EndpointsList)
+	}
+
+	// If the user wants to have failover, environmentParams.FailoverEndpoints will not be null
+	if environmentParams.FailoverEndpoints != nil {
+		environmentParams.FailoverEndpoints.EndpointType = "failover"
+		environmentParams.FailoverEndpoints.Failover = true
+		configData, err = json.Marshal(environmentParams.FailoverEndpoints)
 		if err != nil {
 			return err
 		}
@@ -214,6 +215,16 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		return err
 	}
 	return nil
+}
+
+// isEndpointsFieldsValid returns false if either of the two fields: endpoints, loadBalanceEndpoints and failOverEndpoints are defined
+// in api_params.yaml file by the user mistakenly. This will return true , if only one of them is defined.
+func isEndpointsFieldsValid(endpoints *params.EndpointData, loadBalanceEndpoints *params.LoadBalanceEndpointsData, failoverEndpoints *params.FailoverEndpointsData) bool {
+	if endpoints != nil {
+		return loadBalanceEndpoints == nil && failoverEndpoints == nil
+	} else {
+		return (loadBalanceEndpoints != nil && failoverEndpoints == nil) || (loadBalanceEndpoints == nil && failoverEndpoints != nil)
+	}
 }
 
 // resolveImportFilePath resolves the archive/directory for import

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -179,6 +179,8 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 			environmentParams.EndpointsList.Failover = false
 			environmentParams.EndpointsList.ProductionFailovers = nil
 			environmentParams.EndpointsList.SandboxFailovers = nil
+			// The default class of the algorithm to be used should be set to RoundRobin
+			environmentParams.EndpointsList.AlgorithmClassName = "org.apache.synapse.endpoints.algorithms.RoundRobin"
 		}
 		configData, err = json.Marshal(environmentParams.EndpointsList)
 		if err != nil {

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -54,6 +54,8 @@ type EndpointsListData struct {
 	SessionManagement string `yaml:"sessionManagement" json:"sessionManagement,omitempty"`
 	// Session timeout means the number of milliseconds after which the session would time out
 	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
+	// Class name for algorithm to be used if load balancing should be done
+	AlgorithmClassName string `yaml:"algoClassName" json:"algoClassName,omitempty"`
 }
 
 // Cert stores certificate details

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -48,8 +48,12 @@ type EndpointsListData struct {
 	Sandbox []Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
 	// Production failover endpoints list for failover endpoint types
 	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
-	// To enabble failover endpoints
-	Failover bool `yaml:"faiOver" json:"failOver,omitempty"`
+	// To enable failover endpoints
+	Failover bool `yaml:"failOver" json:"failOver,omitempty"`
+	// Session management method from the load balancing group. Values can be "none", "transport" (by default), "soap", "simpleClientSession" (Client ID)
+	SessionManagement string `yaml:"sessionManagement" json:"sessionManagement,omitempty"`
+	// Session timeout means the number of milliseconds after which the session would time out
+	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
 }
 
 // Cert stores certificate details

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -36,26 +36,34 @@ type EndpointData struct {
 	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
 }
 
-// EndpointsListData contains details about endpoints mainly to be used in load balancing (or failover)
-type EndpointsListData struct {
-	// Endpoint type (can be "load_balance" or "failover")
-	EndpointType string `yaml:"endpointType" json:"endpoint_type,omitempty"`
-	// Production endpoints list for load balancing and failover endpoint types
+// LoadBalanceEndpointsData contains details about endpoints mainly to be used in load balancing
+type LoadBalanceEndpointsData struct {
+	EndpointType string `yaml:"endpoint_type" json:"endpoint_type"`
+	// Production endpoints list for load balancing
 	Production []Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
-	// Production failover endpoints list for failover endpoint types
-	ProductionFailovers []Endpoint `yaml:"productionFailovers" json:"production_failovers,omitempty"`
-	// Sandbox endpoints list for load balancing and failover endpoint types
+	// Sandbox endpoints list for load balancing
 	Sandbox []Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
-	// Production failover endpoints list for failover endpoint types
-	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
-	// To enable failover endpoints
-	Failover bool `yaml:"failOver" json:"failOver,omitempty"`
 	// Session management method from the load balancing group. Values can be "none", "transport" (by default), "soap", "simpleClientSession" (Client ID)
 	SessionManagement string `yaml:"sessionManagement" json:"sessionManagement,omitempty"`
 	// Session timeout means the number of milliseconds after which the session would time out
 	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
 	// Class name for algorithm to be used if load balancing should be done
 	AlgorithmClassName string `yaml:"algoClassName" json:"algoClassName,omitempty"`
+}
+
+// FailoverEndpointsData contains details about endpoints mainly to be used in load balancing
+type FailoverEndpointsData struct {
+	EndpointType string `yaml:"endpoint_type" json:"endpoint_type"`
+	// Primary production endpoint for failover
+	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Production failover endpoints list for failover
+	ProductionFailovers []Endpoint `yaml:"productionFailovers" json:"production_failovers,omitempty"`
+	// Primary sandbox endpoint for failover
+	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Production failover endpoints list for failover endpoint types
+	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
+	// To enable failover endpoints
+	Failover bool `yaml:"failOver" json:"failOver,omitempty"`
 }
 
 // Cert stores certificate details
@@ -76,8 +84,10 @@ type Environment struct {
 	Name string `yaml:"name"`
 	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
-	// EndpointsList contain details about endpoints in a configuration for load balancing or failover scenarios
-	EndpointsList *EndpointsListData `yaml:"endpointsList"`
+	// LoadBalanceEndpoints contain details about endpoints in a configuration for load balancing scenarios
+	LoadBalanceEndpoints *LoadBalanceEndpointsData `yaml:"loadBalanceEndpoints"`
+	// FailoverEndpoints contain details about endpoints in a configuration for failover scenarios
+	FailoverEndpoints *FailoverEndpointsData `yaml:"failoverEndpoints"`
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -36,6 +36,22 @@ type EndpointData struct {
 	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
 }
 
+// EndpointsListData contains details about endpoints mainly to be used in load balancing (or failover)
+type EndpointsListData struct {
+	// Endpoint type (can be "load_balance" or "failover")
+	EndpointType string `yaml:"endpointType" json:"endpoint_type,omitempty"`
+	// Production endpoints list for load balancing and failover endpoint types
+	Production []Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Production failover endpoints list for failover endpoint types
+	ProductionFailovers []Endpoint `yaml:"productionFailovers" json:"production_failovers,omitempty"`
+	// Sandbox endpoints list for load balancing and failover endpoint types
+	Sandbox []Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Production failover endpoints list for failover endpoint types
+	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
+	// To enabble failover endpoints
+	Failover bool `yaml:"faiOver" json:"failOver,omitempty"`
+}
+
 // Cert stores certificate details
 type Cert struct {
 	// Host of the certificate
@@ -54,6 +70,8 @@ type Environment struct {
 	Name string `yaml:"name"`
 	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
+	// EndpointsList contain details about endpoints in a configuration for load balancing or failover scenarios
+	EndpointsList *EndpointsListData `yaml:"endpointsList"`
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment
@@ -116,7 +134,6 @@ func ExtractAPIEndpointConfig(b []byte) (string, error) {
 	return apiConfig.EPConfig, err
 }
 
-
 // GetEnv returns the EndpointData associated for key in the ApiParams, if not found returns nil
 func (config ApiParams) GetEnv(key string) *Environment {
 	for index, env := range config.Environments {
@@ -126,4 +143,3 @@ func (config ApiParams) GetEnv(key string) *Environment {
 	}
 	return nil
 }
-


### PR DESCRIPTION
## Purpose
When importing an API using APIMCLI, there is a need to support to mention multiple endpoints in the api_params.yaml file to handle the load balancing and failover scenarios, because publisher portal already supports those.

## Goals
Add optional parameters to api_params.yaml file to handle multiple endpoints if the user needs to have those.

## Approach
Introduced two (2) new fields (which are almost similar to the field “endpoints”) named as **loadBalanceEndpoints** and **failoverEndpoints** that should be used for load balancing or failover scenarios.
<ol>
<li><strong>loadBalanceEndpoints</strong> field contains the following.
<ol>
<li>production: an array which consists the multiple production endpoints</li>
<li>sandbox: an array which consists the multiple sandbox endpoints</li>
<li>sessionManagement: values can be "none", "transport", "soap", "simpleClientSession" and if not specified the default value would be "transport"</li>
<li>sessionTimeout: the number of milliseconds after which the session would time out</li>
</ol>
</li>
<li><strong>failoverEndpoints</strong> field contains the following.
<ol>
<li>production: the primary production endpoint (not an array)</li>
<li>sandbox: the primary sandbox endpoint (not an array)</li>
<li>productionFailovers: an array which consists failover production endpoints</li>
<li>sandboxFailovers: an array which consists failover sandbox endpoints</li>
</ol>
</li>
</ol>

If you do not want load balancing or fail-over to happen, you can specify the **endpoints** field as usual.

## User stories
- **Load balancing scenario** (in production environment)
The user needs to specify the fields as shown in the below example. (Here production and sandbox fields are yaml arrays) Additionally user can specify **sessionManagement** (values can be "none", "transport", "soap", "simpleClientSession" and if not specified the default value would be "transport") and **sessionTimeout** fields. 
 ```
environments:
  - name: dev
    endpoints:
        production:
        sandbox:
  - name: production
    loadBalanceEndpoints:
        production:
            - url: http://localhost:8001
            - url: http://localhost:8002
            - url: http://localhost:8003
        sandbox:
            - url: http://localhost:8004
            - url: http://localhost:8005
        sessionManagement: soap
        sessionTimeOut: 2000
```
After the API is imported to the APIM (2.6.0) the endpoints will be shown as below.
![image](https://user-images.githubusercontent.com/25246848/83121200-a12e1080-a0ef-11ea-9ac0-ab41ba24c448.png)

- **Failover scenario** (in production environment)
The user needs to specify the fields as shown in the below example.  (Here production, productionFailovers, sandbox and sandboxFailovers fields are yaml arrays)
```
environments:
  - name: dev
    endpoints:
        production:
        sandbox:
  - name: production
    failoverEndpoints:
       production:
            url: http://localhost:8001
       productionFailovers:
           - url: http://localhost:8002
           - url: http://localhost:8003
       sandbox:
            url: http://localhost:8004
       sandboxFailovers:
            - url: http://localhost:8005
```
After the API is imported to the APIM (2.6.0) the endpoints will be shown as below.
![image](https://user-images.githubusercontent.com/25246848/83121402-e2bebb80-a0ef-11ea-90d5-b162cec78e42.png)

- If the user does not want to specify multiple endpoints, the user can use the earlier approach (current approach that we are having) by specifying the fields under **endpoints** as shown below.  (Here production and sandbox fields are **not** yaml arrays)
```
environments:
  - name: dev
    endpoints:
      production:
      sandbox:
  - name: production
    endpoints:
      production:
          url: https://test1.wso2.com
      sandbox:
          url: https://test4.wso2.com
```
After the API is imported to the APIM (2.6.0) the endpoints will be shown as below.
![image](https://user-images.githubusercontent.com/25246848/83014292-10e2c380-a03c-11ea-9115-eb708d6fdd63.png)

- If the user try to specify more than one field from **endpoints**, **loadBalanceEndpoints** or **failoverEndpoints** fields at once in api_params.yaml, the user will receive the below error when trying to import the API.
```
apimcli: Error importing API Reason: Please specify only one field from endpoints, loadBalanceEndpoints or failOverEndpoints in the api_params.yaml file for production and continue...
Exit status 1
```

## Release note
Multiple endpoint support from api_params.yaml has been added to WSO2 APIMCLI 2.x.x.

## Documentation
Documentation changes need to be done.

## Test environment
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64