### PR TITLE
Fix for #371 and #373

### DIFF
--- a/import-export-cli/cmd/keys.go
+++ b/import-export-cli/cmd/keys.go
@@ -63,13 +63,6 @@ var genKeyCmd = &cobra.Command{
 //Subscribe the given API or API Product to the default application and generate an access token
 func getKeys() {
 
-	//Override the value of token endpoint if it is provided with get-keys command
-	if keyGenTokenEndpoint != "" {
-		fmt.Printf("New token endpoint '%s' is used as the token endpoint \n", keyGenTokenEndpoint)
-	} else {
-		var defaultTokenEndpoint = utils.GetTokenEndpointOfEnv(keyGenEnv,utils.MainConfigFilePath)
-		fmt.Printf("'%s' is used as the token endpoint \n", defaultTokenEndpoint)
-	}
 	cred, err := getCredentials(keyGenEnv)
 	if err != nil {
 		utils.HandleErrorAndExit("Error getting credentials", err)

--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -77,11 +77,6 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 				return err
 			}
 		}
-		// remove env from mainConfig file (endpoints file)
-		err = utils.RemoveEnvFromMainConfigFile(envName, mainConfigFilePath)
-		if err != nil {
-			return err
-		}
 
 		// remove keys also if user has already logged into this environment
 		store, err := credentials.GetDefaultCredentialStore()
@@ -91,6 +86,13 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 				return err
 			}
 		}
+
+		// remove env from mainConfig file (endpoints file)
+		err = utils.RemoveEnvFromMainConfigFile(envName, mainConfigFilePath)
+		if err != nil {
+			return err
+		}
+
 	} else {
 		// environment does not exist in mainConfig file (endpoints file). Nothing to remove
 		return errors.New("environment '" + envName + "' not found in " + mainConfigFilePath)

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -252,9 +252,7 @@ func validateGetKeys(t *testing.T, args *apiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		// Remove the string "'https://localhost:8243/token' is used as the token endpoint" from the result
-		stringWithToken := result[strings.Index(result, "\n")+1:]
-		invokeAPI(t, getResourceURL(args.apim, args.api), base.GetValueOfUniformResponse(stringWithToken), 200)
+		invokeAPI(t, getResourceURL(args.apim, args.api), base.GetValueOfUniformResponse(result), 200)
 		unsubscribeAPI(args.apim, args.ctlUser.username, args.ctlUser.password, args.api.ID)
 	}
 
@@ -266,9 +264,7 @@ func validateGetKeys(t *testing.T, args *apiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		// Remove the string "'https://localhost:8243/token' is used as the token endpoint" from the result
-		stringWithToken := result[strings.Index(result, "\n")+1:]
-		invokeAPIProduct(t, getResourceURLForAPIProduct(args.apim, args.apiProduct), base.GetValueOfUniformResponse(stringWithToken), 200)
+		invokeAPIProduct(t, getResourceURLForAPIProduct(args.apim, args.apiProduct), base.GetValueOfUniformResponse(result), 200)
 		unsubscribeAPI(args.apim, args.ctlUser.username, args.ctlUser.password, args.apiProduct.ID)
 	}
 }

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -17,13 +17,19 @@ case $state in
   ;;
   level2)
     case $words[2] in
-      add)
+      change-status)
         _arguments '2: :(api help)'
       ;;
-      change)
-        _arguments '2: :(help registry)'
+      export)
+        _arguments '2: :(api-product help)'
       ;;
-      change-status)
+      list)
+        _arguments '2: :(api-products apis apps envs help)'
+      ;;
+      remove)
+        _arguments '2: :(env help)'
+      ;;
+      add)
         _arguments '2: :(api help)'
       ;;
       delete)
@@ -38,17 +44,11 @@ case $state in
       uninstall)
         _arguments '2: :(api-operator help wso2am-operator)'
       ;;
-      export)
-        _arguments '2: :(api-product help)'
-      ;;
-      list)
-        _arguments '2: :(api-products apis apps envs help)'
-      ;;
-      remove)
-        _arguments '2: :(env help)'
-      ;;
       update)
         _arguments '2: :(api help)'
+      ;;
+      change)
+        _arguments '2: :(help registry)'
       ;;
       *)
         _arguments '*: :_files'


### PR DESCRIPTION
## Purpose
Fixing a related to NPE related _apictl remove env <ENVIRONMENT_NAME>_ and change  test assertions and info messages related to `apictl get-keys -n <API or API Product name> -v <API or API Product version> -r <API or API Product provider> -e <environment> -k`

## Goals
Fixes #371 
Fixes #373

## Approach
**For the Fix of 371.**
1. Remove info messages such as _'https://localhost:9443/oauth2/token' is used as the token endpoint_ from the output of `get-keys `command and keep it only in `add-env.`
2. Changes integration tests as per the change in get-keys output

**For the Fix of 373.**
1. Make sure the user is logging out from the environment before environment configurations ( APIM Endpoint, Publisher Endpoint, DevPortal Endpoint, Registration Endpoint, Token Endpoint, and Admin Endpoint ) are removed from _mainConfig.yaml_ file.
2 Restructuring of code to execute this sequence


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0 -Alpha
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.