### PR TITLE
Adding default values for the optional flags in some of the help command outputs [3.1.X]

### DIFF
--- a/import-export-cli/cmd/addApi.go
+++ b/import-export-cli/cmd/addApi.go
@@ -333,7 +333,7 @@ func init() {
 	addApiCmd.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
 	addApiCmd.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
 	addApiCmd.Flags().BoolVarP(&flagOverride, "override", "", false, "Property to override the existing docker image with same name and version")
-	addApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Property to override the existing docker image with same name and version")
+	addApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Version of the API")
 	addApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
 		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v", utils.PrivateJetModeConst, utils.SidecarModeConst))
 }

--- a/import-export-cli/cmd/apiProducts.go
+++ b/import-export-cli/cmd/apiProducts.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
@@ -232,7 +233,7 @@ func init() {
 		"", "Query pattern")
 	apiProductsCmd.Flags().StringVarP(&listApiProductsCmdLimit, "limit", "l",
 		"", "Maximum number of API Products to return")
-	apiProductsCmd.Flags().StringVarP(&listApiProductsCmdFormat, "format", "", "", "Pretty-print API Products "+
+	apiProductsCmd.Flags().StringVarP(&listApiProductsCmdFormat, "format", "", strconv.Itoa(utils.DefaultApiProductsDisplayLimit), "Pretty-print API Products "+
 		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
 	_ = apiProductsCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/apis.go
+++ b/import-export-cli/cmd/apis.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
@@ -246,7 +247,7 @@ func init() {
 	apisCmd.Flags().StringVarP(&listApisCmdQuery, "query", "q",
 		"", "Query pattern")
 	apisCmd.Flags().StringVarP(&listApisCmdLimit, "limit", "l",
-		"", "Maximum number of apis to return")
+		strconv.Itoa(utils.DefaultApisDisplayLimit), "Maximum number of apis to return")
 	apisCmd.Flags().StringVarP(&listApisCmdFormat, "format", "", "", "Pretty-print apis "+
 		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
 	_ = apisCmd.MarkFlagRequired("environment")

--- a/import-export-cli/cmd/apps.go
+++ b/import-export-cli/cmd/apps.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
@@ -49,6 +50,7 @@ var listAppsCmdEnvironment string
 var listAppsCmdAppOwner string
 var listAppsCmdFormat string
 var listAppsCmdLimit string
+var defaultAppsOwner string
 
 // appsCmd related info
 const appsCmdLiteral = "apps"
@@ -116,6 +118,7 @@ var appsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + appsCmdLiteral + " called")
 		cred, err := getCredentials(listAppsCmdEnvironment)
+		defaultAppsOwner=cred.Username
 		if err != nil {
 			utils.HandleErrorAndExit("Error getting credentials", err)
 		}
@@ -222,13 +225,13 @@ func printApps(apps []utils.Application, format string) {
 func init() {
 	ListCmd.AddCommand(appsCmd)
 
-	appsCmd.Flags().StringVarP(&listAppsCmdAppOwner, "owner", "o", "",
+	appsCmd.Flags().StringVarP(&listAppsCmdAppOwner, "owner", "o", defaultAppsOwner,
 		"Owner of the Application")
 	appsCmd.Flags().StringVarP(&listAppsCmdEnvironment, "environment", "e",
 		"", "Environment to be searched")
 	appsCmd.Flags().StringVarP(&listAppsCmdLimit, "limit", "l",
 		"", "Maximum number of applications to return")
-	appsCmd.Flags().StringVarP(&listAppsCmdFormat, "format", "", "", "Pretty-print output"+
+	appsCmd.Flags().StringVarP(&listAppsCmdFormat, "format", "", strconv.Itoa(utils.DefaultAppsDisplayLimit), "Pretty-print output"+
 		"using Go templates. Use \"{{jsonPretty .}}\" to list all fields")
 	_ = appsCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/envs.go
+++ b/import-export-cli/cmd/envs.go
@@ -165,6 +165,6 @@ func printEnvs(envData map[string]utils.EnvEndpoints, format string) {
 
 func init() {
 	ListCmd.AddCommand(envsCmd)
-	envsCmd.Flags().StringVarP(&envsCmdFormat, "format", "", "", "Pretty-print "+
+	envsCmd.Flags().StringVarP(&envsCmdFormat, "format", "", defaulEnvsTableFormat, "Pretty-print "+
 		"environments using go templates")
 }

--- a/import-export-cli/cmd/exportAPI.go
+++ b/import-export-cli/cmd/exportAPI.go
@@ -171,7 +171,7 @@ func init() {
 		"", "Environment to which the API should be exported")
 	ExportAPICmd.Flags().BoolVarP(&exportAPIPreserveStatus, "preserveStatus", "", true,
 		"Preserve API status when exporting. Otherwise API will be exported in CREATED status")
-	ExportAPICmd.Flags().StringVarP(&exportAPIFormat, "format", "", "", "File format of exported archive(json or yaml)")
+	ExportAPICmd.Flags().StringVarP(&exportAPIFormat, "format", "", utils.DefaultExportFormat, "File format of exported archive(json or yaml)")
 	_ = ExportAPICmd.MarkFlagRequired("name")
 	_ = ExportAPICmd.MarkFlagRequired("version")
 	_ = ExportAPICmd.MarkFlagRequired("environment")

--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -286,6 +286,6 @@ func init() {
 			"any, and to export APIs from beginning")
 	ExportAPIsCmd.Flags().BoolVarP(&exportAPIPreserveStatus, "preserveStatus", "", true,
 		"Preserve API status when exporting. Otherwise API will be exported in CREATED status")
-	ExportAPIsCmd.Flags().StringVarP(&exportAPIsFormat, "format", "", "", "File format of exported archives(json or yaml)")
+	ExportAPIsCmd.Flags().StringVarP(&exportAPIsFormat, "format", "", utils.DefaultExportFormat, "File format of exported archives(json or yaml)")
 	_ = ExportAPIsCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -983,7 +983,7 @@ func init() {
 		"", "Environment from the which the API should be imported")
 	ImportAPICmd.Flags().BoolVar(&importAPICmdPreserveProvider, "preserve-provider", true,
 		"Preserve existing provider of API after importing")
-	ImportAPICmd.Flags().BoolVarP(&importAPIUpdate, "update", "", false, "Update an "+
+	ImportAPICmd.Flags().BoolVar(&importAPIUpdate, "update",  false, "Update an "+
 		"existing API or create a new API")
 	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", DefaultAPIMParamsFileName,
 		"Provide a API Manager params file")

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -103,6 +103,7 @@ func init() {
 
 	var defaultHttpRequestTimeout int
 	var defaultExportDirectory string
+	var defaultTokenType string
 
 	// read current values in file to be passed into default values for flags below
 	mainConfig := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
@@ -115,11 +116,15 @@ func init() {
 		defaultExportDirectory = mainConfig.Config.ExportDirectory
 	}
 
+	if mainConfig.Config.TokenType != "" {
+		defaultTokenType = mainConfig.Config.TokenType
+	}
+
 	SetCmd.Flags().IntVar(&flagHttpRequestTimeout, "http-request-timeout", defaultHttpRequestTimeout,
 		"Timeout for HTTP Client")
 	SetCmd.Flags().StringVar(&flagExportDirectory, "export-directory", defaultExportDirectory,
 		"Path to directory where APIs should be saved")
-	SetCmd.Flags().StringVarP(&flagTokenType, "token-type", "t", "",
+	SetCmd.Flags().StringVarP(&flagTokenType, "token-type", "t", defaultTokenType,
 		"Type of the token to be generated")
-	SetCmd.Flags().StringVarP(&flagKubernetesMode, "mode", "m", "", "mode of apictl")
+	SetCmd.Flags().StringVarP(&flagKubernetesMode, "mode", "m", utils.DefaultEnvironmentName, "mode of apictl")
 }

--- a/import-export-cli/docs/apictl_add_api.md
+++ b/import-export-cli/docs/apictl_add_api.md
@@ -28,7 +28,7 @@ apictl add/update api -n petstore --from-file=./Swagger.json --replicas=3 --name
       --namespace string        namespace of API
       --override                Property to override the existing docker image with same name and version
       --replicas int            replica set (default 1)
-  -v, --version string          Property to override the existing docker image with same name and version
+  -v, --version string          Version of the API
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_export-api.md
+++ b/import-export-cli/docs/apictl_export-api.md
@@ -22,7 +22,7 @@ NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are m
 
 ```
   -e, --environment string   Environment to which the API should be exported
-      --format string        File format of exported archive(json or yaml)
+      --format string        File format of exported archive(json or yaml) (default "YAML")
   -h, --help                 help for export-api
   -n, --name string          Name of the API to be exported
       --preserveStatus       Preserve API status when exporting. Otherwise API will be exported in CREATED status (default true)

--- a/import-export-cli/docs/apictl_export-apis.md
+++ b/import-export-cli/docs/apictl_export-apis.md
@@ -23,7 +23,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 ```
   -e, --environment string   Environment from which the APIs should be exported
       --force                Clean all the previously exported APIs of the given target tenant, in the given environment if any, and to export APIs from beginning
-      --format string        File format of exported archives(json or yaml)
+      --format string        File format of exported archives(json or yaml) (default "YAML")
   -h, --help                 help for export-apis
       --preserveStatus       Preserve API status when exporting. Otherwise API will be exported in CREATED status (default true)
 ```

--- a/import-export-cli/docs/apictl_list_api-products.md
+++ b/import-export-cli/docs/apictl_list_api-products.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print API Products using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print API Products using Go Templates. Use "{{ jsonPretty . }}" to list all fields (default "25")
   -h, --help                 help for api-products
   -l, --limit string         Maximum number of API Products to return
   -q, --query string         Query pattern

--- a/import-export-cli/docs/apictl_list_apis.md
+++ b/import-export-cli/docs/apictl_list_apis.md
@@ -27,7 +27,7 @@ NOTE: The flag (--environment (-e)) is mandatory
   -e, --environment string   Environment to be searched
       --format string        Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for apis
-  -l, --limit string         Maximum number of apis to return
+  -l, --limit string         Maximum number of apis to return (default "25")
   -q, --query string         Query pattern
 ```
 

--- a/import-export-cli/docs/apictl_list_apps.md
+++ b/import-export-cli/docs/apictl_list_apps.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print outputusing Go templates. Use "{{jsonPretty .}}" to list all fields
+      --format string        Pretty-print outputusing Go templates. Use "{{jsonPretty .}}" to list all fields (default "25")
   -h, --help                 help for apps
   -l, --limit string         Maximum number of applications to return
   -o, --owner string         Owner of the Application

--- a/import-export-cli/docs/apictl_list_envs.md
+++ b/import-export-cli/docs/apictl_list_envs.md
@@ -19,7 +19,7 @@ apictl list envs
 ### Options
 
 ```
-      --format string   Pretty-print environments using go templates
+      --format string   Pretty-print environments using go templates (default "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}")
   -h, --help            help for envs
 ```
 

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -28,11 +28,11 @@ apictl set --mode default
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/naduni/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/chamindu/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
-  -m, --mode string                mode of apictl
-  -t, --token-type string          Type of the token to be generated
+  -m, --mode string                mode of apictl (default "default")
+  -t, --token-type string          Type of the token to be generated (default "JWT")
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -17,18 +17,6 @@ case $state in
   ;;
   level2)
     case $words[2] in
-      add)
-        _arguments '2: :(api help)'
-      ;;
-      uninstall)
-        _arguments '2: :(api-operator help wso2am-operator)'
-      ;;
-      update)
-        _arguments '2: :(api help)'
-      ;;
-      remove)
-        _arguments '2: :(env help)'
-      ;;
       change)
         _arguments '2: :(help registry)'
       ;;
@@ -38,11 +26,23 @@ case $state in
       delete)
         _arguments '2: :(api api-product app help)'
       ;;
-      install)
-        _arguments '2: :(api-operator help wso2am-operator)'
-      ;;
       list)
         _arguments '2: :(api-products apis apps envs help)'
+      ;;
+      remove)
+        _arguments '2: :(env help)'
+      ;;
+      update)
+        _arguments '2: :(api help)'
+      ;;
+      add)
+        _arguments '2: :(api help)'
+      ;;
+      uninstall)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      install)
+        _arguments '2: :(api-operator help wso2am-operator)'
       ;;
       *)
         _arguments '*: :_files'

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -131,3 +131,9 @@ var EnvReplaceFilePaths = []string{
 
 const PrivateJetModeConst = "privateJet"
 const SidecarModeConst = "sidecar"
+
+//Default values for Help commands
+const DefaultApisDisplayLimit = 25
+const DefaultApiProductsDisplayLimit = 25
+const DefaultAppsDisplayLimit = 25
+const DefaultExportFormat = "YAML"


### PR DESCRIPTION
## Purpose
Description:
In some of the APICTL commands, there are optional flags. But in command help, we haven't specified what are the default values for them.
Eg:

![](https://user-images.githubusercontent.com/8363838/81823162-a583f680-9551-11ea-90a4-f9f2b21cefa1.png)

This PR will provide the default values for optional flags of commands.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/307 for 3.1.x branch

## Examples after changes
./apictl set -h 
<img width="622" alt="Screenshot 2020-06-17 at 13 56 30" src="https://user-images.githubusercontent.com/42435576/84874539-5c6c1880-b0a2-11ea-9f14-208602c359c4.png">



./apictl list apis -h
<img width="622" alt="Screenshot 2020-06-17 at 13 56 46" src="https://user-images.githubusercontent.com/42435576/84874565-67bf4400-b0a2-11ea-8a64-3d208468fbb1.png">

./apictl import-api -h

<img width="1218" alt="Screenshot 2020-06-17 at 13 47 58" src="https://user-images.githubusercontent.com/42435576/84874596-73126f80-b0a2-11ea-9aae-97abe105b4a4.png">

./apictl export-app -h
<img width="1218" alt="Screenshot 2020-06-17 at 13 47 48" src="https://user-images.githubusercontent.com/42435576/84874688-9b9a6980-b0a2-11ea-9725-1d848cd245fc.png">


## User stories
Using helper commands with apictl


## Test environment
MacOS. 10.15.5
Java jdk 1.8_241
 
