### PR TITLE
'apictl logout' revoke the currently used token when an user is logging out. [Fix for 327] [On 3.1.X Branch]

### DIFF
--- a/import-export-cli/cmd/logout.go
+++ b/import-export-cli/cmd/logout.go
@@ -49,10 +49,18 @@ var logoutCmd = &cobra.Command{
 }
 
 func runLogout(environment string) error {
+	cred, err := getCredentials(environment)
+	//Get current access token for
+	accessToken, err := credentials.GetOAuthAccessToken(cred, environment)
+	error := credentials.RevokeAccessToken(cred, environment, accessToken)
+	if error != nil {
+		return err
+	}
 	store, err := credentials.GetDefaultCredentialStore()
 	if err != nil {
 		return err
 	}
+	fmt.Println("Logged out from", environment, "environment")
 	return store.Erase(environment)
 }
 

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -93,8 +93,6 @@ func RevokeAccessToken(credential Credential, env string, token string)  error {
 
 	//get revoke endpoint
 	tokenRevokeEndpoint := utils.GetTokenRevokeEndpoint(env,utils.MainConfigFilePath)
-	fmt.Println(tokenRevokeEndpoint)
-	fmt.Println(token)
 	//Encoding client secret and client Id
 	var b64EncodedClientIDClientSecret = utils.GetBase64EncodedCredentials(credential.ClientId,credential.ClientSecret)
 	// set headers to request

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -19,8 +19,10 @@
 package credentials
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"path/filepath"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -84,4 +86,40 @@ func GetOAuthAccessToken(credential Credential, env string) (string, error) {
 // GetBasicAuth returns basic auth username:password encoded in base64
 func GetBasicAuth(credential Credential) string {
 	return Base64Encode(fmt.Sprintf("%s:%s", credential.Username, credential.Password))
+}
+
+//Revoke access Token when user is logging out from environment
+func RevokeAccessToken(credential Credential, env string, token string)  error {
+
+	//get revoke endpoint
+	tokenRevokeEndpoint := utils.GetTokenRevokeEndpoint(env,utils.MainConfigFilePath)
+	fmt.Println(tokenRevokeEndpoint)
+	fmt.Println(token)
+	//Encoding client secret and client Id
+	var b64EncodedClientIDClientSecret = utils.GetBase64EncodedCredentials(credential.ClientId,credential.ClientSecret)
+	// set headers to request
+	headers := make(map[string]string)
+	headers[utils.HeaderContentType] = utils.HeaderValueXWWWFormUrlEncoded
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64EncodedClientIDClientSecret
+
+	//Create body for the request
+	body := utils.HeaderToken + token + utils.TokenTypeForRevocation
+
+	resp, err := utils.InvokePOSTRequest(tokenRevokeEndpoint, headers, body)
+	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenRevokeEndpoint)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to Connect.", err)
+	}
+
+	//Check status code
+	if resp.StatusCode() != http.StatusOK {
+		utils.HandleErrorAndExit("Unable to connect.", errors.New("Status: "+resp.Status()))
+		return nil
+	}
+
+	responseDataMap := make(map[string]string) // a map to hold response data
+	data := []byte(resp.Body())
+	json.Unmarshal(data, &responseDataMap) // add response data to the map
+	return  nil
 }

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -28,9 +28,9 @@ apictl set --mode default
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/chamindu/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/chamindu/Desktop/Testing")
   -h, --help                       help for set
-      --http-request-timeout int   Timeout for HTTP Client (default 10000)
+      --http-request-timeout int   Timeout for HTTP Client (default 27823)
   -m, --mode string                mode of apictl (default "default")
   -t, --token-type string          Type of the token to be generated (default "JWT")
 ```

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -30,7 +30,7 @@ apictl set --mode default
 ```
       --export-directory string    Path to directory where APIs should be saved (default "/home/chamindu/Desktop/Testing")
   -h, --help                       help for set
-      --http-request-timeout int   Timeout for HTTP Client (default 27823)
+      --http-request-timeout int   Timeout for HTTP Client (default 100000)
   -m, --mode string                mode of apictl (default "default")
   -t, --token-type string          Type of the token to be generated (default "JWT")
 ```

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -20,6 +20,18 @@ case $state in
       change)
         _arguments '2: :(help registry)'
       ;;
+      install)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      uninstall)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      update)
+        _arguments '2: :(api help)'
+      ;;
+      add)
+        _arguments '2: :(api help)'
+      ;;
       change-status)
         _arguments '2: :(api help)'
       ;;
@@ -31,18 +43,6 @@ case $state in
       ;;
       remove)
         _arguments '2: :(env help)'
-      ;;
-      update)
-        _arguments '2: :(api help)'
-      ;;
-      add)
-        _arguments '2: :(api help)'
-      ;;
-      uninstall)
-        _arguments '2: :(api-operator help wso2am-operator)'
-      ;;
-      install)
-        _arguments '2: :(api-operator help wso2am-operator)'
       ;;
       *)
         _arguments '*: :_files'

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -20,8 +20,11 @@ case $state in
       change)
         _arguments '2: :(help registry)'
       ;;
-      install)
-        _arguments '2: :(api-operator help wso2am-operator)'
+      change-status)
+        _arguments '2: :(api help)'
+      ;;
+      list)
+        _arguments '2: :(api-products apis apps envs help)'
       ;;
       uninstall)
         _arguments '2: :(api-operator help wso2am-operator)'
@@ -32,14 +35,11 @@ case $state in
       add)
         _arguments '2: :(api help)'
       ;;
-      change-status)
-        _arguments '2: :(api help)'
-      ;;
       delete)
         _arguments '2: :(api api-product app help)'
       ;;
-      list)
-        _arguments '2: :(api-products apis apps envs help)'
+      install)
+        _arguments '2: :(api-operator help wso2am-operator)'
       ;;
       remove)
         _arguments '2: :(env help)'

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -23,26 +23,26 @@ case $state in
       change-status)
         _arguments '2: :(api help)'
       ;;
-      list)
-        _arguments '2: :(api-products apis apps envs help)'
-      ;;
-      uninstall)
-        _arguments '2: :(api-operator help wso2am-operator)'
-      ;;
-      update)
-        _arguments '2: :(api help)'
-      ;;
-      add)
-        _arguments '2: :(api help)'
-      ;;
       delete)
         _arguments '2: :(api api-product app help)'
       ;;
       install)
         _arguments '2: :(api-operator help wso2am-operator)'
       ;;
+      list)
+        _arguments '2: :(api-products apis apps envs help)'
+      ;;
       remove)
         _arguments '2: :(env help)'
+      ;;
+      uninstall)
+        _arguments '2: :(api-operator help wso2am-operator)'
+      ;;
+      add)
+        _arguments '2: :(api help)'
+      ;;
+      update)
+        _arguments '2: :(api help)'
       ;;
       *)
         _arguments '*: :_files'

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -61,6 +61,8 @@ const defaultAdminApplicationListEndpointSuffix = "api/am/admin/v0.16/applicatio
 const defaultDevPortalApplicationListEndpointSuffix = "api/am/store/v1/applications"
 const defaultDevPortalThrottlingPoliciesEndpointSuffix = "api/am/store/v1/throttling-policies"
 const defaultClientRegistrationEndpointSuffix = "client-registration/v0.16/register"
+const defaultRevokeEndpointSuffix = "revoke"
+const defaultTokenEndPoint = "token"
 
 const DefaultEnvironmentName = "default"
 
@@ -97,6 +99,8 @@ const LogPrefixError = "[ERROR]: "
 
 // String Constants
 const SearchAndTag = "&"
+const HeaderToken = "token="
+const TokenTypeForRevocation = "&token_type_hint=access_token"
 
 // Regex Validation
 const UsernameValidRegex = `^[\w\d\-]*$`

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"errors"
+	"strings"
 )
 
 // EnvExistsInKeysFile
@@ -308,4 +309,15 @@ func GetDefaultEnvironment(mainConfigFilePath string) string {
 		return DefaultEnvironmentName
 	}
 	return ""
+}
+
+//Get token endpoint for Token revocation
+//@return endpoint URL of token revocation endpoint
+func GetTokenRevokeEndpoint (env, filePath string) string {
+	//Get Internal token endpoint for the environment
+	internalTokenEndpoint := GetTokenEndpointOfEnv(env,filePath)
+	slittedString := strings.Split(internalTokenEndpoint,defaultTokenEndPoint)
+	//Get Apim endpoint or publisher endpoint
+	extractedTokenEndpoint := slittedString[0]
+	return extractedTokenEndpoint + defaultRevokeEndpointSuffix
 }


### PR DESCRIPTION
## Purpose
When a user tries to logout from an environment the generated access token for that user is not revoking and it keeps there. This has to be fixed as when the user is logging out that token has to be revoked. Therefore this has to be fixed as when an user logging out used token should be revoked.

**Reproducing the issue**

1. User login using apictl login
2. Do some work
3. apictl logout
4. Same user logins using "apictl login"
5. When doing next operations, we can see that the same previous token is used for those.


## Goals
Fixes issue No #327 for 3.1.x Branch

## Approach
**1. Create a function RevokeAccessToken()**
_This Function will create an HTTP post request to invoke token revocation endpoint and kill the current access token for that particular user before the user logs out from the environment._
**2. Use that method in logout.go**
_Before the user logout from the environment and erase credentials from .json file a newly introduced method will be executed to revoke the current access token._
**3. Provide tokenRevokeEndpoint.** 
_When providing this revoke token endpoint user does not need to do anything. Derivation of this revocation token endpoint will be done internally. That derived token revocation endpoint will be provided as the url RevokeAccessToken() function._


## User stories
Logging out from an environment in apictl.

## Documentation
No Document changes

## Test environment
Ubuntu 20.04
Java 1.8_252
APIM 3.1.0
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.