### PR TITLE
Modify get-keys functionality to support simplified scopes and to fix generating keys consecutively

### DIFF
--- a/import-export-cli/cmd/keys.go
+++ b/import-export-cli/cmd/keys.go
@@ -39,6 +39,7 @@ const genKeyCmdLongDesc = `Generate JWT token to invoke the API or API Product b
 const genKeyCmdExamples = utils.ProjectName + " " + genKeyCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev --provider admin
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory.
 You can override the default token endpoint using --token (-t) optional flag providing a new token endpoint`
+
 var keyGenEnv string
 var apiName string
 var apiVersion string
@@ -337,7 +338,8 @@ func generateAccessToken(credential credentials.Credential) (string, error) {
 	//Prepping query params
 	body := "grant_type=password&username=" + credential.Username + "&password=" +
 		encodeURL.QueryEscape(credential.Password) + "&validity_period=" + string(utils.DefaultTokenValidityPeriod) +
-		"&scope=apim:api_view+apim:subscribe+apim:api_publish"
+		"&scope=apim:api_view+apim:subscribe+apim:api_publish+apim:app_manage+apim:sub_manage+apim:api_product_import_export+" +
+		"apim:api_import_export+apim:api_view"
 
 	//Call to the token endpoint with the necessary payload
 	resp, err := utils.InvokePOSTRequest(tokenEndpoint, headers, body)

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -23,10 +23,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/renstrom/dedent"
 	"net/http"
 	encodeURL "net/url"
 	"strings"
+
+	"github.com/renstrom/dedent"
 )
 
 // ExecutePreCommandWithBasicAuth deals with generating tokens needed for executing a particular command
@@ -312,8 +313,8 @@ func GetBase64EncodedCredentials(key, secret string) (encodedValue string) {
 // @return error
 func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url string) (map[string]string, error) {
 	body := "grant_type=password&username=" + username + "&password=" + encodeURL.QueryEscape(password) +
-		"&scope=apim:api_delete+apim:api_view+apim:app_import_export+apim:app_owner_change+apim:subscribe+apim:api_publish" +
-		"+apim:api_import_export+apim:api_product_import_export"
+		"&scope=apim:app_import_export+apim:api_import_export+apim:api_product_import_export+apim:app_manage+" +
+		"apim:sub_manage+apim:api_view+apim:api_delete+apim:app_owner_change+apim:subscribe+apim:api_publish"
 
 	// set headers
 	headers := make(map[string]string)


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/381
Fixes: https://github.com/wso2/product-apim-tooling/issues/328

## Goals
- Add the scopes that are needed to invoke get-keys using the user "Internal/devops"
- Remove regenerateConsumerSecret since APIM does not support it anymore
- Add the simplified scopes to support the overall functionality of the API Controller

## Approach
- Added the below list of scopes to **GetOAuthTokens** function
  - apim:app_manage
  - apim:sub_manage
  - apim:app_import_export
  - apim:api_product_import_export
  - apim:api_import_export
  - apim:api_view
- Removed **regenerateConsumerSecret** function
- Removed **generateAccessToken** function

## User stories
- get-keys functionality works with newly simplified scopes (Also with "Internal/devops" now)
- Regeneration of consumer secret will not be done since the APIM does not support it anymore. (Even from the UI, this is not allowed now)
- All the API Controller operations can be done now with the simplified scopes.

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/8849

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64