### PR TITLE
Disable flag parsing in "delete" and "delete api" commands when k8s mode is enabled

### DIFF
--- a/import-export-cli/cmd/delete.go
+++ b/import-export-cli/cmd/delete.go
@@ -41,10 +41,11 @@ const deleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + del
 
 // DeleteCmd represents the delete command
 var DeleteCmd = &cobra.Command{
-	Use:     deleteCmdLiteral,
-	Short:   deleteCmdShortDesc,
-	Long:    deleteCmdLongDesc,
-	Example: deleteCmdExamples,
+	Use:                deleteCmdLiteral,
+	Short:              deleteCmdShortDesc,
+	Long:               deleteCmdLongDesc,
+	Example:            deleteCmdExamples,
+	DisableFlagParsing: isK8sEnabled(),
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -49,9 +49,10 @@ const deleteAPICmdExamplesKubernetes = "\nKubernetes Mode:\n" + "  " +  utils.Pr
 var DeleteAPICmd = &cobra.Command{
 	Use: deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
 		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
-	Short:   deleteAPICmdShortDesc,
-	Long:    deleteAPICmdLongDesc,
-	Example: deleteAPICmdExamplesDefault + deleteAPICmdExamplesKubernetes,
+	Short:              deleteAPICmdShortDesc,
+	Long:               deleteAPICmdLongDesc,
+	Example:            deleteAPICmdExamplesDefault + deleteAPICmdExamplesKubernetes,
+	DisableFlagParsing: isK8sEnabled(),
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)


### PR DESCRIPTION
fix wso2/k8s-api-operator#378

### Delete configmap "k8s mode"
```sh
$ apictl delete -f scenario-3/petstore-basic.yaml
security.wso2.com "petstorebasic" deleted
```

### Delete configmap "default mode"
```sh
$ apictl delete -f scenario-3/petstore-basic.yaml
Error: unknown shorthand flag: 'f' in -f
Usage:
  apictl delete [flags]
  apictl delete [command]

Examples:
apictl delete api -n TwitterAPI -v 1.0.0 -r admin -e dev
apictl delete api-product -n TwitterAPI -r admin -e dev 
apictl delete app -n TestApplication -o admin -e dev
apictl delete api petstore
apictl delete api -l name=myLabel

Available Commands:
  api         Delete API
  api-product Delete API Product
  app         Delete App

Flags:
  -h, --help   help for delete

Global Flags:
  -k, --insecure   Allow connections to SSL endpoints without certs
      --verbose    Enable verbose mode

Use "apictl delete [command] --help" for more information about a command.

unknown shorthand flag: 'f' in -f
```
