### PR TITLE
[2.x] Add quotation marks to the API name when searching the exact API

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -480,7 +480,7 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string) error {
 
 // getApiID returns id of the API by using apiInfo which contains name, version and provider as info
 func getApiID(name, version, provider, environment, accessOAuthToken string) (string, error) {
-	apiQuery := fmt.Sprintf("name:%s version:%s", name, version)
+	apiQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
 	if provider != "" {
 		apiQuery += " provider:" + provider
 	}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/343

## Goals
Add quotation marks to the front and back of the API name in the search query.

## Approach
Add quotation marks in the apiQuery for API name in getApiID function.

## User stories
Can import an API named as ABC for the first time to APIM 2.6.0 using the below command  when there is an API already in the APIM named as ABCsomething.
```
apimcli import-api -f ABC_1.0.0.zip -e envname -k --update --verbose 
```

## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64