### PR TITLE
Assigning sessionManagement: transport with empty string internally to align with APIM

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -200,6 +200,11 @@ func setupMultipleEndpoints(environmentParams *params.Environment) ([]byte, erro
 			// The default class of the algorithm to be used should be set to RoundRobin
 			environmentParams.LoadBalanceEndpoints.AlgorithmClassName = utils.LoadBalanceAlgorithmClass
 			environmentParams.LoadBalanceEndpoints.EndpointType = utils.LoadBalanceEndpointTypeForJSON
+			if environmentParams.LoadBalanceEndpoints.SessionManagement == utils.LoadBalanceSessionManagementTransport {
+				// If the user has specified this as "transport", this should be converted to an empty string.
+				// Otherwise APIM won't recognize this as "transport".
+				environmentParams.LoadBalanceEndpoints.SessionManagement = ""
+			}
 			configData, err = json.Marshal(environmentParams.LoadBalanceEndpoints)
 		}
 
@@ -236,6 +241,11 @@ func setupMultipleEndpoints(environmentParams *params.Environment) ([]byte, erro
 			}
 			for index := range environmentParams.LoadBalanceEndpoints.Sandbox {
 				environmentParams.LoadBalanceEndpoints.Sandbox[index].EndpointType = utils.HttpSOAPEndpointTypeForJSON
+			}
+			if environmentParams.LoadBalanceEndpoints.SessionManagement == utils.LoadBalanceSessionManagementTransport {
+				// If the user has specified this as "transport", this should be converted to an empty string.
+				// Otherwise APIM won't recognize this as "transport".
+				environmentParams.LoadBalanceEndpoints.SessionManagement = ""
 			}
 			configData, err = json.Marshal(environmentParams.LoadBalanceEndpoints)
 		}

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -136,7 +136,7 @@ var EnvReplaceFilePaths = []string{
 
 // project param files
 const (
-	ParamFileAPI         = "api_params.yaml"
+	ParamFileAPI = "api_params.yaml"
 )
 
 const PrivateJetModeConst = "privateJet"
@@ -160,7 +160,8 @@ const DynamicEndpointType = "dynamic"            // To denote "endpointType: dyn
 const LoadBalanceEndpointRoutingPolicy = "load_balanced" // To denote "endpointRoutingPolicy: load_balanced" in api_params.yaml
 const LoadBalanceEndpointTypeForJSON = "load_balance"    // To denote the "endpointType : load_balance" in api.json
 const LoadBalanceAlgorithmClass = "org.apache.synapse.endpoints.algorithms.RoundRobin"
-const FailoverRoutingPolicy = "failover" // To denote "endpointRoutingPolicy: failover" in api_params.yaml and to denote the "endpointType : failover" in api.json
+const FailoverRoutingPolicy = "failover"                  // To denote "endpointRoutingPolicy: failover" in api_params.yaml and to denote the "endpointType : failover" in api.json
+const LoadBalanceSessionManagementTransport = "transport" // To represent the "sessionManagement: transport" in api_params.yaml
 
 const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"url":"default"},"failOver":"False","production_endpoints":{"url":"default"}}`
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/366

## Goals
Import an API with session management as **transport** and display it correctly from APIM.

## Approach
When the **loadBalanceEndpoints** field is specified with **sessionManagement** as **transport**, internally **sessionManagement** will be assigned with the empty string. 
Improvements were done for both the types HTTP/REST and HTTP/SOAP during the load balancing.

## User stories
User story which was blocked from https://github.com/wso2/product-apim-tooling/issues/366

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64