### PR TITLE
Adding support to configure api_params.yaml file for multiple endpoints

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -23,13 +23,14 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
-	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 
 	"github.com/Jeffail/gabs"
 	"github.com/mitchellh/go-homedir"
@@ -279,7 +280,6 @@ func extractArchive(src, dest string) (string, error) {
 	return filepath.Join(dest, strings.Split(filepath.Clean(r), string(os.PathSeparator))[0]), nil
 }
 
-
 func getTempApiDirectory(file string) (string, error) {
 	fileIsDir := false
 	// create a temp directory
@@ -452,7 +452,6 @@ func isEmpty(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
 }
 
-
 // Substitutes environment variables in the project files.
 func replaceEnvVariables(apiFilePath string) error {
 	for _, replacePath := range utils.EnvReplaceFilePaths {
@@ -488,7 +487,7 @@ func init() {
 		"", "Environment from the which the API should be imported")
 	ImportAPICmd.Flags().BoolVar(&importAPICmdPreserveProvider, "preserve-provider", true,
 		"Preserve existing provider of API after importing")
-	ImportAPICmd.Flags().BoolVar(&importAPIUpdate, "update",  false, "Update an "+
+	ImportAPICmd.Flags().BoolVar(&importAPIUpdate, "update", false, "Update an "+
 		"existing API or create a new API")
 	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", DefaultAPIMParamsFileName,
 		"Provide a API Manager params file")

--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	reApiName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
+	reAPIName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
 )
 
 // extractAPIDefinition extracts API information from jsonContent
@@ -72,7 +72,7 @@ func getAPIDefinition(filePath string) (*v2.APIDefinition, []byte, error) {
 
 	var buffer []byte
 	if info.IsDir() {
-		_, content, err := resolveYamlOrJson(path.Join(filePath, "Meta-information", "api"))
+		_, content, err := resolveYamlOrJSON(path.Join(filePath, "Meta-information", "api"))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -93,7 +93,7 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	// read api from Meta-information
 	apiPath := filepath.Join(apiDirectory, "Meta-information", "api")
 	utils.Logln(utils.LogPrefixInfo + "Reading API definition: ")
-	fp, jsonContent, err := resolveYamlOrJson(apiPath)
+	fp, jsonContent, err := resolveYamlOrJSON(apiPath)
 	if err != nil {
 		return err
 	}
@@ -231,10 +231,10 @@ func setupMultipleEndpoints(environmentParams *params.Environment) ([]byte, erro
 			// The default class of the algorithm to be used should be set to RoundRobin
 			environmentParams.LoadBalanceEndpoints.AlgorithmClassName = utils.LoadBalanceAlgorithmClass
 			environmentParams.LoadBalanceEndpoints.EndpointType = utils.LoadBalanceEndpointTypeForJSON
-			for index, _ := range environmentParams.LoadBalanceEndpoints.Production {
+			for index := range environmentParams.LoadBalanceEndpoints.Production {
 				environmentParams.LoadBalanceEndpoints.Production[index].EndpointType = utils.HttpSOAPEndpointTypeForJSON
 			}
-			for index, _ := range environmentParams.LoadBalanceEndpoints.Sandbox {
+			for index := range environmentParams.LoadBalanceEndpoints.Sandbox {
 				environmentParams.LoadBalanceEndpoints.Sandbox[index].EndpointType = utils.HttpSOAPEndpointTypeForJSON
 			}
 			configData, err = json.Marshal(environmentParams.LoadBalanceEndpoints)
@@ -247,10 +247,10 @@ func setupMultipleEndpoints(environmentParams *params.Environment) ([]byte, erro
 			}
 			environmentParams.FailoverEndpoints.Production.EndpointType = utils.HttpSOAPEndpointTypeForJSON
 			environmentParams.FailoverEndpoints.Sandbox.EndpointType = utils.HttpSOAPEndpointTypeForJSON
-			for index, _ := range environmentParams.FailoverEndpoints.ProductionFailovers {
+			for index := range environmentParams.FailoverEndpoints.ProductionFailovers {
 				environmentParams.FailoverEndpoints.ProductionFailovers[index].EndpointType = utils.HttpSOAPEndpointTypeForJSON
 			}
-			for index, _ := range environmentParams.FailoverEndpoints.SandboxFailovers {
+			for index := range environmentParams.FailoverEndpoints.SandboxFailovers {
 				environmentParams.FailoverEndpoints.SandboxFailovers[index].EndpointType = utils.HttpSOAPEndpointTypeForJSON
 			}
 			environmentParams.FailoverEndpoints.EndpointType = utils.FailoverRoutingPolicy
@@ -438,7 +438,7 @@ func resolveAPIParamsPath(importPath, paramPath string) (string, error) {
 	}
 }
 
-func getTempApiDirectory(file string) (string, error) {
+func getTempAPIDirectory(file string) (string, error) {
 	fileIsDir := false
 	// create a temp directory
 	tmpDir, err := ioutil.TempDir("", "apim")
@@ -472,11 +472,11 @@ func getTempApiDirectory(file string) (string, error) {
 	}
 }
 
-// resolveYamlOrJson for a given filepath.
+// resolveYamlOrJSON for a given filepath.
 // first it will look for the yaml file, if not will fallback for json
 // give filename without extension so resolver will resolve for file
 // fn is resolved filename, jsonContent is file as a json object, error if anything wrong happen(or both files does not exists)
-func resolveYamlOrJson(filename string) (string, []byte, error) {
+func resolveYamlOrJSON(filename string) (string, []byte, error) {
 	// lookup for yaml
 	yamlFp := filename + ".yaml"
 	if info, err := os.Stat(yamlFp); err == nil && !info.IsDir() {
@@ -605,9 +605,9 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string) error {
 	return nil
 }
 
-// getApiID returns id of the API by using apiInfo which contains name and version as info
-func getApiID(accessOAuthToken, environment, name, version string) (string, error) {
-	apiQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
+// getAPIID returns id of the API by using apiInfo which contains name and version as info
+func getAPIID(accessOAuthToken, environment, name, version string) (string, error) {
+	apiQuery := fmt.Sprintf("name:%s version:%s", name, version)
 	count, apis, err := GetAPIListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiQuery), "")
 	if err != nil {
 		return "", err
@@ -625,7 +625,7 @@ func isEmpty(s string) bool {
 
 func preProcessAPI(apiDirectory string) error {
 	dirty := false
-	apiPath, jsonData, err := resolveYamlOrJson(filepath.Join(apiDirectory, "Meta-information", "api"))
+	apiPath, jsonData, err := resolveYamlOrJSON(filepath.Join(apiDirectory, "Meta-information", "api"))
 	if err != nil {
 		return err
 	}
@@ -674,14 +674,14 @@ func preProcessAPI(apiDirectory string) error {
 	}
 
 	if dirty {
-		yamlApiPath := filepath.Join(apiDirectory, "Meta-information", "api.yaml")
-		utils.Logln(utils.LogPrefixInfo+"Writing preprocessed API to:", yamlApiPath)
+		yamlAPIPath := filepath.Join(apiDirectory, "Meta-information", "api.yaml")
+		utils.Logln(utils.LogPrefixInfo+"Writing preprocessed API to:", yamlAPIPath)
 		content, err := utils.JsonToYaml(api.Bytes())
 		if err != nil {
 			return err
 		}
 		// write this to disk
-		err = ioutil.WriteFile(yamlApiPath, content, 0644)
+		err = ioutil.WriteFile(yamlAPIPath, content, 0644)
 		if err != nil {
 			return err
 		}
@@ -716,7 +716,7 @@ func replaceEnvVariables(apiFilePath string) error {
 	return nil
 }
 
-func populateApiWithDefaults(def *v2.APIDefinition) (dirty bool) {
+func populateAPIWithDefaults(def *v2.APIDefinition) (dirty bool) {
 	dirty = false
 	if def.ContextTemplate == "" {
 		if !strings.Contains(def.Context, "{version}") {
@@ -744,13 +744,13 @@ func populateApiWithDefaults(def *v2.APIDefinition) (dirty bool) {
 	return
 }
 
-// validateApiDefinition validates an API against basic rules
-func validateApiDefinition(def *v2.APIDefinition) error {
+// validateAPIDefinition validates an API against basic rules
+func validateAPIDefinition(def *v2.APIDefinition) error {
 	utils.Logln(utils.LogPrefixInfo + "Validating API")
 	if isEmpty(def.ID.APIName) {
 		return errors.New("apiName is required")
 	}
-	if reApiName.MatchString(def.ID.APIName) {
+	if reAPIName.MatchString(def.ID.APIName) {
 		return errors.New(`apiName contains one or more illegal characters (~!@#;:%^*()+={}|\\<>"',&\/$)`)
 	}
 
@@ -878,14 +878,14 @@ func ImportAPIToEnv(accessOAuthToken, importEnvironment, importPath, apiParamsPa
 func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, apiParamsPath string, importAPIUpdate, preserveProvider,
 	importAPISkipCleanup bool) error {
 	exportDirectory := filepath.Join(utils.ExportDirectory, utils.ExportedApisDirName)
-	resolvedApiFilePath, err := resolveImportFilePath(importPath, exportDirectory)
+	resolvedAPIFilePath, err := resolveImportFilePath(importPath, exportDirectory)
 	if err != nil {
 		return err
 	}
-	utils.Logln(utils.LogPrefixInfo+"API Location:", resolvedApiFilePath)
+	utils.Logln(utils.LogPrefixInfo+"API Location:", resolvedAPIFilePath)
 
 	utils.Logln(utils.LogPrefixInfo + "Creating workspace")
-	tmpPath, err := getTempApiDirectory(resolvedApiFilePath)
+	tmpPath, err := getTempAPIDirectory(resolvedAPIFilePath)
 	if err != nil {
 		return err
 	}
@@ -915,7 +915,7 @@ func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, a
 	}
 
 	utils.Logln(utils.LogPrefixInfo + "Attempting to inject parameters to the API from api_params.yaml (if exists)")
-	paramsPath, err := resolveAPIParamsPath(resolvedApiFilePath, apiParamsPath)
+	paramsPath, err := resolveAPIParamsPath(resolvedAPIFilePath, apiParamsPath)
 	if err != nil && apiParamsPath != utils.ParamFileAPI && apiParamsPath != "" {
 		return err
 	}
@@ -933,7 +933,7 @@ func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, a
 		return err
 	}
 	// Fill with defaults
-	if populateApiWithDefaults(apiInfo) {
+	if populateAPIWithDefaults(apiInfo) {
 		utils.Logln(utils.LogPrefixInfo + "API is populated with defaults")
 		// api is dirty, write it to disk
 		buf, err := json.Marshal(apiInfo)
@@ -967,7 +967,7 @@ func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, a
 		}
 	}
 	// validate definition
-	if err = validateApiDefinition(apiInfo); err != nil {
+	if err = validateAPIDefinition(apiInfo); err != nil {
 		return err
 	}
 
@@ -999,7 +999,7 @@ func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, a
 	updateAPI := false
 	if importAPIUpdate {
 		// check for API existence
-		id, err := getApiID(accessOAuthToken, importEnvironment, apiInfo.ID.APIName, apiInfo.ID.Version)
+		id, err := getAPIID(accessOAuthToken, importEnvironment, apiInfo.ID.APIName, apiInfo.ID.Version)
 		if err != nil {
 			return err
 		}

--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	reApiProductName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
+	reAPIProductName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
 )
 
 // extractAPIProductDefinition extracts API Product information from jsonContent
@@ -64,7 +64,7 @@ func getAPIProductDefinition(filePath string) (*v2.APIProductDefinition, []byte,
 
 	var buffer []byte
 	if info.IsDir() {
-		_, content, err := resolveYamlOrJson(path.Join(filePath, "Meta-information", "api"))
+		_, content, err := resolveYamlOrJSON(path.Join(filePath, "Meta-information", "api"))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -100,9 +100,9 @@ func resolveImportAPIProductFilePath(file, defaultExportDirectory string) (strin
 	return absPath, nil
 }
 
-// getApiProductID returns id of the API Product by using apiProductInfo which contains name, version and provider as info
-func getApiProductID(name, version, environment, accessOAuthToken string) (string, error) {
-	apiProductQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
+// getAPIProductID returns id of the API Product by using apiProductInfo which contains name, version and provider as info
+func getAPIProductID(name, version, environment, accessOAuthToken string) (string, error) {
+	apiProductQuery := fmt.Sprintf("name:%s version:%s", name, version)
 	apiProductQuery += " type:\"" + utils.DefaultApiProductType + "\""
 	count, apiProducts, err := GetAPIProductListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiProductQuery), "")
 	if err != nil {
@@ -114,7 +114,7 @@ func getApiProductID(name, version, environment, accessOAuthToken string) (strin
 	return apiProducts[0].ID, nil
 }
 
-func populateApiProductWithDefaults(def *v2.APIProductDefinition) (dirty bool) {
+func populateAPIProductWithDefaults(def *v2.APIProductDefinition) (dirty bool) {
 	dirty = false
 	if def.ContextTemplate == "" {
 		if !strings.Contains(def.Context, "{version}") {
@@ -135,12 +135,12 @@ func populateApiProductWithDefaults(def *v2.APIProductDefinition) (dirty bool) {
 }
 
 // validateApiProductDefinition validates an API Product against basic rules
-func validateApiProductDefinition(def *v2.APIProductDefinition) error {
+func validateAPIProductDefinition(def *v2.APIProductDefinition) error {
 	utils.Logln(utils.LogPrefixInfo + "Validating API Product")
 	if isEmpty(def.ID.APIProductName) {
 		return errors.New("apiProductName is required")
 	}
-	if reApiProductName.MatchString(def.ID.APIProductName) {
+	if reAPIProductName.MatchString(def.ID.APIProductName) {
 		return errors.New(`apiProductName contains one or more illegal characters (~!@#;:%^*()+={}|\\<>"',&\/$)`)
 	}
 	if isEmpty(def.ID.Version) {
@@ -263,14 +263,14 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 	importAPIProductUpdate, importAPIProductPreserveProvider, importAPIProductSkipCleanup bool) error {
 	var exportDirectory = filepath.Join(utils.ExportDirectory, utils.ExportedApiProductsDirName)
 
-	resolvedApiProductFilePath, err := resolveImportAPIProductFilePath(importPath, exportDirectory)
+	resolvedAPIProductFilePath, err := resolveImportAPIProductFilePath(importPath, exportDirectory)
 	if err != nil {
 		return err
 	}
-	utils.Logln(utils.LogPrefixInfo+"API Product Location:", resolvedApiProductFilePath)
+	utils.Logln(utils.LogPrefixInfo+"API Product Location:", resolvedAPIProductFilePath)
 
 	utils.Logln(utils.LogPrefixInfo + "Creating workspace")
-	tmpPath, err := getTempApiDirectory(resolvedApiProductFilePath)
+	tmpPath, err := getTempAPIDirectory(resolvedAPIProductFilePath)
 	if err != nil {
 		return err
 	}
@@ -305,7 +305,7 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 		return err
 	}
 	// Fill with defaults
-	if populateApiProductWithDefaults(apiProductInfo) {
+	if populateAPIProductWithDefaults(apiProductInfo) {
 		utils.Logln(utils.LogPrefixInfo + "API Product is populated with defaults")
 		// API Product is dirty, write it to disk
 		buf, err := json.Marshal(apiProductInfo)
@@ -339,7 +339,7 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 		}
 	}
 	// Validate definition
-	if err = validateApiProductDefinition(apiProductInfo); err != nil {
+	if err = validateAPIProductDefinition(apiProductInfo); err != nil {
 		return err
 	}
 
@@ -371,7 +371,7 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 	updateAPIProduct := false
 	if importAPIsUpdate || importAPIProductUpdate {
 		// Check for API Product existence
-		id, err := getApiProductID(apiProductInfo.ID.APIProductName, apiProductInfo.ID.Version, importEnvironment, accessOAuthToken)
+		id, err := getAPIProductID(apiProductInfo.ID.APIProductName, apiProductInfo.ID.Version, importEnvironment, accessOAuthToken)
 		if err != nil {
 			return err
 		}

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -21,6 +21,8 @@ type Configuration struct {
 
 // Endpoint details
 type Endpoint struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type,omitempty"`
 	// Url of the endpoint
 	Url *string `yaml:"url" json:"url"`
 	// Config of endpoint
@@ -29,10 +31,58 @@ type Endpoint struct {
 
 // EndpointData contains details about endpoints
 type EndpointData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
 	// Production endpoint
 	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
 	// Sandbox endpoint
 	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+}
+
+// LoadBalanceEndpointsData contains details about endpoints mainly to be used in load balancing
+type LoadBalanceEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Production endpoints list for load balancing
+	Production []Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Sandbox endpoints list for load balancing
+	Sandbox []Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Session management method from the load balancing group. Values can be "none", "transport" (by default), "soap", "simpleClientSession" (Client ID)
+	SessionManagement string `yaml:"sessionManagement" json:"sessionManagement,omitempty"`
+	// Session timeout means the number of milliseconds after which the session would time out
+	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
+	// Class name for algorithm to be used if load balancing should be done
+	AlgorithmClassName string `yaml:"algoClassName" json:"algoClassName,omitempty"`
+}
+
+// FailoverEndpointsData contains details about endpoints mainly to be used in failover scenario
+type FailoverEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Primary production endpoint for failover
+	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Production failover endpoints list for failover
+	ProductionFailovers []Endpoint `yaml:"productionFailovers" json:"production_failovers,omitempty"`
+	// Primary sandbox endpoint for failover
+	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Production failover endpoints list for failover endpoint types
+	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
+	// To enable failover endpoints
+	Failover bool `json:"failOver,omitempty"`
+}
+
+// AWSLambdaEndpointsData contains details about endpoints to be used with AWS Lambda endpoints
+type AWSLambdaEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Access method for endpoint. Values can be "role-supplied" (Using IAM role-supplied temporary AWS credentials) and "stored" (Using stored AWS credentials)
+	AccessMethod string `yaml:"accessMethod" json:"access_method,omitempty"`
+	// Region where endpoint located (Regions list https://docs.aws.amazon.com/general/latest/gr/rande.html)
+	AmznRegion string `yaml:"amznRegion" json:"amznRegion,omitempty"`
+	// Access Key for endpoint
+	AmznAccessKey string `yaml:"amznAccessKey" json:"amznAccessKey,omitempty"`
+	// Access Secret for endpoint
+	AmznSecretKey string `yaml:"amznSecretKey" json:"amznSecretKey,omitempty"`
 }
 
 // SecurityData contains the details about endpoint security from api_params.yaml
@@ -63,8 +113,19 @@ type Cert struct {
 type Environment struct {
 	// Name of the environment
 	Name string `yaml:"name"`
+	// Type of the endpoints. Values can be "rest", "soap", "dynamic" or "aws"
+	EndpointType string `yaml:"endpointType"`
+	// EndpointRoutingPolicy contains the routing policy related to the endpoint. Values can be "load_balanced" or "failover".
+	// (Only available for the endpointTypes "rest" or "soap")
+	EndpointRoutingPolicy string `yaml:"endpointRoutingPolicy"`
 	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
+	// LoadBalanceEndpoints contain details about endpoints in a configuration for load balancing scenarios
+	LoadBalanceEndpoints *LoadBalanceEndpointsData `yaml:"loadBalanceEndpoints"`
+	// FailoverEndpoints contain details about endpoints in a configuration for failover scenarios
+	FailoverEndpoints *FailoverEndpointsData `yaml:"failoverEndpoints"`
+	// AWSLambdaEndpoints contain details about endpoints in a configuration with AWD Lambda configuration
+	AWSLambdaEndpoints *AWSLambdaEndpointsData `yaml:"awsLambdaEndpoints"`
 	// Security contains the details about endpoint security
 	Security *SecurityData `yaml:"security"`
 	// GatewayEnvironments contains environments that used to deploy API
@@ -136,7 +197,6 @@ func ExtractAPIEndpointConfig(b []byte) (string, error) {
 	return apiConfig.EPConfig, err
 }
 
-
 // GetEnv returns the EndpointData associated for key in the ApiParams, if not found returns nil
 func (config ApiParams) GetEnv(key string) *Environment {
 	for index, env := range config.Environments {
@@ -146,4 +206,3 @@ func (config ApiParams) GetEnv(key string) *Environment {
 	}
 	return nil
 }
-

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -143,3 +143,23 @@ const DefaultApisDisplayLimit = 25
 const DefaultApiProductsDisplayLimit = 25
 const DefaultAppsDisplayLimit = 25
 const DefaultExportFormat = "YAML"
+
+// Multiple endpoints related constants
+const HttpRESTEndpointType = "rest"              // To denote "endpointType: rest" in api_params.yaml
+const HttpRESTEndpointTypeForJSON = "http"       // To denote "endpointType: http" in api_params.yaml and to denote the "endpointType : http" in api.json
+const HttpSOAPEndpointType = "soap"              // To denote "endpointType: soap" in api_params.yaml
+const HttpSOAPEndpointTypeForJSON = "address"    // To denote the "endpointType : address" in api.json
+const AwsLambdaEndpointType = "aws"              // To denote "endpointType: aws" in api_params.yaml
+const AwsLambdaEndpointTypeForJSON = "awslambda" // To denote "endpointType: awslambda" in api.json
+const DynamicEndpointType = "dynamic"            // To denote "endpointType: dynamic" in api_params.yaml
+
+const LoadBalanceEndpointRoutingPolicy = "load_balanced" // To denote "endpointRoutingPolicy: load_balanced" in api_params.yaml
+const LoadBalanceEndpointTypeForJSON = "load_balance"    // To denote the "endpointType : load_balance" in api.json
+const LoadBalanceAlgorithmClass = "org.apache.synapse.endpoints.algorithms.RoundRobin"
+const FailoverRoutingPolicy = "failover" // To denote "endpointRoutingPolicy: failover" in api_params.yaml and to denote the "endpointType : failover" in api.json
+
+const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"url":"default"},"failOver":"False","production_endpoints":{"url":"default"}}`
+
+const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
+const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
+const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/322

## Goals
Provide the support to import an API with multiple endpoints by mentioning them in the api_params.yaml.

## Approach
Introduced five (5) new fields.
<ol>
<li><strong>endpointType</strong> to specify the type of the endpoint. Values can be "rest", "soap", "dynamic" or "aws".</li>
<li><strong>endpointRoutingPolicy</strong> to specify the routing policy to be used. Values can be "load_balanced" or "failover".</li>
<li><strong>loadBalanceEndpoints</strong> should be specified if the endpointRoutingPolicy is "load_balanced". This field contains the following.
<ol>
<li>production: An array which consists the multiple production endpoints</li>
<li>sandbox: An array which consists the multiple sandbox endpoints</li>
<li>sessionManagement: Values can be "none", "transport", "soap", "simpleClientSession" and if not specified the default value would be "transport"</li>
<li>sessionTimeout: The number of milliseconds after which the session would time out</li>
</ol>
</li>
<li><strong>failoverEndpoints</strong> should be specified if the endpointRoutingPolicy is "failover". This field contains the following.
<ol>
<li>production: The primary production endpoint (not an array)</li>
<li>sandbox: The primary sandbox endpoint (not an array)</li>
<li>productionFailovers: An array which consists failover production endpoints</li>
<li>sandboxFailovers: An array which consists failover sandbox endpoints</li>
</ol>
</li>
</li>
<li><strong>awsLambdaEndpoints</strong> should be specified if the endpointType is "aws". This field contains the following.
<ol>
<li>accessMethod: The access method of awslambda endpoint. Mandatory to specify. (Values can be "role_supplied" or "stored") </li>
<li>amznRegion: Region where the endpoint is located. Can be chosen from <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html">https://docs.aws.amazon.com/general/latest/gr/rande.html</a></li>
<li>amznAccessKey: Access Key for endpoint</li>
<li>amznSecretKey: Access Secret for endpoint</li>
</ol>
</li>
</ol>

The usage of the above fields can be found in the below section.

## User stories
There are four (4) main types of endpoints according to the APIM 3.1.x.
![image](https://user-images.githubusercontent.com/25246848/84594615-33187600-ae71-11ea-8a20-84a85ba5477e.png)

Nine (9) user scenarios can be considered based on the above 4 types as follows.
1. HTTP/REST Endpoint - Without load balancing or failover (the usual way)
2. HTTP/REST Endpoint - With load balancing
3. HTTP/REST Endpoint - With failover
4. HTTP/SOAP Endpoint - Without load balancing or failover 
5. HTTP/SOAP Endpoint - With load balancing
6. HTTP/REST Endpoint - With failover
8. AWS Lambda - Using IAM role-supplied temporary AWS credentials
9. AWS Lambda - Using stored AWS credentials

For more information about the user scenarios and the parameter configuration (with the examples), please refer the below document.
[Issue (2020.05.29) - Need support to set up api_params.yaml for multiple endpoints.pdf](https://github.com/wso2/product-apim-tooling/files/4819352/Issue.2020.05.29.-.Need.support.to.set.up.api_params.yaml.for.multiple.endpoints.pdf)

## Release note
WSO2 API Controller now supports importing an API with multiple endpoints.

## Documentation
Documentation has an impact. The doc changes have been in https://github.com/wso2/docs-apim/pull/1391  using the above .pdf.

## Test environment
- go version go1.14 linux/amd64
- Ubuntu 18.04.4 LTS