### PR TITLE
Adding keyManagers field to API definition

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -631,6 +631,10 @@ func populateApiWithDefaults(def *v2.APIDefinition) (dirty bool) {
 		def.Implementation = "ENDPOINT"
 		dirty = true
 	}
+	if def.KeyManagers == nil || len(def.KeyManagers) == 0 {
+		def.KeyManagers = []string{"all"}
+		dirty = true
+	}
 	return
 }
 

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -73,6 +73,7 @@ type APIDefinition struct {
 	AccessControl                      string             `json:"accessControl,omitempty" yaml:"accessControl,omitempty"`
 	Rating                             float64            `json:"rating,omitempty" yaml:"rating,omitempty"`
 	IsLatest                           bool               `json:"isLatest,omitempty" yaml:"isLatest,omitempty"`
+	KeyManagers                        []string           `json:"keyManagers,omitempty" yaml:"keyManagers,omitempty"`
 }
 type ID struct {
 	ProviderName string `json:"providerName" yaml:"providerName"`


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/8294

## Goals
To eliminate the internal server error which occurs when importing an API which was created by executing the apictl init command.

## Approach
- A new field named **keyManagers** (a string array) was added to the APIDefinition.
- Before importing an API to the APIM, if **keyManagers** array is not specified in the API or it is defined as empty, the string value "all" will be added to that array. 

## User stories
- The use case which was blocked as mentioned in https://github.com/wso2/product-apim/issues/8294 can be done now.

## Test environment
- Ubuntu 18.04.4 LTS
- go version go1.14 linux/amd64