### PR TITLE
Adding Integration Tests

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -853,7 +853,7 @@ func (instance *Client) DeleteSubscriptions(apiID string) {
 }
 
 // AddApplication : Add new Application to APIM
-func (instance *Client) AddApplication(t *testing.T, application *Application, username string, password string,doClean bool) *Application {
+func (instance *Client) AddApplication(t *testing.T, application *Application, username string, password string, doClean bool) *Application {
 	appsURL := instance.devPortalRestURL + "/applications"
 
 	data, err := json.Marshal(application)

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -930,6 +930,27 @@ func (instance *Client) GetApplication(appID string) *Application {
 	return &appResponse
 }
 
+// GetApplications : Get Applications list from APIM
+func (instance *Client) GetApplications() *ApplicationList {
+	appsURL := instance.devPortalRestURL + "/applications"
+
+	request := base.CreateGet(appsURL)
+
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+	base.LogRequest("apim.GetApplications()", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
+	base.ValidateAndLogResponse("apim.GetApplications()", response, 200)
+
+	var appResponse ApplicationList
+	json.NewDecoder(response.Body).Decode(&appResponse)
+	return &appResponse
+}
+
 // GetApplicationByName : Get Application from APIM by name
 func (instance *Client) GetApplicationByName(name string) *ApplicationInfo {
 	appsURL := instance.devPortalRestURL + "/applications"

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -853,7 +853,7 @@ func (instance *Client) DeleteSubscriptions(apiID string) {
 }
 
 // AddApplication : Add new Application to APIM
-func (instance *Client) AddApplication(t *testing.T, application *Application, username string, password string) *Application {
+func (instance *Client) AddApplication(t *testing.T, application *Application, username string, password string,doClean bool) *Application {
 	appsURL := instance.devPortalRestURL + "/applications"
 
 	data, err := json.Marshal(application)
@@ -877,10 +877,12 @@ func (instance *Client) AddApplication(t *testing.T, application *Application, u
 	var appResponse Application
 	json.NewDecoder(response.Body).Decode(&appResponse)
 
-	t.Cleanup(func() {
-		instance.Login(username, password)
-		instance.DeleteApplication(appResponse.ApplicationID)
-	})
+	if doClean {
+		t.Cleanup(func() {
+			instance.Login(username, password)
+			instance.DeleteApplication(appResponse.ApplicationID)
+		})
+	}
 
 	return &appResponse
 }

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -19,10 +19,14 @@
 package integration
 
 import (
-	"testing"
-
+	"github.com/magiconair/properties/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"testing"
+	"time"
 )
+
+const numberOfApps = 5 // Number of Applications to be added in a loop
 
 func TestListApp(t *testing.T) {
 	username := superAdminUser
@@ -92,7 +96,27 @@ func TestExportImportOwnAppAdminSuperTenant(t *testing.T) {
 		destAPIM:    prod,
 	}
 
-	validateAppExportImport(t, args)
+	validateAppExportImportWithPreserveOwner(t, args)
+}
+
+func TestExportImportOwnAppAdminSuperTenantWithUpdate(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	app := addApp(t, dev, adminUsername, adminPassword)
+
+	args := &appImportExportTestArgs{
+		appOwner:    credentials{username: adminUsername, password: adminPassword},
+		ctlUser:     credentials{username: adminUsername, password: adminPassword},
+		application: app,
+		srcAPIM:     dev,
+		destAPIM:    prod,
+	}
+
+	validateAppExportImportWithUpdate(t, args)
 }
 
 func TestExportImportOtherAppAdminSuperTenant(t *testing.T) {
@@ -114,7 +138,7 @@ func TestExportImportOtherAppAdminSuperTenant(t *testing.T) {
 		destAPIM:    prod,
 	}
 
-	validateAppExportImport(t, args)
+	validateAppExportImportWithPreserveOwner(t, args)
 }
 
 func TestExportImportOwnAppAdminTenant(t *testing.T) {
@@ -134,7 +158,7 @@ func TestExportImportOwnAppAdminTenant(t *testing.T) {
 		destAPIM:    prod,
 	}
 
-	validateAppExportImport(t, args)
+	validateAppExportImportWithPreserveOwner(t, args)
 }
 
 func TestExportOtherAppAdminTenant(t *testing.T) {
@@ -156,7 +180,7 @@ func TestExportOtherAppAdminTenant(t *testing.T) {
 		destAPIM:    prod,
 	}
 
-	validateAppExportImport(t, args)
+	validateAppExportImportWithPreserveOwner(t, args)
 }
 
 func TestExportCrossTenantAppAdminTenant(t *testing.T) {
@@ -190,7 +214,7 @@ func TestExportAppSecondaryUserStoreAdminSuperTenant(t *testing.T) {
 
 	base.SetupEnv(t, devEnv, devApim, devTokenEP)
 	base.Login(t, devEnv, username, password)
-validateAppExportImport
+validateAppExportImportWithPreserveOwner
 	exportApp(t, name, owner, devEnv)
 
 	assert.True(t, base.IsApplicationArchiveExists(devAppExportPath, name, owner))
@@ -211,3 +235,50 @@ func TestExportAppSecondaryUserStoreAdminSuperTenantLowerCase(t *testing.T) {
 	assert.True(t, base.IsApplicationArchiveExists(devAppExportPath, name, owner))
 }
 */
+
+func validateAppDelete(t *testing.T, args *appImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
+
+	// Delete an API of env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	time.Sleep(1 * time.Second)
+	appsListBeforeDelete := args.srcAPIM.GetApplications()
+
+	deleteAppByCtl(t, args)
+
+	appsListAfterDelete := args.srcAPIM.GetApplications()
+	time.Sleep(1 * time.Second)
+
+	// Validate whether the expected number of API count is there
+	assert.Equal(t, appsListBeforeDelete.Count, appsListAfterDelete.Count+1, "Expected number of Applications not deleted")
+
+	// Validate that the delete is a success
+	validateApplicationIsDeleted(t, args.application, appsListAfterDelete)
+}
+
+func TestDeleteAppSuperTenantUser(t *testing.T) {
+	applicationCreator := creator.UserName
+	applicationCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	var application *apim.Application
+	for apiCount := 0; apiCount <= numberOfApps; apiCount++ {
+		application = addApp(t, dev, applicationCreator, applicationCreatorPassword)
+	}
+
+	// This will be the Application that will be deleted by apictl, so no need to do cleaning
+	application = addApplicationWithoutCleaning(t, dev, applicationCreator, applicationCreatorPassword)
+
+	args := &appImportExportTestArgs{
+		ctlUser: credentials{username: applicationCreator, password: applicationCreatorPassword},
+		application:     application,
+		srcAPIM: dev,
+	}
+
+	validateAppDelete(t, args)
+}

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -277,9 +277,9 @@ func TestDeleteAppSuperTenantUser(t *testing.T) {
 	application = addApplicationWithoutCleaning(t, dev, adminUsername, adminPassword)
 
 	args := &appImportExportTestArgs{
-		ctlUser: credentials{username: superAdminUser, password: superAdminPassword},
-		application:     application,
-		srcAPIM: dev,
+		ctlUser:     credentials{username: superAdminUser, password: superAdminPassword},
+		application: application,
+		srcAPIM:     dev,
 	}
 
 	validateAppDelete(t, args)

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -243,7 +243,7 @@ func validateAppDelete(t *testing.T, args *appImportExportTestArgs) {
 	// Setup apictl envs
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
 
-	// Delete an API of env 1
+	// Delete an App of env 1
 	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
 	time.Sleep(1 * time.Second)
@@ -254,7 +254,7 @@ func validateAppDelete(t *testing.T, args *appImportExportTestArgs) {
 	appsListAfterDelete := args.srcAPIM.GetApplications()
 	time.Sleep(1 * time.Second)
 
-	// Validate whether the expected number of API count is there
+	// Validate whether the expected number of App count is there
 	assert.Equal(t, appsListBeforeDelete.Count, appsListAfterDelete.Count+1, "Expected number of Applications not deleted")
 
 	// Validate that the delete is a success

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -99,6 +99,7 @@ func TestExportImportOwnAppAdminSuperTenant(t *testing.T) {
 	validateAppExportImportWithPreserveOwner(t, args)
 }
 
+//Import an already export App with already generated Keys with --update flag
 func TestExportImportOwnAppAdminSuperTenantWithUpdate(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword
@@ -260,22 +261,23 @@ func validateAppDelete(t *testing.T, args *appImportExportTestArgs) {
 	validateApplicationIsDeleted(t, args.application, appsListAfterDelete)
 }
 
+//Delete an Application as a super tenant admin
 func TestDeleteAppSuperTenantUser(t *testing.T) {
-	applicationCreator := creator.UserName
-	applicationCreatorPassword := creator.Password
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
 
 	dev := apimClients[0]
 
 	var application *apim.Application
-	for apiCount := 0; apiCount <= numberOfApps; apiCount++ {
-		application = addApp(t, dev, applicationCreator, applicationCreatorPassword)
+	for appCount := 0; appCount <= numberOfApps; appCount++ {
+		application = addApp(t, dev, adminUsername, adminPassword)
 	}
 
 	// This will be the Application that will be deleted by apictl, so no need to do cleaning
-	application = addApplicationWithoutCleaning(t, dev, applicationCreator, applicationCreatorPassword)
+	application = addApplicationWithoutCleaning(t, dev, adminUsername, adminPassword)
 
 	args := &appImportExportTestArgs{
-		ctlUser: credentials{username: applicationCreator, password: applicationCreatorPassword},
+		ctlUser: credentials{username: superAdminUser, password: superAdminPassword},
 		application:     application,
 		srcAPIM: dev,
 	}

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -20,6 +20,7 @@ package base
 
 import (
 	"flag"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -271,4 +272,23 @@ func RemoveDir(projectName string) {
 	if error != nil {
 		log.Fatal(error)
 	}
+}
+
+func GetExportedPathFromOutput(output string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(output[strings.Index(output, "/"):], "\n", ""), " ", "")
+}
+
+//Count number of files in a directory
+func CountFiles(path string) (int, error) {
+	i := 0
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return 0, err
+	}
+	for _, file := range files {
+		if !file.IsDir() {
+			i++
+		}
+	}
+	return i, nil
 }

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -78,6 +78,16 @@ func SetupEnv(t *testing.T, env string, apim string, tokenEp string) {
 	})
 }
 
+// SetupEnv : Adds a new environment just with apim endpoint and automatically removes it when the
+// calling test function execution ends
+func SetupEnvWithoutTokenFlag(t *testing.T, env string, apim string) {
+	Execute(t, "add-env", "-e", env, "--apim", apim)
+
+	t.Cleanup(func() {
+		Execute(t, "remove", "env", env)
+	})
+}
+
 // Login : Logs into an environment and automatically logs out when the calling test function execution ends
 //
 func Login(t *testing.T, env string, username string, password string) {

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -266,7 +266,7 @@ func logResponse(logString string, response *http.Response) {
 	log.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
 }
 
-func RemoveDir(projectName string){
+func RemoveDir(projectName string) {
 	error := os.RemoveAll(projectName)
 	if error != nil {
 		log.Fatal(error)

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -265,3 +265,10 @@ func logResponse(logString string, response *http.Response) {
 	log.Println(string(dump))
 	log.Println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
 }
+
+func RemoveDir(projectName string){
+	error := os.RemoveAll(projectName)
+	if error != nil {
+		log.Fatal(error)
+	}
+}

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -20,6 +20,7 @@ package integration
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"log"
 	"testing"
 )
@@ -29,7 +30,7 @@ func TestInitializeProject(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	var projectName = "SampleTestAPI"
+	projectName := "SampleTestAPI"
 
 	args := &initTestArgs{
 		ctlUser:  credentials{username: username, password: password},
@@ -43,8 +44,10 @@ func TestInitializeProject(t *testing.T) {
 	}
 
 	assert.Nil(t, err, "Error while generating Project")
-	assert.Containsf(t, output, "Project initialized", "TestInitializeProject Failed")
+	assert.Contains(t, output, "Project initialized", "TestInitializeProject Failed")
 
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
 	t.Cleanup(func() {
 		base.Execute(t, "logout", apim.GetEnvName())
 	})
@@ -55,14 +58,13 @@ func TestInitializeProjectWithDefinitionFlag(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	var projectName = "SampleTestAPI2"
-	var definitionFilePath = ""
+	projectName := "SampleTestAPIWithDefinition"
 
 	args := &initTestArgs{
 		ctlUser:        credentials{username: username, password: password},
 		srcAPIM:        apim,
 		initFlag:       projectName,
-		definitionFlag: definitionFilePath,
+		definitionFlag: utils.DefinitionYamlPath,
 		forceFlag:      true,
 	}
 
@@ -72,7 +74,10 @@ func TestInitializeProjectWithDefinitionFlag(t *testing.T) {
 	}
 
 	assert.Nil(t, err, "Error while generating Project")
-	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
 	t.Cleanup(func() {
 		base.Execute(t, "logout", apim.GetEnvName())
 	})
@@ -83,14 +88,13 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	var projectName = "SampleTestAPI2"
-	var swaggerDefinitionFilePath = "testdata/swagger2Definition.yaml"
+	projectName := "Swagger2APIProject"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},
 		srcAPIM:   apim,
 		initFlag:  projectName,
-		oasFlag:   swaggerDefinitionFilePath,
+		oasFlag:   utils.TestSwagger2DefinitionPath,
 		forceFlag: false,
 	}
 
@@ -101,6 +105,9 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 
 	assert.Nil(t, err, "Error while generating Project")
 	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
 	t.Cleanup(func() {
 		base.Execute(t, "logout", apim.GetEnvName())
 	})
@@ -111,14 +118,13 @@ func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	var projectName = "OpenAPI3"
-	var openAPISpecificationFilePath = "testdata/openAPI3Definition.yaml"
+	var projectName = "OpenAPI3Project"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},
 		srcAPIM:   apim,
 		initFlag:  projectName,
-		oasFlag:   openAPISpecificationFilePath,
+		oasFlag:   utils.TestOpenAPI3DefinitionPath,
 		forceFlag: false,
 	}
 
@@ -128,7 +134,10 @@ func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	}
 
 	assert.Nil(t, err, "Error while generating Project")
-	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
 	t.Cleanup(func() {
 		base.Execute(t, "logout", apim.GetEnvName())
 	})
@@ -139,14 +148,13 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	var projectName = "PetStore"
-	var openAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"
+	var projectName = "ProjectInitWithURL"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},
 		srcAPIM:   apim,
 		initFlag:  projectName,
-		oasFlag:   openAPISpecificationURL,
+		oasFlag:   utils.TestOpenAPISpecificationURL,
 		forceFlag: false,
 	}
 
@@ -156,8 +164,12 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 	}
 
 	assert.Nil(t, err, "Error while generating Project")
-	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
 	t.Cleanup(func() {
 		base.Execute(t, "logout", apim.GetEnvName())
 	})
 }
+

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -53,48 +53,17 @@ func TestInitializeProject(t *testing.T) {
 	})
 }
 
-//Initialize an API the the definition.yaml (apictl init SampleAPI --definition definition.yaml)
-func TestInitializeProjectWithDefinitionFlag(t *testing.T) {
+//Function to initialize a project using API definition
+func InitializeAPIFromDefinition(t *testing.T, projectName string, definitionFileName string) (string, error) {
 	username := superAdminUser
 	password := superAdminPassword
 	apim := apimClients[0]
-	projectName := "SampleTestAPIWithDefinition"
-
-	args := &initTestArgs{
-		ctlUser:        credentials{username: username, password: password},
-		srcAPIM:        apim,
-		initFlag:       projectName,
-		definitionFlag: utils.DefinitionYamlPath,
-		forceFlag:      true,
-	}
-
-	output, err := initProjectWithDefinitionFlag(t, args)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	assert.Nil(t, err, "Error while generating Project")
-	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
-
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
-}
-
-//Initialize an API from Swagger 2 Specification
-func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
-	username := superAdminUser
-	password := superAdminPassword
-	apim := apimClients[0]
-	projectName := "Swagger2APIProject"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},
 		srcAPIM:   apim,
 		initFlag:  projectName,
-		oasFlag:   utils.TestSwagger2DefinitionPath,
+		oasFlag:   definitionFileName,
 		forceFlag: false,
 	}
 
@@ -103,6 +72,15 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 		log.Fatal(err)
 	}
 
+	return output, err
+}
+
+//Initialize an API from Swagger 2 Specification
+func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
+	apim := apimClients[0]
+	projectName := "Swagger2APIProject"
+
+	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestSwagger2DefinitionPath)
 	assert.Nil(t, err, "Error while generating Project")
 	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
 
@@ -115,23 +93,9 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 
 //Initialize an API from OpenAPI 3 Specification
 func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
-	username := superAdminUser
-	password := superAdminPassword
 	apim := apimClients[0]
 	var projectName = "OpenAPI3Project"
-
-	args := &initTestArgs{
-		ctlUser:   credentials{username: username, password: password},
-		srcAPIM:   apim,
-		initFlag:  projectName,
-		oasFlag:   utils.TestOpenAPI3DefinitionPath,
-		forceFlag: false,
-	}
-
-	output, err := initProjectWithOasFlag(t, args)
-	if err != nil {
-		log.Fatal(err)
-	}
+	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
 
 	assert.Nil(t, err, "Error while generating Project")
 	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
@@ -173,3 +137,85 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 	})
 }
 
+//Import API from initialized project with swagger 2 definition
+func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
+	apim := apimClients[0]
+	projectName := "OpenAPI3Project"
+
+	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestSwagger2DefinitionPath)
+	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	assert.Nil(t, err, "Error while generating Project")
+
+	result, error := importApiFromProject(t, projectName, apim.GetEnvName())
+	assert.Nil(t, error, "Error while generating Project")
+	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Import API from initialized project with openAPI 3 definition
+func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
+	apim := apimClients[0]
+	projectName := "OpenAPI3Project"
+
+	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	assert.Nil(t, err, "Error while generating Project")
+
+	result, error := importApiFromProject(t, projectName, apim.GetEnvName())
+	assert.Nil(t, error, "Error while generating Project")
+	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Import API from initialized project from API definition which is already in publisher without --update flag
+func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
+	apim := apimClients[0]
+	projectName := "OpenAPI3Project"
+
+	InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+
+	//Import API for the First time
+	importApiFromProject(t, projectName, apim.GetEnvName())
+
+	//Import API for the second time
+	result, _ := importApiFromProject(t, projectName, apim.GetEnvName())
+	assert.Contains(t, result, "Resource Already Exists", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Import API from initialized project from API definition which is already in publisher with --update flag
+func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
+	apim := apimClients[0]
+	projectName := "OpenAPI3Project"
+
+	InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+
+	//Import API for the First time
+	importApiFromProject(t, projectName, apim.GetEnvName())
+
+	//Import API for the second time
+	result, error := importApiFromProjectWithUpdate(t, projectName, apim.GetEnvName())
+	assert.Nil(t, error, "Error while generating Project")
+	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -84,7 +84,7 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 	password := superAdminPassword
 	apim := apimClients[0]
 	var projectName = "SampleTestAPI2"
-	var swaggerDefinitionFilePath = ""
+	var swaggerDefinitionFilePath = "testdata/swagger2Definition.yaml"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},
@@ -112,7 +112,7 @@ func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	password := superAdminPassword
 	apim := apimClients[0]
 	var projectName = "OpenAPI3"
-	var openAPISpecificationFilePath = ""
+	var openAPISpecificationFilePath = "testdata/openAPI3Definition.yaml"
 
 	args := &initTestArgs{
 		ctlUser:   credentials{username: username, password: password},

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -1,0 +1,163 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"log"
+	"testing"
+)
+
+//Initialize a project Initialize an API without any flag
+func TestInitializeProject(t *testing.T) {
+	username := superAdminUser
+	password := superAdminPassword
+	apim := apimClients[0]
+	var projectName = "SampleTestAPI"
+
+	args := &initTestArgs{
+		ctlUser:  credentials{username: username, password: password},
+		srcAPIM:  apim,
+		initFlag: projectName,
+	}
+
+	output, err := initProject(t, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "TestInitializeProject Failed")
+
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Initialize an API the the definition.yaml (apictl init SampleAPI --definition definition.yaml)
+func TestInitializeProjectWithDefinitionFlag(t *testing.T) {
+	username := superAdminUser
+	password := superAdminPassword
+	apim := apimClients[0]
+	var projectName = "SampleTestAPI2"
+	var definitionFilePath = ""
+
+	args := &initTestArgs{
+		ctlUser:        credentials{username: username, password: password},
+		srcAPIM:        apim,
+		initFlag:       projectName,
+		definitionFlag: definitionFilePath,
+		forceFlag:      true,
+	}
+
+	output, err := initProjectWithDefinitionFlag(t, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Initialize an API from Swagger 2 Specification
+func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
+	username := superAdminUser
+	password := superAdminPassword
+	apim := apimClients[0]
+	var projectName = "SampleTestAPI2"
+	var swaggerDefinitionFilePath = ""
+
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   swaggerDefinitionFilePath,
+		forceFlag: false,
+	}
+
+	output, err := initProjectWithOasFlag(t, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Initialize an API from OpenAPI 3 Specification
+func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
+	username := superAdminUser
+	password := superAdminPassword
+	apim := apimClients[0]
+	var projectName = "OpenAPI3"
+	var openAPISpecificationFilePath = ""
+
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   openAPISpecificationFilePath,
+		forceFlag: false,
+	}
+
+	output, err := initProjectWithOasFlag(t, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}
+
+//Initialize an API from API Specification URL
+func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
+	username := superAdminUser
+	password := superAdminPassword
+	apim := apimClients[0]
+	var projectName = "PetStore"
+	var openAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"
+
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   openAPISpecificationURL,
+		forceFlag: false,
+	}
+
+	output, err := initProjectWithOasFlag(t, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	t.Cleanup(func() {
+		base.Execute(t, "logout", apim.GetEnvName())
+	})
+}

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"log"
 	"testing"
+	"time"
 )
 
 //Initialize a project Initialize an API without any flag
@@ -38,73 +39,76 @@ func TestInitializeProject(t *testing.T) {
 		initFlag: projectName,
 	}
 
+	validateInitializeProject(t, args)
+	//Remove Created project and logout
+	base.RemoveDir(projectName)
+}
+
+func validateInitializeProject(t *testing.T, args *initTestArgs) {
+	t.Helper()
+
 	output, err := initProject(t, args)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	assert.Nil(t, err, "Error while generating Project")
-	assert.Contains(t, output, "Project initialized", "TestInitializeProject Failed")
-
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
+	assert.Contains(t, output, "Project initialized", "Project initialization Failed")
 }
 
 //Function to initialize a project using API definition
-func InitializeAPIFromDefinition(t *testing.T, projectName string, definitionFileName string) (string, error) {
-	username := superAdminUser
-	password := superAdminPassword
-	apim := apimClients[0]
-
-	args := &initTestArgs{
-		ctlUser:   credentials{username: username, password: password},
-		srcAPIM:   apim,
-		initFlag:  projectName,
-		oasFlag:   definitionFileName,
-		forceFlag: false,
-	}
+func validateInitializeProjectWithOASFlag(t *testing.T, args *initTestArgs) {
+	t.Helper()
 
 	output, err := initProjectWithOasFlag(t, args)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	return output, err
+	assert.Nil(t, err, "Error while generating Project")
+	assert.Containsf(t, output, "Project initialized", "Test initialization Failed with --oas flag")
 }
 
 //Initialize an API from Swagger 2 Specification
 func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 	apim := apimClients[0]
 	projectName := "Swagger2APIProject"
+	username := superAdminUser
+	password := superAdminPassword
 
-	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestSwagger2DefinitionPath)
-	assert.Nil(t, err, "Error while generating Project")
-	assert.Containsf(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestSwagger2DefinitionPath,
+		forceFlag: false,
+	}
+
+	validateInitializeProjectWithOASFlag(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }
 
 //Initialize an API from OpenAPI 3 Specification
 func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	apim := apimClients[0]
 	var projectName = "OpenAPI3Project"
-	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+	username := superAdminUser
+	password := superAdminPassword
 
-	assert.Nil(t, err, "Error while generating Project")
-	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestOpenAPI3DefinitionPath,
+		forceFlag: false,
+	}
+
+	validateInitializeProjectWithOASFlag(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }
 
 //Initialize an API from API Specification URL
@@ -122,100 +126,131 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 		forceFlag: false,
 	}
 
-	output, err := initProjectWithOasFlag(t, args)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	assert.Nil(t, err, "Error while generating Project")
-	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
+	validateInitializeProjectWithOASFlag(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
+}
+
+func validateImportInitializedProject(t *testing.T, args *initTestArgs) {
+	t.Helper()
+	//Initialize a project with API definition
+	validateInitializeProjectWithOASFlag(t, args)
+
+	time.Sleep(1 * time.Second)
+
+	result, error := importApiFromProject(t, args.initFlag, args.srcAPIM.GetEnvName())
+	assert.Nil(t, error, "Error while importing Project")
+	assert.Contains(t, result, "Successfully imported API", "Error while importing Project")
+}
+
+func validateImportFailedWithInitializedProject(t *testing.T, args *initTestArgs) {
+	t.Helper()
+
+	result, _ := importApiFromProject(t, args.initFlag, args.srcAPIM.GetEnvName())
+	assert.Contains(t, result, "Resource Already Exists", "Test failed because API is imported successfully")
+}
+
+func validateImportUpdatePassedWithInitializedProject(t *testing.T, args *initTestArgs) {
+	t.Helper()
+
+	result, error := importApiFromProjectWithUpdate(t, args.initFlag, args.srcAPIM.GetEnvName())
+	assert.Nil(t, error, "Error while generating Project")
+	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
 }
 
 //Import API from initialized project with swagger 2 definition
 func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
 	apim := apimClients[0]
-	projectName := "OpenAPI3Project"
+	projectName := "Swagger2Project"
+	username := superAdminUser
+	password := superAdminPassword
 
-	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestSwagger2DefinitionPath)
-	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
-	assert.Nil(t, err, "Error while generating Project")
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestSwagger2DefinitionPath,
+		forceFlag: false,
+	}
 
-	result, error := importApiFromProject(t, projectName, apim.GetEnvName())
-	assert.Nil(t, error, "Error while generating Project")
-	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+	//Assert that project import to publisher portal is successful
+	validateImportInitializedProject(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }
 
 //Import API from initialized project with openAPI 3 definition
 func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	apim := apimClients[0]
 	projectName := "OpenAPI3Project"
+	username := superAdminUser
+	password := superAdminPassword
 
-	output, err := InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
-	assert.Contains(t, output, "Project initialized", "Test InitializeProjectWithDefinitionFlag Failed")
-	assert.Nil(t, err, "Error while generating Project")
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestOpenAPI3DefinitionPath,
+		forceFlag: false,
+	}
 
-	result, error := importApiFromProject(t, projectName, apim.GetEnvName())
-	assert.Nil(t, error, "Error while generating Project")
-	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+	//Assert that project import to publisher portal is successful
+	validateImportInitializedProject(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }
 
 //Import API from initialized project from API definition which is already in publisher without --update flag
 func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
 	apim := apimClients[0]
 	projectName := "OpenAPI3Project"
+	username := superAdminUser
+	password := superAdminPassword
 
-	InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestOpenAPI3DefinitionPath,
+		forceFlag: false,
+	}
 
 	//Import API for the First time
-	importApiFromProject(t, projectName, apim.GetEnvName())
+	validateImportInitializedProject(t, args)
 
+	time.Sleep(1 * time.Second)
 	//Import API for the second time
-	result, _ := importApiFromProject(t, projectName, apim.GetEnvName())
-	assert.Contains(t, result, "Resource Already Exists", "Test InitializeProjectWithDefinitionFlag Failed")
+	validateImportFailedWithInitializedProject(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }
 
 //Import API from initialized project from API definition which is already in publisher with --update flag
 func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	apim := apimClients[0]
 	projectName := "OpenAPI3Project"
+	username := superAdminUser
+	password := superAdminPassword
 
-	InitializeAPIFromDefinition(t, projectName, utils.TestOpenAPI3DefinitionPath)
+	args := &initTestArgs{
+		ctlUser:   credentials{username: username, password: password},
+		srcAPIM:   apim,
+		initFlag:  projectName,
+		oasFlag:   utils.TestOpenAPI3DefinitionPath,
+		forceFlag: false,
+	}
 
 	//Import API for the First time
-	importApiFromProject(t, projectName, apim.GetEnvName())
+	validateImportInitializedProject(t, args)
 
+	time.Sleep(1 * time.Second)
 	//Import API for the second time
-	result, error := importApiFromProjectWithUpdate(t, projectName, apim.GetEnvName())
-	assert.Nil(t, error, "Error while generating Project")
-	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+	validateImportUpdatePassedWithInitializedProject(t, args)
 
 	//Remove Created project and logout
 	base.RemoveDir(projectName)
-	t.Cleanup(func() {
-		base.Execute(t, "logout", apim.GetEnvName())
-	})
 }

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -40,8 +40,7 @@ func TestInitializeProject(t *testing.T) {
 	}
 
 	validateInitializeProject(t, args)
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
+
 }
 
 func validateInitializeProject(t *testing.T, args *initTestArgs) {
@@ -54,6 +53,11 @@ func validateInitializeProject(t *testing.T, args *initTestArgs) {
 
 	assert.Nil(t, err, "Error while generating Project")
 	assert.Contains(t, output, "Project initialized", "Project initialization Failed")
+
+	//Remove Created project and logout
+	t.Cleanup(func() {
+		base.RemoveDir(args.initFlag)
+	})
 }
 
 //Function to initialize a project using API definition
@@ -67,6 +71,13 @@ func validateInitializeProjectWithOASFlag(t *testing.T, args *initTestArgs) {
 
 	assert.Nil(t, err, "Error while generating Project")
 	assert.Containsf(t, output, "Project initialized", "Test initialization Failed with --oas flag")
+
+	//Remove Created project and logout
+
+	t.Cleanup(func() {
+		base.RemoveDir(args.initFlag)
+	})
+
 }
 
 //Initialize an API from Swagger 2 Specification
@@ -86,8 +97,6 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 
 	validateInitializeProjectWithOASFlag(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 //Initialize an API from OpenAPI 3 Specification
@@ -107,8 +116,6 @@ func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 
 	validateInitializeProjectWithOASFlag(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 //Initialize an API from API Specification URL
@@ -128,8 +135,6 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 
 	validateInitializeProjectWithOASFlag(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 func validateImportInitializedProject(t *testing.T, args *initTestArgs) {
@@ -142,21 +147,40 @@ func validateImportInitializedProject(t *testing.T, args *initTestArgs) {
 	result, error := importApiFromProject(t, args.initFlag, args.srcAPIM.GetEnvName())
 	assert.Nil(t, error, "Error while importing Project")
 	assert.Contains(t, result, "Successfully imported API", "Error while importing Project")
+
+	//Remove Created project and logout
+	t.Cleanup(func() {
+		base.RemoveDir(args.initFlag)
+	})
 }
 
 func validateImportFailedWithInitializedProject(t *testing.T, args *initTestArgs) {
 	t.Helper()
 
+	time.Sleep(1 * time.Second)
+
 	result, _ := importApiFromProject(t, args.initFlag, args.srcAPIM.GetEnvName())
 	assert.Contains(t, result, "Resource Already Exists", "Test failed because API is imported successfully")
+
+	//Remove Created project and logout
+	t.Cleanup(func() {
+		base.RemoveDir(args.initFlag)
+	})
 }
 
 func validateImportUpdatePassedWithInitializedProject(t *testing.T, args *initTestArgs) {
 	t.Helper()
 
+	time.Sleep(1 * time.Second)
+
 	result, error := importApiFromProjectWithUpdate(t, args.initFlag, args.srcAPIM.GetEnvName())
 	assert.Nil(t, error, "Error while generating Project")
 	assert.Contains(t, result, "Successfully imported API", "Test InitializeProjectWithDefinitionFlag Failed")
+
+	//Remove Created project and logout
+	t.Cleanup(func() {
+		base.RemoveDir(args.initFlag)
+	})
 }
 
 //Import API from initialized project with swagger 2 definition
@@ -177,8 +201,6 @@ func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
 	//Assert that project import to publisher portal is successful
 	validateImportInitializedProject(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 //Import API from initialized project with openAPI 3 definition
@@ -199,8 +221,6 @@ func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	//Assert that project import to publisher portal is successful
 	validateImportInitializedProject(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 //Import API from initialized project from API definition which is already in publisher without --update flag
@@ -221,12 +241,9 @@ func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
 	//Import API for the First time
 	validateImportInitializedProject(t, args)
 
-	time.Sleep(1 * time.Second)
 	//Import API for the second time
 	validateImportFailedWithInitializedProject(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }
 
 //Import API from initialized project from API definition which is already in publisher with --update flag
@@ -247,10 +264,7 @@ func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	//Import API for the First time
 	validateImportInitializedProject(t, args)
 
-	time.Sleep(1 * time.Second)
 	//Import API for the second time
 	validateImportUpdatePassedWithInitializedProject(t, args)
 
-	//Remove Created project and logout
-	base.RemoveDir(projectName)
 }

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -103,22 +103,3 @@ func TestChangeTokenType(t *testing.T) {
 	assert.Contains(t, output2, "Token type is set to", "1st attempt of Token Type change is not successful")
 }
 
-//Login to the environment using email and logout
-func TestLoginWithEmail(t *testing.T) {
-
-	tenantAdminUsername := superAdminUser + "@" + TENANT1
-	tenantAdminPassword := superAdminPassword
-	dev := apimClients[0]
-
-	args := &loginTestArgs{
-		ctlUser: credentials{username: tenantAdminUsername, password: tenantAdminPassword},
-		srcAPIM: dev,
-	}
-	// Setup apictl envs
-	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
-	base.Execute(t, "login", args.srcAPIM.GetEnvName(), "-u", tenantAdminUsername, "-p", tenantAdminPassword, "-k", "--verbose")
-
-	t.Cleanup(func() {
-		base.Execute(t, "logout", args.srcAPIM.GetEnvName())
-	})
-}

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -23,17 +23,17 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"testing"
 )
+
 const defaultExportPath = utils.DefaultExportDirName
 
-
 //List Environments using apictl
-func TestListEnvironments (t *testing.T){
+func TestListEnvironments(t *testing.T) {
 	apim := apimClients[0]
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
 	response, _ := base.Execute(t, "list", "envs")
 	base.GetRowsFromTableResponse(response)
 	base.Log(response)
-	assert.Contains(t,response,apim.GetEnvName(),"TestListEnvironments Failed")
+	assert.Contains(t, response, apim.GetEnvName(), "TestListEnvironments Failed")
 }
 
 //Change Export directory using apictl and assert the change
@@ -43,7 +43,7 @@ func TestChangeExportDirectory(t *testing.T) {
 	defaultExportPath := utils.DefaultExportDirPath
 
 	args := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:             apim,
 		exportDirectoryFlag: changedExportDirectory,
 	}
 	output, _ := environmentSetExportDirectory(t, args)
@@ -51,20 +51,20 @@ func TestChangeExportDirectory(t *testing.T) {
 
 	//Change value back to default value
 	argsDefault := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:             apim,
 		exportDirectoryFlag: defaultExportPath,
 	}
 	environmentSetExportDirectory(t, argsDefault)
-	assert.Contains(t,output,"Token type set to:  JWT","Export Directory change is not successful")
+	assert.Contains(t, output, "Token type set to:  JWT", "Export Directory change is not successful")
 }
 
 //Change HTTP request Timeout using apictl and assert the change
 func TestChangeHttpRequestTimout(t *testing.T) {
 	apim := apimClients[0]
-	defaultHttpRequestTimeOut:=utils.DefaultHttpRequestTimeout
+	defaultHttpRequestTimeOut := utils.DefaultHttpRequestTimeout
 	newHttpRequestTimeOut := 20000
 	args := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:            apim,
 		httpRequestTimeout: newHttpRequestTimeOut,
 	}
 	output, _ := environmentSetHttpRequestTimeout(t, args)
@@ -72,11 +72,11 @@ func TestChangeHttpRequestTimout(t *testing.T) {
 
 	//Change value back to default value
 	argsDefault := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:            apim,
 		httpRequestTimeout: defaultHttpRequestTimeOut,
 	}
 	environmentSetHttpRequestTimeout(t, argsDefault)
-	assert.Contains(t,output,"Token type set to:  JWT","HTTP Request TimeOut change is not successful")
+	assert.Contains(t, output, "Token type set to:  JWT", "HTTP Request TimeOut change is not successful")
 }
 
 //Change Token type using apictl and assert the change (for both "jwt" and "oauth" token types)
@@ -85,34 +85,34 @@ func TestChangeTokenType(t *testing.T) {
 
 	tokenType1 := "Oauth"
 	args := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:       apim,
 		tokenTypeFlag: tokenType1,
 	}
-	output, _ := environmentSetHttpRequestTimeout(t, args)
+	output, _ := environmentSetTokenType(t, args)
 	base.Log(output)
-	assert.Contains(t,output,"Token type set to:  JWT","1st attempt of Token Type change is not successful")
+	assert.Contains(t, output, "Token type set to:  JWT", "1st attempt of Token Type change is not successful")
 	tokenType2 := "JWT"
 
 	//Change value back to default value with a test
 	argsDefault := &setTestArgs{
-		srcAPIM: apim,
+		srcAPIM:       apim,
 		tokenTypeFlag: tokenType2,
 	}
-	output2, _ := environmentSetHttpRequestTimeout(t, argsDefault)
+	output2, _ := environmentSetTokenType(t, argsDefault)
 	base.Log(output2)
-	assert.Contains(t,output2,"Token type set to:  JWT","1st attempt of Token Type change is not successful")
+	assert.Contains(t, output2, "Token type set to:  JWT", "1st attempt of Token Type change is not successful")
 }
 
 //Login to the environment using email and logout
-func TestLoginWithEmail (t *testing.T){
+func TestLoginWithEmail(t *testing.T) {
 
 	tenantAdminUsername := superAdminUser + "@" + TENANT1
 	tenantAdminPassword := superAdminPassword
 	dev := apimClients[0]
 
 	args := &loginTestArgs{
-		ctlUser:     credentials{username: tenantAdminUsername, password: tenantAdminPassword},
-		srcAPIM:  dev,
+		ctlUser: credentials{username: tenantAdminUsername, password: tenantAdminPassword},
+		srcAPIM: dev,
 	}
 	// Setup apictl envs
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -55,7 +55,7 @@ func TestChangeExportDirectory(t *testing.T) {
 		exportDirectoryFlag: defaultExportPath,
 	}
 	environmentSetExportDirectory(t, argsDefault)
-	assert.Contains(t, output, "Token type set to:  JWT", "Export Directory change is not successful")
+	assert.Contains(t, output, "Export Directory is set to", "Export Directory change is not successful")
 }
 
 //Change HTTP request Timeout using apictl and assert the change
@@ -76,22 +76,22 @@ func TestChangeHttpRequestTimout(t *testing.T) {
 		httpRequestTimeout: defaultHttpRequestTimeOut,
 	}
 	environmentSetHttpRequestTimeout(t, argsDefault)
-	assert.Contains(t, output, "Token type set to:  JWT", "HTTP Request TimeOut change is not successful")
+	assert.Contains(t, output, "Http Request Timout is set to", "HTTP Request TimeOut change is not successful")
 }
 
 //Change Token type using apictl and assert the change (for both "jwt" and "oauth" token types)
 func TestChangeTokenType(t *testing.T) {
 	apim := apimClients[0]
 
-	tokenType1 := "Oauth"
+	tokenType1 := "oauth"
 	args := &setTestArgs{
 		srcAPIM:       apim,
 		tokenTypeFlag: tokenType1,
 	}
 	output, _ := environmentSetTokenType(t, args)
 	base.Log(output)
-	assert.Contains(t, output, "Token type set to:  JWT", "1st attempt of Token Type change is not successful")
-	tokenType2 := "JWT"
+	assert.Contains(t, output, "Token type is set to", "1st attempt of Token Type change is not successful")
+	tokenType2 := "jwt"
 
 	//Change value back to default value with a test
 	argsDefault := &setTestArgs{
@@ -100,7 +100,7 @@ func TestChangeTokenType(t *testing.T) {
 	}
 	output2, _ := environmentSetTokenType(t, argsDefault)
 	base.Log(output2)
-	assert.Contains(t, output2, "Token type set to:  JWT", "1st attempt of Token Type change is not successful")
+	assert.Contains(t, output2, "Token type is set to", "1st attempt of Token Type change is not successful")
 }
 
 //Login to the environment using email and logout

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -32,43 +32,75 @@ func TestListEnvironments (t *testing.T){
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
 	response, _ := base.Execute(t, "list", "envs")
 	base.GetRowsFromTableResponse(response)
+	base.Log(response)
 	assert.Contains(t,response,apim.GetEnvName(),"TestListEnvironments Failed")
 }
 
 //Change Export directory using apictl and assert the change
 func TestChangeExportDirectory(t *testing.T) {
 	apim := apimClients[0]
-	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	var changedExportDirectory = "/testingPath/" + utils.DefaultExportDirName
-	output, _ := base.Execute(t, "set",  "---export-directory ", changedExportDirectory, "-k", "--verbose")
+	changedExportDirectory := utils.MockTestExportDirectory + utils.DefaultExportDirName
+	defaultExportPath := utils.DefaultExportDirPath
+
+	args := &setTestArgs{
+		srcAPIM: apim,
+		exportDirectoryFlag: changedExportDirectory,
+	}
+	output, _ := environmentSetExportDirectory(t, args)
 	base.Log(output)
-	assert.Equal(t,changedExportDirectory,utils.DefaultExportDirPath,"Export Directory change is not successful")
+
+	//Change value back to default value
+	argsDefault := &setTestArgs{
+		srcAPIM: apim,
+		exportDirectoryFlag: defaultExportPath,
+	}
+	environmentSetExportDirectory(t, argsDefault)
+	assert.Contains(t,output,"Token type set to:  JWT","Export Directory change is not successful")
 }
 
 //Change HTTP request Timeout using apictl and assert the change
 func TestChangeHttpRequestTimout(t *testing.T) {
 	apim := apimClients[0]
-	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
-	var newHttpRequestTimeOut = 20000
-	output, _ := base.Execute(t, "set",  "--http-request-timeout ", string(newHttpRequestTimeOut), "-k", "--verbose")
+	defaultHttpRequestTimeOut:=utils.DefaultHttpRequestTimeout
+	newHttpRequestTimeOut := 20000
+	args := &setTestArgs{
+		srcAPIM: apim,
+		httpRequestTimeout: newHttpRequestTimeOut,
+	}
+	output, _ := environmentSetHttpRequestTimeout(t, args)
 	base.Log(output)
-	assert.Equal(t,newHttpRequestTimeOut,configVars.Config.HttpRequestTimeout,"HTTP Request TimeOut change is not successful")
+
+	//Change value back to default value
+	argsDefault := &setTestArgs{
+		srcAPIM: apim,
+		httpRequestTimeout: defaultHttpRequestTimeOut,
+	}
+	environmentSetHttpRequestTimeout(t, argsDefault)
+	assert.Contains(t,output,"Token type set to:  JWT","HTTP Request TimeOut change is not successful")
 }
 
 //Change Token type using apictl and assert the change (for both "jwt" and "oauth" token types)
 func TestChangeTokenType(t *testing.T) {
 	apim := apimClients[0]
-	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
-	var tokenType1 = "Oauth"
-	output1, _ := base.Execute(t, "set",  "--token-type",tokenType1 , "-k", "--verbose")
-	base.Log(output1)
-	assert.Equal(t,tokenType1,configVars.Config.TokenType,"1st attempt of Token Type change is not successful")
-	var tokenType2 = "JWT"
-	output2, _ := base.Execute(t, "set",  "--token-type",tokenType2 , "-k", "--verbose")
+
+	tokenType1 := "Oauth"
+	args := &setTestArgs{
+		srcAPIM: apim,
+		tokenTypeFlag: tokenType1,
+	}
+	output, _ := environmentSetHttpRequestTimeout(t, args)
+	base.Log(output)
+	assert.Contains(t,output,"Token type set to:  JWT","1st attempt of Token Type change is not successful")
+	tokenType2 := "JWT"
+
+	//Change value back to default value with a test
+	argsDefault := &setTestArgs{
+		srcAPIM: apim,
+		tokenTypeFlag: tokenType2,
+	}
+	output2, _ := environmentSetHttpRequestTimeout(t, argsDefault)
 	base.Log(output2)
-	assert.Equal(t,tokenType2,configVars.Config.TokenType,"2nd attempt of Token Type change is not successful")
+	assert.Contains(t,output2,"Token type set to:  JWT","1st attempt of Token Type change is not successful")
 }
 
 //Login to the environment using email and logout

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -1,0 +1,92 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package integration
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"testing"
+)
+const defaultExportPath = utils.DefaultExportDirName
+
+
+//List Environments using apictl
+func TestListEnvironments (t *testing.T){
+	apim := apimClients[0]
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	response, _ := base.Execute(t, "list", "envs")
+	base.GetRowsFromTableResponse(response)
+	assert.Contains(t,response,apim.GetEnvName(),"TestListEnvironments Failed")
+}
+
+//Change Export directory using apictl and assert the change
+func TestChangeExportDirectory(t *testing.T) {
+	apim := apimClients[0]
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	var changedExportDirectory = "/testingPath/" + utils.DefaultExportDirName
+	output, _ := base.Execute(t, "set",  "---export-directory ", changedExportDirectory, "-k", "--verbose")
+	base.Log(output)
+	assert.Equal(t,changedExportDirectory,utils.DefaultExportDirPath,"Export Directory change is not successful")
+}
+
+//Change HTTP request Timeout using apictl and assert the change
+func TestChangeHttpRequestTimout(t *testing.T) {
+	apim := apimClients[0]
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
+	var newHttpRequestTimeOut = 20000
+	output, _ := base.Execute(t, "set",  "--http-request-timeout ", string(newHttpRequestTimeOut), "-k", "--verbose")
+	base.Log(output)
+	assert.Equal(t,newHttpRequestTimeOut,configVars.Config.HttpRequestTimeout,"HTTP Request TimeOut change is not successful")
+}
+
+//Change Token type using apictl and assert the change (for both "jwt" and "oauth" token types)
+func TestChangeTokenType(t *testing.T) {
+	apim := apimClients[0]
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
+	var tokenType1 = "Oauth"
+	output1, _ := base.Execute(t, "set",  "--token-type",tokenType1 , "-k", "--verbose")
+	base.Log(output1)
+	assert.Equal(t,tokenType1,configVars.Config.TokenType,"1st attempt of Token Type change is not successful")
+	var tokenType2 = "JWT"
+	output2, _ := base.Execute(t, "set",  "--token-type",tokenType2 , "-k", "--verbose")
+	base.Log(output2)
+	assert.Equal(t,tokenType2,configVars.Config.TokenType,"2nd attempt of Token Type change is not successful")
+}
+
+//Login to the environment using email and logout
+func TestLoginWithEmail (t *testing.T){
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+	dev := apimClients[0]
+
+	args := &loginTestArgs{
+		ctlUser:     credentials{username: tenantAdminUsername, password: tenantAdminPassword},
+		srcAPIM:  dev,
+	}
+	// Setup apictl envs
+	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
+	base.Execute(t, "login", args.srcAPIM.GetEnvName(), "-u", tenantAdminUsername, "-p", tenantAdminPassword, "-k", "--verbose")
+
+	t.Cleanup(func() {
+		base.Execute(t, "logout", args.srcAPIM.GetEnvName())
+	})
+}

--- a/import-export-cli/integration/testTypes.go
+++ b/import-export-cli/integration/testTypes.go
@@ -60,23 +60,23 @@ type apiGetKeyTestArgs struct {
 }
 
 type loginTestArgs struct {
-	ctlUser     credentials
-	srcAPIM     *apim.Client
+	ctlUser credentials
+	srcAPIM *apim.Client
 }
 
 type setTestArgs struct {
-	srcAPIM     *apim.Client
-	exportDirectoryFlag  string
-	modeFlag             string
-	tokenTypeFlag        string
-	httpRequestTimeout   int
+	srcAPIM             *apim.Client
+	exportDirectoryFlag string
+	modeFlag            string
+	tokenTypeFlag       string
+	httpRequestTimeout  int
 }
 
 type initTestArgs struct {
-	ctlUser credentials
-	srcAPIM     *apim.Client
-	initFlag        string
-	definitionFlag  string
-	forceFlag       bool
-	oasFlag         string
+	ctlUser        credentials
+	srcAPIM        *apim.Client
+	initFlag       string
+	definitionFlag string
+	forceFlag      bool
+	oasFlag        string
 }

--- a/import-export-cli/integration/testTypes.go
+++ b/import-export-cli/integration/testTypes.go
@@ -64,7 +64,14 @@ type loginTestArgs struct {
 	srcAPIM     *apim.Client
 }
 
-//TODO init args
+type setTestArgs struct {
+	srcAPIM     *apim.Client
+	exportDirectoryFlag  string
+	modeFlag             string
+	tokenTypeFlag        string
+	httpRequestTimeout   int
+}
+
 type initTestArgs struct {
 	ctlUser credentials
 	srcAPIM     *apim.Client

--- a/import-export-cli/integration/testTypes.go
+++ b/import-export-cli/integration/testTypes.go
@@ -58,3 +58,18 @@ type apiGetKeyTestArgs struct {
 	apiProduct *apim.APIProduct
 	apim       *apim.Client
 }
+
+type loginTestArgs struct {
+	ctlUser     credentials
+	srcAPIM     *apim.Client
+}
+
+//TODO init args
+type initTestArgs struct {
+	ctlUser credentials
+	srcAPIM     *apim.Client
+	initFlag        string
+	definitionFlag  string
+	forceFlag       bool
+	oasFlag         string
+}

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -1175,3 +1175,13 @@ func environmentSetTokenType(t *testing.T,args *setTestArgs) (string, error) {
 	output, error := base.Execute(t, "set","--token-type", strconv.Itoa(args.httpRequestTimeout), "-k")
 	return output,error
 }
+
+func importApiFromProject(t *testing.T, projectName string, envName string) (string, error) {
+	projectPath, _ :=filepath.Abs(projectName)
+	return base.Execute(t,"import-api", "-f",projectPath,"-e",envName,"-k")
+}
+
+func importApiFromProjectWithUpdate(t *testing.T, projectName string, envName string) (string, error) {
+	projectPath, _ :=filepath.Abs(projectName)
+	return base.Execute(t,"import-api", "-f",projectPath,"-e",envName,"-k","--update")
+}

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -273,14 +273,14 @@ func addApp(t *testing.T, client *apim.Client, username string, password string)
 	client.Login(username, password)
 	app := client.GenerateSampleAppData()
 	doClean := true
-	return client.AddApplication(t, app, username, password,doClean)
+	return client.AddApplication(t, app, username, password, doClean)
 }
 
 func addApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
 	client.Login(username, password)
 	application := client.GenerateSampleAppData()
 	doClean := false
-	app := client.AddApplication(t, application, username, password,doClean)
+	app := client.AddApplication(t, application, username, password, doClean)
 	application = client.GetApplication(app.ApplicationID)
 	return application
 }
@@ -332,7 +332,7 @@ func importAppPreserveOwner(t *testing.T, sourceEnv string, app *apim.Applicatio
 
 func importAppPreserveOwnerAndUpdate(t *testing.T, sourceEnv string, app *apim.Application, client *apim.Client) (string, error) {
 	fileName := base.GetApplicationArchiveFilePath(t, sourceEnv, app.Name, app.Owner)
-	output, err := base.Execute(t, "import-app","--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "import-app", "--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
 
 	t.Cleanup(func() {
 		client.DeleteApplicationByName(app.Name)
@@ -1118,7 +1118,7 @@ func validateAPIProductDeleteFailure(t *testing.T, args *apiProductImportExportT
 }
 
 func deleteAppByCtl(t *testing.T, args *appImportExportTestArgs) (string, error) {
-	output, err := base.Execute(t, "delete", "app", "-n", args.application.Name,  "-e", args.srcAPIM.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "delete", "app", "-n", args.application.Name, "-e", args.srcAPIM.EnvName, "-k", "--verbose")
 	return output, err
 }
 
@@ -1128,60 +1128,60 @@ func validateApplicationIsDeleted(t *testing.T, application *apim.Application, a
 	}
 }
 
-func initProject (t *testing.T,args *initTestArgs)(string, error) {
+func initProject(t *testing.T, args *initTestArgs) (string, error) {
 	//Setup Environment and login to it.
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
 	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	output,err:=base.Execute(t,"init", args.initFlag ,)
-	return output,err
+	output, err := base.Execute(t, "init", args.initFlag)
+	return output, err
 }
 
-func initProjectWithDefinitionFlag (t *testing.T,args *initTestArgs)(string, error) {
+func initProjectWithDefinitionFlag(t *testing.T, args *initTestArgs) (string, error) {
 	//Setup Environment and login to it.
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
 	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	output,err:=base.Execute(t,"init", args.initFlag ,"--definition",args.definitionFlag,"--force",strconv.FormatBool(args.forceFlag))
-	return output,err
+	output, err := base.Execute(t, "init", args.initFlag, "--definition", args.definitionFlag, "--force", strconv.FormatBool(args.forceFlag))
+	return output, err
 }
 
-func initProjectWithOasFlag (t *testing.T,args *initTestArgs)(string, error) {
+func initProjectWithOasFlag(t *testing.T, args *initTestArgs) (string, error) {
 	//Setup Environment and login to it.
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
 	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	output,err:=base.Execute(t,"init", args.initFlag ,"--oas",args.oasFlag)
-	return output,err
+	output, err := base.Execute(t, "init", args.initFlag, "--oas", args.oasFlag)
+	return output, err
 }
 
-func environmentSetExportDirectory (t *testing.T,args *setTestArgs) (string, error) {
+func environmentSetExportDirectory(t *testing.T, args *setTestArgs) (string, error) {
 	apim := args.srcAPIM
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	output, error := base.Execute(t, "set","--export-directory", args.exportDirectoryFlag, "-k")
-	return output,error
+	output, error := base.Execute(t, "set", "--export-directory", args.exportDirectoryFlag, "-k")
+	return output, error
 }
 
-func environmentSetHttpRequestTimeout(t *testing.T,args *setTestArgs) (string, error) {
+func environmentSetHttpRequestTimeout(t *testing.T, args *setTestArgs) (string, error) {
 	apim := args.srcAPIM
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	output, error := base.Execute(t, "set","--http-request-timeout", strconv.Itoa(args.httpRequestTimeout), "-k")
-	return output,error
+	output, error := base.Execute(t, "set", "--http-request-timeout", strconv.Itoa(args.httpRequestTimeout), "-k")
+	return output, error
 }
 
-func environmentSetTokenType(t *testing.T,args *setTestArgs) (string, error) {
+func environmentSetTokenType(t *testing.T, args *setTestArgs) (string, error) {
 	apim := args.srcAPIM
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	output, error := base.Execute(t, "set","--token-type", args.tokenTypeFlag, "-k")
-	return output,error
+	output, error := base.Execute(t, "set", "--token-type", args.tokenTypeFlag, "-k")
+	return output, error
 }
 
 func importApiFromProject(t *testing.T, projectName string, envName string) (string, error) {
-	projectPath, _ :=filepath.Abs(projectName)
-	return base.Execute(t,"import-api", "-f",projectPath,"-e",envName,"-k")
+	projectPath, _ := filepath.Abs(projectName)
+	return base.Execute(t, "import-api", "-f", projectPath, "-e", envName, "-k")
 }
 
 func importApiFromProjectWithUpdate(t *testing.T, projectName string, envName string) (string, error) {
-	projectPath, _ :=filepath.Abs(projectName)
-	return base.Execute(t,"import-api", "-f",projectPath,"-e",envName,"-k","--update")
+	projectPath, _ := filepath.Abs(projectName)
+	return base.Execute(t, "import-api", "-f", projectPath, "-e", envName, "-k", "--update")
 }

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -334,10 +334,6 @@ func importAppPreserveOwnerAndUpdate(t *testing.T, sourceEnv string, app *apim.A
 	fileName := base.GetApplicationArchiveFilePath(t, sourceEnv, app.Name, app.Owner)
 	output, err := base.Execute(t, "import-app", "--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
 
-	t.Cleanup(func() {
-		client.DeleteApplicationByName(app.Name)
-	})
-
 	return output, err
 }
 
@@ -1184,4 +1180,9 @@ func importApiFromProject(t *testing.T, projectName string, envName string) (str
 func importApiFromProjectWithUpdate(t *testing.T, projectName string, envName string) (string, error) {
 	projectPath, _ := filepath.Abs(projectName)
 	return base.Execute(t, "import-api", "-f", projectPath, "-e", envName, "-k", "--update")
+}
+
+func exportApisWithOneCommand(t *testing.T, args *initTestArgs) (string, error) {
+	output, error := base.Execute(t, "export-apis", "-e", args.srcAPIM.GetEnvName(), "-k")
+	return output, error
 }

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -1140,7 +1140,7 @@ func initProjectWithDefinitionFlag (t *testing.T,args *initTestArgs)(string, err
 	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
 	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
 
-	output,err:=base.Execute(t,"init", args.initFlag ,"--definition",args.definitionFlag,"--force",args.forceFlag)
+	output,err:=base.Execute(t,"init", args.initFlag ,"--definition",args.definitionFlag,"--force",strconv.FormatBool(args.forceFlag))
 	return output,err
 }
 

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -101,6 +101,14 @@ func addAPIWithoutCleaning(t *testing.T, client *apim.Client, username string, p
 	return api
 }
 
+func addApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
+	client.Login(username, password)
+	application := client.GenerateSampleAppData()
+	app := client.AddApplication(t, application, username, password)
+	application = client.GetApplication(app.ApplicationID)
+	return application
+}
+
 func addAPIToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
 	client1.Login(username, password)
 	api := client1.GenerateSampleAPIData(username)
@@ -320,6 +328,17 @@ func importAppPreserveOwner(t *testing.T, sourceEnv string, app *apim.Applicatio
 	return output, err
 }
 
+func importAppPreserveOwnerAndUpdate(t *testing.T, sourceEnv string, app *apim.Application, client *apim.Client) (string, error) {
+	fileName := base.GetApplicationArchiveFilePath(t, sourceEnv, app.Name, app.Owner)
+	output, err := base.Execute(t, "import-app","--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
+
+	t.Cleanup(func() {
+		client.DeleteApplicationByName(app.Name)
+	})
+
+	return output, err
+}
+
 func exportAPI(t *testing.T, name string, version string, provider string, env string) (string, error) {
 	var output string
 	var err error
@@ -482,7 +501,7 @@ func validateAppExportFailure(t *testing.T, args *appImportExportTestArgs) {
 		args.application.Name, args.appOwner.username))
 }
 
-func validateAppExportImport(t *testing.T, args *appImportExportTestArgs) {
+func validateAppExportImportWithPreserveOwner(t *testing.T, args *appImportExportTestArgs) {
 	t.Helper()
 
 	// Setup apictl envs
@@ -509,6 +528,33 @@ func validateAppExportImport(t *testing.T, args *appImportExportTestArgs) {
 	validateAppsEqual(t, args.application, importedApp)
 }
 
+func validateAppExportImportWithUpdate(t *testing.T, args *appImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL(), args.srcAPIM.GetTokenURL())
+	base.SetupEnv(t, args.destAPIM.GetEnvName(), args.destAPIM.GetApimURL(), args.destAPIM.GetTokenURL())
+
+	// Export app from env 1
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	exportApp(t, args.application.Name, args.appOwner.username, args.srcAPIM.GetEnvName())
+
+	assert.True(t, base.IsApplicationArchiveExists(t, getEnvAppExportPath(args.srcAPIM.GetEnvName()),
+		args.application.Name, args.appOwner.username))
+
+	// Import app to env 2
+	base.Login(t, args.destAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	importAppPreserveOwnerAndUpdate(t, args.srcAPIM.GetEnvName(), args.application, args.destAPIM)
+
+	// Get App from env 2
+	importedApp := getApp(t, args.destAPIM, args.application.Name, args.appOwner.username, args.appOwner.password)
+
+	// Validate env 1 and env 2 App is equal
+	validateAppsEqual(t, args.application, importedApp)
+}
+
 func validateAppsEqual(t *testing.T, app1 *apim.Application, app2 *apim.Application) {
 	t.Helper()
 
@@ -516,7 +562,7 @@ func validateAppsEqual(t *testing.T, app1 *apim.Application, app2 *apim.Applicat
 	app2Copy := apim.CopyApp(app2)
 
 	// Since the Applications are from too different envs, their respective ApplicationID will defer.
-	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	// Therefore this will be overridden to the same value to ensure that the equality check will pass.
 	app1Copy.ApplicationID = "override_with_same_value"
 	app2Copy.ApplicationID = app1Copy.ApplicationID
 
@@ -679,7 +725,7 @@ func validateAPIsEqualCrossTenant(t *testing.T, api1 *apim.API, api2 *apim.API) 
 
 	same := "override_with_same_value"
 	// Since the APIs are from too different envs, their respective ID will defer.
-	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	// Therefore this will be overridden to the same value to ensure that the equality check will pass.
 	api1Copy.ID = same
 	api2Copy.ID = same
 
@@ -690,14 +736,14 @@ func validateAPIsEqualCrossTenant(t *testing.T, api1 *apim.API, api2 *apim.API) 
 	api2Copy.LastUpdatedTime = same
 
 	// The contexts and providers will differ since this is a cross tenant import
-	// Therefore this will be overriden to the same value to ensure that the equality check will pass.
+	// Therefore this will be overridden to the same value to ensure that the equality check will pass.
 	api1Copy.Context = same
 	api2Copy.Context = same
 
 	api1Copy.Provider = same
 	api2Copy.Provider = same
 
-	// Sort member collections to make equality chack possible
+	// Sort member collections to make equality check possible
 	apim.SortAPIMembers(&api1Copy)
 	apim.SortAPIMembers(&api2Copy)
 
@@ -1067,4 +1113,42 @@ func validateAPIProductDeleteFailure(t *testing.T, args *apiProductImportExportT
 	apiProductsListAfterDelete := args.srcAPIM.GetAPIProducts()
 
 	assert.Equal(t, apiProductsListBeforeDelete.Count, apiProductsListAfterDelete.Count, "API Product delete is successful")
+}
+
+func deleteAppByCtl(t *testing.T, args *appImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "delete", "app", "-n", args.application.Name,  "-e", args.srcAPIM.EnvName, "-k", "--verbose")
+	return output, err
+}
+
+func validateApplicationIsDeleted(t *testing.T, application *apim.Application, appsListAfterDelete *apim.ApplicationList) {
+	for _, existingApplication := range appsListAfterDelete.List {
+		assert.NotEqual(t, existingApplication.ApplicationID, application.ApplicationID, "API delete is not successful")
+	}
+}
+
+func initProject (t *testing.T,args *initTestArgs)(string, error) {
+	//Setup Environment and login to it.
+	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	output,err:=base.Execute(t,"init", args.initFlag ,)
+	return output,err
+}
+
+func initProjectWithDefinitionFlag (t *testing.T,args *initTestArgs)(string, error) {
+	//Setup Environment and login to it.
+	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	output,err:=base.Execute(t,"init", args.initFlag ,"--definition",args.definitionFlag,"--force",args.forceFlag)
+	return output,err
+}
+
+func initProjectWithOasFlag (t *testing.T,args *initTestArgs)(string, error) {
+	//Setup Environment and login to it.
+	base.SetupEnvWithoutTokenFlag(t, args.srcAPIM.GetEnvName(), args.srcAPIM.GetApimURL())
+	base.Login(t, args.srcAPIM.GetEnvName(), args.ctlUser.username, args.ctlUser.password)
+
+	output,err:=base.Execute(t,"init", args.initFlag ,"--oas",args.oasFlag)
+	return output,err
 }

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -1172,7 +1172,7 @@ func environmentSetHttpRequestTimeout(t *testing.T,args *setTestArgs) (string, e
 func environmentSetTokenType(t *testing.T,args *setTestArgs) (string, error) {
 	apim := args.srcAPIM
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	output, error := base.Execute(t, "set","--token-type", strconv.Itoa(args.httpRequestTimeout), "-k")
+	output, error := base.Execute(t, "set","--token-type", args.tokenTypeFlag, "-k")
 	return output,error
 }
 

--- a/import-export-cli/integration/testUtils.go
+++ b/import-export-cli/integration/testUtils.go
@@ -101,14 +101,6 @@ func addAPIWithoutCleaning(t *testing.T, client *apim.Client, username string, p
 	return api
 }
 
-func addApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
-	client.Login(username, password)
-	application := client.GenerateSampleAppData()
-	app := client.AddApplication(t, application, username, password)
-	application = client.GetApplication(app.ApplicationID)
-	return application
-}
-
 func addAPIToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
 	client1.Login(username, password)
 	api := client1.GenerateSampleAPIData(username)
@@ -280,7 +272,17 @@ func validateGetKeys(t *testing.T, args *apiGetKeyTestArgs) {
 func addApp(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
 	client.Login(username, password)
 	app := client.GenerateSampleAppData()
-	return client.AddApplication(t, app, username, password)
+	doClean := true
+	return client.AddApplication(t, app, username, password,doClean)
+}
+
+func addApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
+	client.Login(username, password)
+	application := client.GenerateSampleAppData()
+	doClean := false
+	app := client.AddApplication(t, application, username, password,doClean)
+	application = client.GetApplication(app.ApplicationID)
+	return application
 }
 
 func getApp(t *testing.T, client *apim.Client, name string, username string, password string) *apim.Application {
@@ -1151,4 +1153,25 @@ func initProjectWithOasFlag (t *testing.T,args *initTestArgs)(string, error) {
 
 	output,err:=base.Execute(t,"init", args.initFlag ,"--oas",args.oasFlag)
 	return output,err
+}
+
+func environmentSetExportDirectory (t *testing.T,args *setTestArgs) (string, error) {
+	apim := args.srcAPIM
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	output, error := base.Execute(t, "set","--export-directory", args.exportDirectoryFlag, "-k")
+	return output,error
+}
+
+func environmentSetHttpRequestTimeout(t *testing.T,args *setTestArgs) (string, error) {
+	apim := args.srcAPIM
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	output, error := base.Execute(t, "set","--http-request-timeout", strconv.Itoa(args.httpRequestTimeout), "-k")
+	return output,error
+}
+
+func environmentSetTokenType(t *testing.T,args *setTestArgs) (string, error) {
+	apim := args.srcAPIM
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	output, error := base.Execute(t, "set","--token-type", strconv.Itoa(args.httpRequestTimeout), "-k")
+	return output,error
 }

--- a/import-export-cli/integration/testdata/openAPI3Definition.yaml
+++ b/import-export-cli/integration/testdata/openAPI3Definition.yaml
@@ -1,0 +1,273 @@
+  openapi: "3.0.0"
+  info: 
+    title: "Swagger Petstore New"
+    description: "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
+    termsOfService: "http://swagger.io/terms/"
+    contact: 
+      email: "apiteam@swagger.io"
+    license: 
+      name: "Apache 2.0"
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+    version: "1.0.0"
+  servers: 
+    - 
+      url: "https://petstore.swagger.io/v2"
+    - 
+      url: "http://petstore.swagger.io/v2"
+  tags: 
+    - 
+      name: "pet"
+      description: "Everything about your Pets"
+      externalDocs: 
+        description: "Find out more"
+        url: "http://swagger.io"
+    - 
+      name: "store"
+      description: "Access to Petstore orders"
+    - 
+      name: "user"
+      description: "Operations about user"
+      externalDocs: 
+        description: "Find out more about our store"
+        url: "http://swagger.io"
+  paths: 
+    /pet/findByStatus: 
+      get: 
+        tags: 
+          - "pet"
+        summary: "Finds Pets by status"
+        description: "Multiple status values can be provided with comma separated strings"
+        operationId: "findPetsByStatus"
+        parameters: 
+          - 
+            name: "status"
+            in: "query"
+            description: "Status values that need to be considered for filter"
+            required: true
+            style: "form"
+            explode: true
+            schema: 
+              type: "array"
+              items: 
+                type: "string"
+                enum: 
+                  - "available"
+                  - "pending"
+                  - "sold"
+                default: "available"
+        responses: 
+          200: 
+            description: "successful operation"
+            content: 
+              application/xml: 
+                schema: 
+                  type: "array"
+                  items: 
+                    $ref: "#/components/schemas/Pet"
+              application/json: 
+                schema: 
+                  type: "array"
+                  items: 
+                    $ref: "#/components/schemas/Pet"
+          400: 
+            description: "Invalid status value"
+        security: 
+          - 
+            default: []
+        x-auth-type: "Application & Application User"
+        x-throttling-tier: "Unlimited"
+        x-wso2-application-security: 
+          security-types: 
+            - "oauth2"
+          optional: false
+    /pet/{petId}: 
+      get: 
+        tags: 
+          - "pet"
+        summary: "Find pet by ID"
+        description: "Returns a single pet"
+        operationId: "getPetById"
+        parameters: 
+          - 
+            name: "petId"
+            in: "path"
+            description: "ID of pet to return"
+            required: true
+            style: "simple"
+            explode: false
+            schema: 
+              type: "integer"
+              format: "int64"
+        responses: 
+          200: 
+            description: "successful operation"
+            content: 
+              application/xml: 
+                schema: 
+                  $ref: "#/components/schemas/Pet"
+              application/json: 
+                schema: 
+                  $ref: "#/components/schemas/Pet"
+          400: 
+            description: "Invalid ID supplied"
+          404: 
+            description: "Pet not found"
+        security: 
+          - 
+            foo: 
+              - "otest"
+          -
+            outh: 
+              - "test"
+        x-auth-type: "Application & Application User"
+        x-throttling-tier: "Unlimited"
+        x-wso2-application-security: 
+          security-types: 
+            - "oauth2"
+          optional: false
+    /pet/getNames: 
+      get: 
+        parameters: []
+        responses: 
+          200: 
+            description: "ok"
+        security: 
+          - 
+            default: 
+              - "test3"
+        x-auth-type: "Application & Application User"
+        x-throttling-tier: null
+        x-wso2-application-security: 
+          security-types: 
+            - "oauth2"
+          optional: false
+  components: 
+    schemas: 
+      Category: 
+        type: "object"
+        properties: 
+          id: 
+            type: "integer"
+            format: "int64"
+          name: 
+            type: "string"
+        xml: 
+          name: "Category"
+      Tag: 
+        type: "object"
+        properties: 
+          id: 
+            type: "integer"
+            format: "int64"
+          name: 
+            type: "string"
+        xml: 
+          name: "Tag"
+      Pet: 
+        required: 
+          - "name"
+          - "photoUrls"
+        type: "object"
+        properties: 
+          id: 
+            type: "integer"
+            format: "int64"
+          category: 
+            $ref: "#/components/schemas/Category"
+          name: 
+            type: "string"
+            example: "doggie"
+          photoUrls: 
+            type: "array"
+            xml: 
+              name: "photoUrl"
+              wrapped: true
+            items: 
+              type: "string"
+          tags: 
+            type: "array"
+            xml: 
+              name: "tag"
+              wrapped: true
+            items: 
+              $ref: "#/components/schemas/Tag"
+          status: 
+            type: "string"
+            description: "pet status in the store"
+            enum: 
+              - "available"
+              - "pending"
+              - "sold"
+        xml: 
+          name: "Pet"
+    requestBodies: 
+      Pet: 
+        description: "Pet object that needs to be added to the store"
+        content: 
+          application/json: 
+            schema: 
+              $ref: "#/components/schemas/Pet"
+          application/xml: 
+            schema: 
+              $ref: "#/components/schemas/Pet"
+        required: true
+    securitySchemes: 
+      outh: 
+        type: "oauth2"
+        flows: 
+          implicit: 
+            authorizationUrl: "https://test.com"
+            scopes: 
+              test: ""
+            x-scopes-bindings: 
+              test: "admin"
+      default: 
+        type: "oauth2"
+        flows: 
+          implicit: 
+            authorizationUrl: "https://test.com"
+            scopes: 
+              read: ""
+              test3: ""
+              test4: ""
+            x-scopes-bindings: 
+              test4: "admin"
+              read: "admin"
+              test3: "admin"
+      foo: 
+        type: "oauth2"
+        flows: 
+          implicit: 
+            authorizationUrl: "https://test1.com"
+            scopes: 
+              test1: ""
+              otest: ""
+            x-scopes-bindings: 
+              test1: "admin"
+              otest: "admin"
+  x-wso2-auth-header: "Authorization"
+  x-wso2-cors: 
+    corsConfigurationEnabled: false
+    accessControlAllowOrigins: 
+      - "*"
+    accessControlAllowCredentials: false
+    accessControlAllowHeaders: 
+      - "authorization"
+      - "Access-Control-Allow-Origin"
+      - "Content-Type"
+      - "SOAPAction"
+      - "apikey"
+    accessControlAllowMethods: 
+      - "GET"
+      - "PUT"
+      - "POST"
+      - "DELETE"
+      - "PATCH"
+      - "OPTIONS"
+  x-wso2-basePath: "/test/1.0.0"
+  x-wso2-transports: 
+    - "http"
+    - "https"
+  x-wso2-response-cache: 
+    enabled: false
+    cacheTimeoutInSeconds: 300

--- a/import-export-cli/integration/testdata/swagger2Definition.yaml
+++ b/import-export-cli/integration/testdata/swagger2Definition.yaml
@@ -1,0 +1,770 @@
+swagger: "2.0"
+info:
+  description: |
+    This is a RESTFul API for Pizza Shack online pizza delivery store.
+  version: 1.0.0
+  title: PizzaShackAPI
+  contact:
+    name: John Doe
+    url: http://www.pizzashack.com
+    email: architecture@pizzashack.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+schemes:
+- https
+consumes:
+- application/json
+produces:
+- application/json
+security:
+- default: []
+paths:
+  /order:
+    post:
+      description: Create a new Order
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        description: Order object that needs to be added
+        required: true
+        schema:
+          required:
+          - orderId
+          properties:
+            customerName:
+              type: string
+            delivered:
+              type: boolean
+            address:
+              type: string
+            pizzaType:
+              type: string
+            creditCardNumber:
+              type: string
+            quantity:
+              type: number
+            orderId:
+              type: string
+          title: Pizza Order
+      responses:
+        "201":
+          description: Created. Successful response with the newly created object
+            as entity inthe body. Location header contains URL of newly created entity.
+          headers:
+            Location:
+              type: string
+              description: The URL of the newly created resource.
+            Content-Type:
+              type: string
+              description: The content type of the body.
+          schema:
+            required:
+            - orderId
+            properties:
+              customerName:
+                type: string
+              delivered:
+                type: boolean
+              address:
+                type: string
+              pizzaType:
+                type: string
+              creditCardNumber:
+                type: string
+              quantity:
+                type: number
+              orderId:
+                type: string
+            title: Pizza Order
+        "400":
+          description: Bad Request. Invalid request or validation error.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+        "415":
+          description: Unsupported Media Type. The entity of the request was in a
+            not supported format.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+      security:
+      - foo:
+        - fooTest1
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+  /menu:
+    get:
+      description: Return a list of available menu items
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters: []
+      responses:
+        "200":
+          description: OK. List of APIs is returned.
+          headers: {}
+          schema:
+            type: array
+            items:
+              type: object
+              title: Pizza menu Item
+              properties:
+                price:
+                  type: string
+                description:
+                  type: string
+                name:
+                  type: string
+                image:
+                  type: string
+              required:
+              - name
+        "304":
+          description: Not Modified. Empty body because the client has already the
+            latest version of the requested resource.
+        "406":
+          description: Not Acceptable. The requested media type is not supported
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+      security:
+      - bar:
+        - barTest1
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+  /order/{orderId}:
+    get:
+      description: Get details of an Order
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: orderId
+        in: path
+        description: Order Id
+        required: true
+        type: string
+        format: string
+      responses:
+        "200":
+          description: OK Requested Order will be returned
+          headers: {}
+          schema:
+            required:
+            - orderId
+            properties:
+              customerName:
+                type: string
+              delivered:
+                type: boolean
+              address:
+                type: string
+              pizzaType:
+                type: string
+              creditCardNumber:
+                type: string
+              quantity:
+                type: number
+              orderId:
+                type: string
+            title: Pizza Order
+        "304":
+          description: Not Modified. Empty body because the client has already the
+            latest version of the requested resource.
+        "404":
+          description: Not Found. Requested API does not exist.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+        "406":
+          description: Not Acceptable. The requested media type is not supported
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+    put:
+      description: Update an existing Order
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: orderId
+        in: path
+        description: Order Id
+        required: true
+        type: string
+        format: string
+      - in: body
+        name: body
+        description: Order object that needs to be added
+        required: true
+        schema:
+          required:
+          - orderId
+          properties:
+            customerName:
+              type: string
+            delivered:
+              type: boolean
+            address:
+              type: string
+            pizzaType:
+              type: string
+            creditCardNumber:
+              type: string
+            quantity:
+              type: number
+            orderId:
+              type: string
+          title: Pizza Order
+      responses:
+        "200":
+          description: OK. Successful response with updated Order
+          headers:
+            Location:
+              type: string
+              description: The URL of the newly created resource.
+            Content-Type:
+              type: string
+              description: The content type of the body.
+          schema:
+            required:
+            - orderId
+            properties:
+              customerName:
+                type: string
+              delivered:
+                type: boolean
+              address:
+                type: string
+              pizzaType:
+                type: string
+              creditCardNumber:
+                type: string
+              quantity:
+                type: number
+              orderId:
+                type: string
+            title: Pizza Order
+        "400":
+          description: Bad Request. Invalid request or validation error
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+        "404":
+          description: Not Found. The resource to be updated does not exist.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+        "412":
+          description: Precondition Failed. The request has not been performed because
+            one of the preconditions is not met.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+    delete:
+      description: Delete an existing Order
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      parameters:
+      - name: orderId
+        in: path
+        description: Order Id
+        required: true
+        type: string
+        format: string
+      responses:
+        "200":
+          description: OK. Resource successfully deleted.
+        "404":
+          description: Not Found. Resource to be deleted does not exist.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+        "412":
+          description: Precondition Failed. The request has not been performed because
+            one of the preconditions is not met.
+          schema:
+            required:
+            - code
+            - message
+            properties:
+              message:
+                type: string
+                description: Error message.
+              error:
+                type: array
+                description: If there are more than one error list them out. Ex. list
+                  out validation errors by each field.
+                items:
+                  type: object
+                  title: Description of individual errors that may have occored during
+                    a request.
+                  properties:
+                    message:
+                      type: string
+                      description: Description about individual errors occored
+                    code:
+                      type: integer
+                      format: int64
+                  required:
+                  - code
+                  - message
+              description:
+                type: string
+                description: A detail description about the error message.
+              code:
+                type: integer
+                format: int64
+              moreInfo:
+                type: string
+                description: Preferably an url with more details about the error.
+            title: Error object returned with 4XX HTTP status
+      security:
+      - default: []
+      x-auth-type: Application & Application User
+      x-throttling-tier: Unlimited
+securityDefinitions:
+  foo:
+    type: oauth2
+    authorizationUrl: https://test1.com
+    flow: implicit
+    scopes:
+      fooTest1: TestingSopes2121
+      fooTest3: TestingSopes33333
+    x-scopes-bindings:
+      fooTest1: admin
+      fooTest3: admin
+  bar:
+    type: oauth2
+    authorizationUrl: https://test2.com
+    flow: implicit
+    scopes:
+      barTest1: TestingSopes
+    x-scopes-bindings:
+      barTest1: admin
+definitions:
+  ErrorListItem:
+    required:
+    - code
+    - message
+    properties:
+      message:
+        type: string
+        description: Description about individual errors occored
+      code:
+        type: integer
+        format: int64
+    title: Description of individual errors that may have occored during a request.
+  MenuItem:
+    required:
+    - name
+    properties:
+      price:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      image:
+        type: string
+    title: Pizza menu Item
+  Order:
+    required:
+    - orderId
+    properties:
+      customerName:
+        type: string
+      delivered:
+        type: boolean
+      address:
+        type: string
+      pizzaType:
+        type: string
+      creditCardNumber:
+        type: string
+      quantity:
+        type: number
+      orderId:
+        type: string
+    title: Pizza Order
+  Error:
+    required:
+    - code
+    - message
+    properties:
+      message:
+        type: string
+        description: Error message.
+      error:
+        type: array
+        description: If there are more than one error list them out. Ex. list out
+          validation errors by each field.
+        items:
+          type: object
+          title: Description of individual errors that may have occored during a request.
+          properties:
+            message:
+              type: string
+              description: Description about individual errors occored
+            code:
+              type: integer
+              format: int64
+          required:
+          - code
+          - message
+      description:
+        type: string
+        description: A detail description about the error message.
+      code:
+        type: integer
+        format: int64
+      moreInfo:
+        type: string
+        description: Preferably an url with more details about the error.
+    title: Error object returned with 4XX HTTP status
+x-wso2-auth-header: Authorization
+x-throttling-tier: Unlimited
+x-wso2-cors:
+  corsConfigurationEnabled: false
+  accessControlAllowOrigins:
+  - '*'
+  accessControlAllowCredentials: false
+  accessControlAllowHeaders:
+  - authorization
+  - Access-Control-Allow-Origin
+  - Content-Type
+  - SOAPAction
+  accessControlAllowMethods:
+  - GET
+  - PUT
+  - POST
+  - DELETE
+  - PATCH
+  - OPTIONS
+x-wso2-production-endpoints:
+  urls:
+  - https://localhost:9443/am/sample/pizzashack/v1/api/
+  type: http
+x-wso2-sandbox-endpoints:
+  urls:
+  - https://localhost:9443/am/sample/pizzashack/v1/api/
+  type: http
+x-wso2-basePath: /pizzashack/1.0.0/Chamindu
+x-wso2-transports:
+- http
+- https

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -168,3 +168,9 @@ const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"
 const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
 const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
 const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
+
+const MockTestExportDirectory ="testdata/MockExportDirectory"
+const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
+const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
+const DefinitionYamlPath = ""
+const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -168,9 +168,3 @@ const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"
 const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
 const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
 const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
-
-const MockTestExportDirectory ="testdata/MockExportDirectory"
-const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
-const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
-const DefinitionYamlPath = ""
-const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"

--- a/import-export-cli/utils/testConstants.go
+++ b/import-export-cli/utils/testConstants.go
@@ -1,0 +1,23 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package utils
+
+const MockTestExportDirectory ="testdata/MockExportDirectory"
+const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
+const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
+const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"

--- a/import-export-cli/utils/testConstants.go
+++ b/import-export-cli/utils/testConstants.go
@@ -17,7 +17,14 @@
  */
 package utils
 
-const MockTestExportDirectory ="testdata/MockExportDirectory"
+const CustomTestExportDirectory = "testdata/CustomExportDirectory/"
 const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
 const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
 const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"
+const TestMigrationDirectorySuffix = "/migration"
+
+const DefaultApictlTestAppName = "default-apictl-app"
+
+//Export test cases
+const DevFirstDefaultAPIName = "SwaggerPetstoreNew"
+const DevFirstDefaultAPIVersion = "1.0.0"


### PR DESCRIPTION
## Purpose
Adding Integration tests to apictl

## Goals
Automating Integration tests

## Automation tests
### Covered Automated Tests from this PR
**Tests Related Environments**

1. Add Environments (without --token flag)
2. Change the export directory
4. Change tokenType  
5. Remove Environments 
6. List Environments

**Tests Related to Dev-first Approach**

1. Initialize an API without any flag (apictl init SampleAPI)
2. Initialize an API from Swagger 2 Specification
3. Initialize an API with URL
4. Initialize an API from OpenAPI 3 Specification
5. Import an initialized Project using import-API with OpenAPI 3 Specification
6. Import an initialized Project using import-API with Swagger 2 Specification
7. Import an API when it has already existed in publisher without update flag
8. Import an API when it has already existed in publisher with update flag
9. Import an API with scopes (scopes are added to the swagger file)

**Tests Related to Applications**

1. Delete an Application as a super tenant admin


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0 -Alpha
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.