### PR TITLE
Change Info messages of "apictl set" commands. [ Fix for #361 ]

### DIFF
--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -63,36 +63,64 @@ var SetCmd = &cobra.Command{
 func executeSetCmd(mainConfigFilePath, exportDirectory string) {
 	// read the existing config vars
 	configVars := utils.GetMainConfigFromFile(mainConfigFilePath)
+	//Change Http Request timeout
 	if flagHttpRequestTimeout > 0 {
+		//Check whether the provided Http time out value is not equal to default value
+		if flagHttpRequestTimeout != configVars.Config.HttpRequestTimeout {
+			fmt.Println("Http Request Timout is set to : ", flagHttpRequestTimeout)
+		}
 		configVars.Config.HttpRequestTimeout = flagHttpRequestTimeout
 	} else {
 		fmt.Println("Invalid input for flag --http-request-timeout")
 	}
+
+	//Change Export Directory path
 	if flagExportDirectory != "" && utils.IsValid(flagExportDirectory) {
+		//Check whether the provided export directory is not equal to default value
+		if flagExportDirectory != configVars.Config.ExportDirectory {
+			fmt.Println("Export Directory is set to  : ",flagExportDirectory)
+		}
 		configVars.Config.ExportDirectory = flagExportDirectory
 	} else {
 		fmt.Println("Invalid input for flag --export-directory")
 	}
+
+	//Change Mode
 	if flagKubernetesMode != "" {
 		if strings.EqualFold(flagKubernetesMode, "kubernetes") || strings.EqualFold(flagKubernetesMode, "k8s") {
+			//Check whether the provided mode value is not equal to default value
+			if true != configVars.Config.KubernetesMode {
+				fmt.Println("Mode is set to : ", flagKubernetesMode)
+			}
 			configVars.Config.KubernetesMode = true
 		} else if strings.EqualFold(flagKubernetesMode, "default") {
+			if false != configVars.Config.KubernetesMode {
+				fmt.Println("Mode is set to : ", flagKubernetesMode)
+			}
 			configVars.Config.KubernetesMode = false
 		} else {
 			utils.HandleErrorAndExit("Error changing mode ",
 				errors.New("mode should be set to either kubernetes or none"))
 		}
 	}
+
+	//Change TokenType
 	if flagTokenType != "" {
 		if strings.EqualFold(flagTokenType, "jwt") {
+			//Check whether the provided token type value is not equal to default value
+			if flagTokenType != configVars.Config.TokenType {
+				fmt.Println("Token type is set to : ", flagTokenType)
+			}
 			configVars.Config.TokenType = "JWT"
 		} else if strings.EqualFold(flagTokenType, "oauth") {
+			if flagTokenType != configVars.Config.TokenType {
+				fmt.Println("Token type is set to : ", flagTokenType)
+			}
 			configVars.Config.TokenType = "OAUTH"
 		} else {
 			utils.HandleErrorAndExit("Error setting token type ",
 				errors.New("Token type should be either JWT or OAuth"))
 		}
-		fmt.Println("Token type set to: ", flagTokenType)
 	}
 	utils.WriteConfigFile(configVars, mainConfigFilePath)
 }


### PR DESCRIPTION
## Purpose
Currently when` apictl <FLAG_NAME> <FLAG_VALUE>` is provided the info messages show in command display are not correct. This PR will fix that issue.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/361

## Approach
![Screenshot from 2020-06-25 11-58-19](https://user-images.githubusercontent.com/42435576/85667628-6b268100-b6db-11ea-8338-41ca215be45f.png)

![Screenshot from 2020-06-25 11-58-36](https://user-images.githubusercontent.com/42435576/85667642-6e217180-b6db-11ea-8bab-a77082951dc7.png)


## User stories

- 1. Change Http Request Timeout using apictl.
- 2. Change Export Directory path using apictl.
- 3. Change Token TypeTimeout using apictl.
- 4. Change Mode (Default/Kuberenetes) Timeout using apictl.


## Documentation
No Doc changes


## Test environment
OS - Ubuntu 20.04
Java - JDK 1.8_252
APIM - 3.2.0 Aplha
