### PR TITLE
[3.2] Add quotation marks to the API or API Product name when searching the exact API or the API Product

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	reApiName                    = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
+	reApiName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
 )
 
 // extractAPIDefinition extracts API information from jsonContent
@@ -497,7 +497,7 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string) error {
 
 // getApiID returns id of the API by using apiInfo which contains name and version as info
 func getApiID(accessOAuthToken, environment, name, version string) (string, error) {
-	apiQuery := fmt.Sprintf("name:%s version:%s", name, version)
+	apiQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
 	count, apis, err := GetAPIListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiQuery), "")
 	if err != nil {
 		return "", err
@@ -766,7 +766,7 @@ func ImportAPIToEnv(accessOAuthToken, importEnvironment, importPath, apiParamsPa
 
 // ImportAPI function is used with import-api command
 func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, apiParamsPath string, importAPIUpdate, preserveProvider,
-		importAPISkipCleanup bool) error {
+	importAPISkipCleanup bool) error {
 	exportDirectory := filepath.Join(utils.ExportDirectory, utils.ExportedApisDirName)
 	resolvedApiFilePath, err := resolveImportFilePath(importPath, exportDirectory)
 	if err != nil {

--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	reApiProductName                    = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
+	reApiProductName = regexp.MustCompile(`[~!@#;:%^*()+={}|\\<>"',&/$]`)
 )
 
 // extractAPIProductDefinition extracts API Product information from jsonContent
@@ -102,7 +102,7 @@ func resolveImportAPIProductFilePath(file, defaultExportDirectory string) (strin
 
 // getApiProductID returns id of the API Product by using apiProductInfo which contains name, version and provider as info
 func getApiProductID(name, version, environment, accessOAuthToken string) (string, error) {
-	apiProductQuery := fmt.Sprintf("name:%s version:%s", name, version)
+	apiProductQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
 	apiProductQuery += " type:\"" + utils.DefaultApiProductType + "\""
 	count, apiProducts, err := GetAPIProductListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiProductQuery), "")
 	if err != nil {
@@ -260,7 +260,7 @@ func ImportAPIProductToEnv(accessOAuthToken, importEnvironment, importPath strin
 
 // ImportAPIProduct function is used with import-api-product command
 func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, importPath string, importAPIs, importAPIsUpdate,
-		importAPIProductUpdate, importAPIProductPreserveProvider, importAPIProductSkipCleanup bool) error {
+	importAPIProductUpdate, importAPIProductPreserveProvider, importAPIProductSkipCleanup bool) error {
 	var exportDirectory = filepath.Join(utils.ExportDirectory, utils.ExportedApiProductsDirName)
 
 	resolvedApiProductFilePath, err := resolveImportAPIProductFilePath(importPath, exportDirectory)
@@ -414,4 +414,3 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 	err = importAPIProduct(adminEndpoint, httpMethod, apiProductFilePath, accessOAuthToken, extraParams)
 	return err
 }
-


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/343

## Goals
Add quotation marks to the front and back of the API (or API Product) name in the search query.

## Approach
- Add quotation marks in the apiQuery for API name in getApiID function.
- Add quotation marks in the apiProductQuery for API Product name in getApiProductID function.

## User stories
- Can import an API named as ABC for the first time to APIM 3.2.0 using the below command  when there is an API already in the APIM named as ABCsomething.
```
apictl import-api -f ABC_1.0.0.zip -e envname --update --verbose 
```
- Can import an API Product named as ABC for the first time to APIM 3.2.0 using the below command  when there is an API Product already in the APIM named as ABCsomething.
```
apictl import api-product -f ABC_1.0.0.zip -e envname --update-api-product --verbose 
```
## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64