### PR TITLE
[3.1.x.] Remove kubectl from args for kubectl

### DIFF
--- a/import-export-cli/cmd/delete.go
+++ b/import-export-cli/cmd/delete.go
@@ -32,7 +32,7 @@ const deleteCmdLongDesc = `Delete an API available in the environment specified 
 Delete an Application of a specific user in the environment specified by flag (--environment, -e) in default mode
 Delete resources by filenames, stdin, resources and names, or by resources and label selector in kubernetes mode`
 
-const deleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral  + ` -n TwitterAPI -v 1.0.0 -r admin -e dev 
+const deleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev 
 ` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAppCmdLiteral + ` -n TestApplication -o admin -e dev
 ` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
 ` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
@@ -47,7 +47,7 @@ var DeleteCmd = &cobra.Command{
 		utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 		if configVars.Config.KubernetesMode {
-			k8sArgs := []string{k8sUtils.Kubectl, k8sUtils.K8sDelete}
+			k8sArgs := []string{k8sUtils.K8sDelete}
 			k8sArgs = append(k8sArgs, args...)
 			executeKubernetes(k8sArgs...)
 		}

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -41,25 +41,25 @@ const deleteAPICmdLiteral = "api"
 const deleteAPICmdShortDesc = "Delete API"
 const deleteAPICmdLongDesc = "Delete an API from an environment in default mode and delete API resources by API name or label selector in kubernetes mode"
 
-const deleteAPICmdExamplesDefault = "Default Mode:\n" + "  " +  utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
-` + "  " +  utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -e production
+const deleteAPICmdExamplesDefault = "Default Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -e production
 NOTE: The 3 flags (--name (-n), --version (-v), and --environment (-e)) are mandatory.`
 
-const deleteAPICmdExamplesKubernetes = "\nKubernetes Mode:\n" + "  " +  utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
-` + "  " +  utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
+const deleteAPICmdExamplesKubernetes = "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
+` + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
 
 // DeleteAPICmd represents the delete api command
 var DeleteAPICmd = &cobra.Command{
-	Use:   deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
-		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` `  + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
-	Short: deleteAPICmdShortDesc,
-	Long: deleteAPICmdLongDesc,
+	Use: deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
+		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
+	Short:   deleteAPICmdShortDesc,
+	Long:    deleteAPICmdLongDesc,
 	Example: deleteAPICmdExamplesDefault + deleteAPICmdExamplesKubernetes,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 		if configVars.Config.KubernetesMode {
-			k8sArgs := []string{k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.K8sApi}
+			k8sArgs := []string{k8sUtils.K8sDelete, k8sUtils.K8sApi}
 			k8sArgs = append(k8sArgs, args...)
 			executeKubernetes(k8sArgs...)
 		} else {
@@ -73,7 +73,7 @@ var DeleteAPICmd = &cobra.Command{
 }
 
 // executeDeleteAPICmd executes the delete api command
-func executeDeleteAPICmd(credential credentials.Credential)  {
+func executeDeleteAPICmd(credential credentials.Credential) {
 	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, deleteAPIEnvironment)
 	if preCommandErr == nil {
 		deleteAPIEndpoint := utils.GetApiListEndpointOfEnv(deleteAPIEnvironment, utils.MainConfigFilePath)
@@ -82,7 +82,7 @@ func executeDeleteAPICmd(credential credentials.Credential)  {
 			utils.HandleErrorAndExit("Error while deleting API ", err)
 		}
 		// Print info on response
-		utils.Logf(utils.LogPrefixInfo + "ResponseStatus: %v\n", resp.Status())
+		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
 		if resp.StatusCode() == http.StatusOK {
 			// 200 OK
 			fmt.Println(deleteAPIName + " API deleted successfully!")


### PR DESCRIPTION
wso2/k8s-api-operator#354
Same changes in https://github.com/wso2/product-apim-tooling/pull/323
for 3.1.x branch