### PR TITLE
[2.x] Add quotation marks to the API version when searching the exact API

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -480,7 +480,7 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string) error {
 
 // getApiID returns id of the API by using apiInfo which contains name, version and provider as info
 func getApiID(name, version, provider, environment, accessOAuthToken string) (string, error) {
-	apiQuery := fmt.Sprintf("name:\"%s\" version:%s", name, version)
+	apiQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
 	if provider != "" {
 		apiQuery += " provider:" + provider
 	}


### PR DESCRIPTION
## Purpose
Similar to https://github.com/wso2/product-apim-tooling/issues/343
Fixes the same problem in version.

## Goals
Add quotation marks to the front and back of the API version in the search query.

## Approach
Add quotation marks in the apiQuery for API version in getApiID function.

## User stories
Can import an API with the version 1.0 for the first time to APIM 2.6.0 using the below command when there is the same API versioned 1.0something in the APIM.
```
apimcli import-api -f ABC_1.0.zip -e envname -k --update --verbose 
```

## Test environment
- JDK 1.8.0_241
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64