### PR TITLE
Remove kubectl from args for kubectl

### DIFF
--- a/import-export-cli/cmd/delete.go
+++ b/import-export-cli/cmd/delete.go
@@ -49,7 +49,7 @@ var DeleteCmd = &cobra.Command{
 		utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 		if configVars.Config.KubernetesMode {
-			k8sArgs := []string{k8sUtils.Kubectl, k8sUtils.K8sDelete}
+			k8sArgs := []string{k8sUtils.K8sDelete}
 			k8sArgs = append(k8sArgs, args...)
 			executeKubernetes(k8sArgs...)
 		}

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -50,16 +50,16 @@ const deleteAPICmdExamplesKubernetes = "\nKubernetes Mode:\n" + "  " +  utils.Pr
 
 // DeleteAPICmd represents the delete api command
 var DeleteAPICmd = &cobra.Command{
-	Use:   deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
-		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` `  + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
-	Short: deleteAPICmdShortDesc,
-	Long: deleteAPICmdLongDesc,
+	Use: deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
+		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
+	Short:   deleteAPICmdShortDesc,
+	Long:    deleteAPICmdLongDesc,
 	Example: deleteAPICmdExamplesDefault + deleteAPICmdExamplesKubernetes,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 		if configVars.Config.KubernetesMode {
-			k8sArgs := []string{k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.K8sApi}
+			k8sArgs := []string{k8sUtils.K8sDelete, k8sUtils.K8sApi}
 			k8sArgs = append(k8sArgs, args...)
 			executeKubernetes(k8sArgs...)
 		} else {
@@ -73,7 +73,7 @@ var DeleteAPICmd = &cobra.Command{
 }
 
 // executeDeleteAPICmd executes the delete api command
-func executeDeleteAPICmd(credential credentials.Credential)  {
+func executeDeleteAPICmd(credential credentials.Credential) {
 	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, deleteAPIEnvironment)
 	if preCommandErr == nil {
 		deleteAPIEndpoint := utils.GetApiListEndpointOfEnv(deleteAPIEnvironment, utils.MainConfigFilePath)
@@ -82,7 +82,7 @@ func executeDeleteAPICmd(credential credentials.Credential)  {
 			utils.HandleErrorAndExit("Error while deleting API ", err)
 		}
 		// Print info on response
-		utils.Logf(utils.LogPrefixInfo + "ResponseStatus: %v\n", resp.Status())
+		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
 		if resp.StatusCode() == http.StatusOK {
 			// 200 OK
 			fmt.Println(deleteAPIName + " API deleted successfully!")


### PR DESCRIPTION
fix wso2/k8s-api-operator#354

## Purpose
Remove kubectl from args for kubectl