### PR TITLE
[3.2] Add quotation marks to the API or API Product version when searching the exact API or the API Product

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -497,7 +497,7 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string) error {
 
 // getApiID returns id of the API by using apiInfo which contains name and version as info
 func getApiID(accessOAuthToken, environment, name, version string) (string, error) {
-	apiQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
+	apiQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
 	count, apis, err := GetAPIListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiQuery), "")
 	if err != nil {
 		return "", err

--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -102,7 +102,7 @@ func resolveImportAPIProductFilePath(file, defaultExportDirectory string) (strin
 
 // getApiProductID returns id of the API Product by using apiProductInfo which contains name, version and provider as info
 func getApiProductID(name, version, environment, accessOAuthToken string) (string, error) {
-	apiProductQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
+	apiProductQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
 	apiProductQuery += " type:\"" + utils.DefaultApiProductType + "\""
 	count, apiProducts, err := GetAPIProductListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiProductQuery), "")
 	if err != nil {


### PR DESCRIPTION
## Purpose
Similar to https://github.com/wso2/product-apim-tooling/issues/343
Fixes the same problem in version.

## Goals
Add quotation marks to the front and back of the API (or API Product) version in the search query.

## Approach
- Add quotation marks in the apiQuery for API version in getApiID function.
- Add quotation marks in the apiProductQuery for API Product version in getApiProductID function.

## User stories
- Can import an API with the version 1.0 for the first time to APIM 3.2.0 using the below command when there is the same API versioned 1.0something in the APIM.
```
apictl import-api -f ABC_1.0.0.zip -e envname --update --verbose 
```
- Can import an API Product with the version 1.0 for the first time to APIM 3.2.0 using the below command when there is the same API Product versioned 1.0something in the APIM. (This is basically for future use when the API Product versioning is supported from APIM)
```
apictl import api-product -f ABC_1.0.0.zip -e envname --update-api-product --verbose 
```
## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64