### PR TITLE
Fix for  #373 [3.1.X Branch]

### DIFF
--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -77,12 +77,6 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 				return err
 			}
 		}
-		// remove env from mainConfig file (endpoints file)
-		err = utils.RemoveEnvFromMainConfigFile(envName, mainConfigFilePath)
-		if err != nil {
-			return err
-		}
-
 		// remove keys also if user has already logged into this environment
 		store, err := credentials.GetDefaultCredentialStore()
 		if store.Has(envName) {
@@ -91,6 +85,12 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 				return err
 			}
 		}
+		// remove env from mainConfig file (endpoints file)
+		err = utils.RemoveEnvFromMainConfigFile(envName, mainConfigFilePath)
+		if err != nil {
+			return err
+		}
+
 	} else {
 		// environment does not exist in mainConfig file (endpoints file). Nothing to remove
 		return errors.New("environment '" + envName + "' not found in " + mainConfigFilePath)


### PR DESCRIPTION
## Purpose
Fixing a related to NPE related `apictl remove env <ENVIRONMENT_NAME> 
`
## Goals
Fixes #373 

## Approach

1. Make sure the user is logging out from the environment before environment configurations ( APIM Endpoint, Publisher Endpoint, DevPortal Endpoint, Registration Endpoint, Token Endpoint, and Admin Endpoint ) are removed from mainConfig.yaml file.
2. Restructuring of code to execute this sequence

## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0 -Alpha
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.