### PR TITLE
Change the implementation of JsonToYaml function to fix #370

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -100,7 +100,7 @@ type SecurityData struct {
 // Cert stores certificate details
 type Cert struct {
 	// Host of the certificate
-	Host string `yaml:"host" json:"hostName"`
+	Host string `yaml:"hostName" json:"hostName"`
 	// Alias for certificate
 	Alias string `yaml:"alias" json:"alias"`
 	// Path for certificate file
@@ -137,12 +137,12 @@ type Environment struct {
 // ApiParams represents environments defined in configuration file
 type ApiParams struct {
 	// Environments contains all environments in a configuration
-	Environments []Environment   `yaml:"environments"`
+	Environments []Environment `yaml:"environments"`
 }
 
 // APIEndpointConfig contains details about endpoints in an API
 type APIEndpointConfig struct {
-    // EPConfig is representing endpoint configuration
+	// EPConfig is representing endpoint configuration
 	EPConfig string `json:"endpointConfig"`
 }
 

--- a/import-export-cli/utils/yaml.go
+++ b/import-export-cli/utils/yaml.go
@@ -4,23 +4,11 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
-	yaml2 "gopkg.in/yaml.v2"
 )
 
 // JsonToYaml converts a json string to yaml
 func JsonToYaml(jsonData []byte) ([]byte, error) {
-	var m yaml2.MapSlice
-	err := yaml2.Unmarshal(jsonData, &m)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := yaml2.Marshal(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return yaml.JSONToYAML(jsonData)
 }
 
 // YamlToJson converts a yaml string to json


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/370

## Goals
Change the implementation of JsonToYaml function and change the "host" to "hostName" in Certs struct to match with docs.

## Approach
- Replaced the old implementation of JsonToYaml with a call to JSONToYaml function in the library **github.com/ghodss/yaml**
- Changed the "host" field to "hostName" in **Certs** struct to match with the docs.

## User stories
Can import an API along with api_params.yaml with the certs field.

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64