### PR TITLE
Upgrade the DCR version to v0.17 and upgrade the APICTL version in the integration tests to 3.2.0

### DIFF
--- a/import-export-cli/integration/README.md
+++ b/import-export-cli/integration/README.md
@@ -42,7 +42,7 @@ rest-api-version: v1
    The version of the apictl that is being integration tested.
 
 ```
-apictl-version: 3.1.0
+apictl-version: 3.2.0
 ```   
 
 

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -11,4 +11,4 @@ environments:
   offset: 1
 dcr-version: v0.17
 rest-api-version: v1
-apictl-version: 3.1.0
+apictl-version: 3.2.0

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -9,6 +9,6 @@ environments:
 - name: production
   host: localhost
   offset: 1
-dcr-version: v0.16
+dcr-version: v0.17
 rest-api-version: v1
 apictl-version: 3.1.0

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -61,7 +61,7 @@ const defaultUnifiedSearchEndpointSuffix = "api/am/publisher/v1/search"
 const defaultAdminApplicationListEndpointSuffix = "api/am/admin/v1/applications"
 const defaultDevPortalApplicationListEndpointSuffix = "api/am/store/v1/applications"
 const defaultDevPortalThrottlingPoliciesEndpointSuffix = "api/am/store/v1/throttling-policies"
-const defaultClientRegistrationEndpointSuffix = "client-registration/v0.16/register"
+const defaultClientRegistrationEndpointSuffix = "client-registration/v0.17/register"
 const defaultTokenEndPoint = "oauth2/token"
 const defaultRevokeEndpointSuffix = "oauth2/revoke"
 


### PR DESCRIPTION
## Purpose
Sync the DCR version of APICTL with the DCR version of APIM and upgrade the integration tests version

## Goals
- Upgrade the DCR version from v0.16 to v0.17
- Upgrade the APICTL version from 3.1.0 to 3.2.0 in integration tests

## Approach
- Replaced v0.16 in the **defaultClientRegistrationEndpointSuffix** with v0.17
- Updated **dcr-version** in integration tests to v0.17
- Updated **apictl-version** in integration tests to 3.2.0

## User stories
- The API Controller operations can be performed with the latest APIM
- The integration tests can be run with the latest APIM

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64