### PR TITLE
[apictl] HTTPS, Quay.io registry separated operator installation

### DIFF
--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -65,7 +65,9 @@ var DockerHubRegistry = &Registry{
 			}
 		}
 
-		reg.Repository.Name = repository
+		// support prefix "docker.io/" to be compatible with older version of API-CTL
+		// trim it if found
+		reg.Repository.Name = strings.TrimPrefix(repository, "docker.io/")
 		reg.Repository.Username = username
 		reg.Repository.Password = password
 	},

--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -84,7 +84,8 @@ var DockerHubRegistry = &Registry{
 		dockerHubValues.repository = repository
 	},
 	Run: func() {
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace, dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace,
+			dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
 		dockerHubValues.password = "" // clear password
 	},
 	Flags: Flags{
@@ -132,7 +133,8 @@ func readDockerHubInputs() (string, string, string) {
 		fmt.Println("\nRepository: " + repository)
 		fmt.Println("Username  : " + username)
 
-		isConfirmStr, err := utils.ReadInputString("Confirm configurations", utils.Default{Value: "Y", IsDefault: true}, "", false)
+		isConfirmStr, err := utils.ReadInputString("Confirm configurations",
+			utils.Default{Value: "Y", IsDefault: true}, "", false)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading user input Confirmation", err)
 		}

--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -28,24 +28,13 @@ import (
 	"strings"
 )
 
-const DockerHubRegistryUrl = "https://index.docker.io/v1/"
-
-var dockerHubRepo = new(string)
-
-var dockerHubValues = struct {
-	repository    string
-	repositoryUrl string
-	username      string
-	password      string
-}{}
-
 // DockerHubRegistry represents Docker Hub registry
 var DockerHubRegistry = &Registry{
 	Name:       "DOCKER_HUB",
 	Caption:    "Docker Hub",
-	Repository: dockerHubRepo,
+	Repository: Repository{ServerUrl: "https://index.docker.io/v1/"},
 	Option:     1,
-	Read: func(flagValues *map[string]FlagValue) {
+	Read: func(reg *Registry, flagValues *map[string]FlagValue) {
 		var repository, username, password string
 
 		// check input mode: interactive or batch
@@ -76,17 +65,14 @@ var DockerHubRegistry = &Registry{
 			}
 		}
 
-		dockerHubValues.repositoryUrl = DockerHubRegistryUrl
-		dockerHubValues.username = username
-		dockerHubValues.password = password
-
-		*dockerHubRepo = repository
-		dockerHubValues.repository = repository
+		reg.Repository.Name = repository
+		reg.Repository.Username = username
+		reg.Repository.Password = password
 	},
-	Run: func() {
+	Run: func(reg *Registry) {
 		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace,
-			dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
-		dockerHubValues.password = "" // clear password
+			reg.Repository.ServerUrl, reg.Repository.Username, reg.Repository.Password)
+		reg.Repository.Password = "" // clear password
 	},
 	Flags: Flags{
 		RequiredFlags: &map[string]bool{k8sUtils.FlagBmRepository: true, k8sUtils.FlagBmUsername: true},

--- a/import-export-cli/operator/registry/https.go
+++ b/import-export-cli/operator/registry/https.go
@@ -19,39 +19,31 @@
 package registry
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"net/http"
 	"strings"
 )
 
-const DockerHubRegistryUrl = "https://index.docker.io/v1/"
+var httpsValues = struct {
+	repository *string
+	username   string
+	password   string
+}{repository: new(string)}
 
-var dockerHubRepo = new(string)
-
-var dockerHubValues = struct {
-	repository    string
-	repositoryUrl string
-	username      string
-	password      string
-}{}
-
-// DockerHubRegistry represents Docker Hub registry
-var DockerHubRegistry = &Registry{
-	Name:       "DOCKER_HUB",
-	Caption:    "Docker Hub",
-	Repository: dockerHubRepo,
-	Option:     1,
+// HttpsRegistry represents private HTTPS registry
+var HttpsRegistry = &Registry{
+	Name:       "HTTPS",
+	Caption:    "HTTPS Private Registry",
+	Repository: httpsValues.repository,
+	Option:     5,
 	Read: func(flagValues *map[string]FlagValue) {
 		var repository, username, password string
 
 		// check input mode: interactive or batch
 		if flagValues == nil {
 			// get inputs in interactive mode
-			repository, username, password = readDockerHubInputs()
+			repository, username, password = readHttpsRepInputs()
 		} else {
 			// get inputs in batch mode
 			repository = (*flagValues)[k8sUtils.FlagBmRepository].Value.(string)
@@ -62,7 +54,9 @@ var DockerHubRegistry = &Registry{
 			if !utils.ValidateValue(repository, utils.RepoValidRegex) {
 				utils.HandleErrorAndExit("Invalid repository name: "+repository, nil)
 			}
-			if !utils.ValidateValue(username, utils.UsernameValidRegex) {
+
+			// validate optional inputs
+			if username != "" && !utils.ValidateValue(username, utils.UsernameValidRegex) {
 				utils.HandleErrorAndExit("Invalid username : "+username, nil)
 			}
 
@@ -76,25 +70,24 @@ var DockerHubRegistry = &Registry{
 			}
 		}
 
-		dockerHubValues.repositoryUrl = DockerHubRegistryUrl
-		dockerHubValues.username = username
-		dockerHubValues.password = password
-
-		*dockerHubRepo = repository
-		dockerHubValues.repository = repository
+		*httpsValues.repository = repository
+		httpsValues.username = username
+		httpsValues.password = password
 	},
 	Run: func() {
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace, dockerHubValues.repositoryUrl, dockerHubValues.username, dockerHubValues.password)
-		dockerHubValues.password = "" // clear password
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace,
+			getRegistryUrl(*httpsValues.repository), httpsValues.username, httpsValues.password)
+		httpsValues.password = "" // clear password
 	},
 	Flags: Flags{
-		RequiredFlags: &map[string]bool{k8sUtils.FlagBmRepository: true, k8sUtils.FlagBmUsername: true},
-		OptionalFlags: &map[string]bool{k8sUtils.FlagBmPassword: true, k8sUtils.FlagBmPasswordStdin: true},
+		RequiredFlags: &map[string]bool{k8sUtils.FlagBmRepository: true},
+		OptionalFlags: &map[string]bool{k8sUtils.FlagBmUsername: true, k8sUtils.FlagBmPassword: true,
+			k8sUtils.FlagBmPasswordStdin: true},
 	},
 }
 
-// readDockerHubInputs reads docker-registry URL, username and password from the user
-func readDockerHubInputs() (string, string, string) {
+// readHttpsRepInputs reads https private registry URL, username and password from the user
+func readHttpsRepInputs() (string, string, string) {
 	isConfirm := false
 	repository := ""
 	username := ""
@@ -102,10 +95,10 @@ func readDockerHubInputs() (string, string, string) {
 	var err error
 
 	for !isConfirm {
-		repository, err = utils.ReadInputString("Enter repository name", utils.Default{Value: "", IsDefault: false},
-			utils.RepoValidRegex, true)
+		repository, err = utils.ReadInputString("Enter repository",
+			utils.Default{Value: "", IsDefault: false}, utils.RepoValidRegex, true)
 		if err != nil {
-			utils.HandleErrorAndExit("Error reading repository name from user", err)
+			utils.HandleErrorAndExit("Error reading registry repository name from user", err)
 		}
 
 		username, err = utils.ReadInputString("Enter username", utils.Default{Value: "", IsDefault: false},
@@ -119,20 +112,11 @@ func readDockerHubInputs() (string, string, string) {
 			utils.HandleErrorAndExit("Error reading password from user", err)
 		}
 
-		// only validate credentials if registry is DockerHub
-		isCredentialsValid, err := validateDockerHubCredentials(repository, username, password)
-		if err != nil {
-			utils.HandleErrorAndExit("Error connecting to Docker Registry repository using credentials", err)
-		}
-
-		if !isCredentialsValid {
-			utils.HandleErrorAndExit("Invalid credentials for Docker Hub", err)
-		}
-
 		fmt.Println("\nRepository: " + repository)
 		fmt.Println("Username  : " + username)
 
-		isConfirmStr, err := utils.ReadInputString("Confirm configurations", utils.Default{Value: "Y", IsDefault: true}, "", false)
+		isConfirmStr, err := utils.ReadInputString("Confirm configurations",
+			utils.Default{Value: "Y", IsDefault: true}, "", false)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading user input Confirmation", err)
 		}
@@ -143,20 +127,18 @@ func readDockerHubInputs() (string, string, string) {
 	return repository, username, password
 }
 
-// validateDockerHubCredentials validates the credentials for the repository
-func validateDockerHubCredentials(repository string, username string, password string) (bool, error) {
-	cred, err := json.Marshal(map[string]string{
-		"username": username,
-		"password": password,
-	})
-	resp, err := http.Post("https://hub.docker.com/v2/users/login/", "application/json", bytes.NewBuffer(cred))
-	if err != nil {
-		return false, err
+// getRegistryUrl returns the registry URL for given repository
+func getRegistryUrl(repository string) string {
+	names := strings.SplitN(repository, "/", 2)
+	// if "myDomain.com:5000/foo" return "myDomain.com:5000"
+	if len(names) == 2 {
+		return names[0]
 	}
-	_ = resp.Body.Close()
-	return resp.StatusCode == 200, nil //TODO: use repository as well to validate
+
+	// if "myDomain.com:5000" return "myDomain.com:5000"
+	return repository
 }
 
 func init() {
-	add(DockerHubRegistry)
+	add(HttpsRegistry)
 }

--- a/import-export-cli/operator/registry/https.go
+++ b/import-export-cli/operator/registry/https.go
@@ -64,7 +64,13 @@ var HttpsRegistry = &Registry{
 			}
 		}
 
-		reg.Repository.Name = repository
+		// support prefixed repository with registry url to be compatible with older version of API-CTL
+		// if it is not prefixed add it
+		if strings.HasPrefix(repository, reg.Repository.ServerUrl) {
+			reg.Repository.Name = repository
+		} else {
+			reg.Repository.Name = reg.Repository.ServerUrl + repository
+		}
 		reg.Repository.Username = username
 		reg.Repository.Password = password
 	},

--- a/import-export-cli/operator/registry/quay.go
+++ b/import-export-cli/operator/registry/quay.go
@@ -18,8 +18,6 @@
 
 package registry
 
-import k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
-
 // HttpRegistry represents private HTTPS registry
 // copy of HttpsRegistry
 var QuayRegistry = *HttpsRegistry
@@ -28,11 +26,7 @@ func init() {
 	QuayRegistry.Name = "QUAY"
 	QuayRegistry.Caption = "Quay.io"
 	QuayRegistry.Option = 6
-	QuayRegistry.Run = func() {
-		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace,
-			"quay.io", httpsValues.username, httpsValues.password)
-		httpsValues.password = "" // clear password
-	}
+	QuayRegistry.Repository.ServerUrl = "quay.io/"
 
 	add(&QuayRegistry)
 }

--- a/import-export-cli/operator/registry/quay.go
+++ b/import-export-cli/operator/registry/quay.go
@@ -18,6 +18,8 @@
 
 package registry
 
+import k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+
 // HttpRegistry represents private HTTPS registry
 // copy of HttpsRegistry
 var QuayRegistry = *HttpsRegistry
@@ -26,6 +28,11 @@ func init() {
 	QuayRegistry.Name = "QUAY"
 	QuayRegistry.Caption = "Quay.io"
 	QuayRegistry.Option = 6
+	QuayRegistry.Run = func() {
+		k8sUtils.K8sCreateSecretFromInputs(k8sUtils.DockerRegCredSecret, k8sUtils.ApiOpWso2Namespace,
+			"quay.io", httpsValues.username, httpsValues.password)
+		httpsValues.password = "" // clear password
+	}
 
 	add(&QuayRegistry)
 }

--- a/import-export-cli/operator/registry/quay.go
+++ b/import-export-cli/operator/registry/quay.go
@@ -20,12 +20,12 @@ package registry
 
 // HttpRegistry represents private HTTPS registry
 // copy of HttpsRegistry
-var HttpRegistry = *HttpsRegistry
+var QuayRegistry = *HttpsRegistry
 
 func init() {
-	HttpRegistry.Name = "HTTP"
-	HttpRegistry.Caption = "HTTP Private Registry"
-	HttpRegistry.Option = 4
+	QuayRegistry.Name = "QUAY"
+	QuayRegistry.Caption = "Quay.io"
+	QuayRegistry.Option = 6
 
-	add(&HttpRegistry)
+	add(&QuayRegistry)
 }

--- a/import-export-cli/operator/registry/registry.go
+++ b/import-export-cli/operator/registry/registry.go
@@ -30,13 +30,22 @@ import (
 
 // Registry represents Docker Registry
 type Registry struct {
-	Name       string                                 // Unique Name
-	Caption    string                                 // Text to display in the CLI about registry details
-	Repository *string                                // Repository name
-	Option     int                                    // Option to be choose the CLI registry list
-	Read       func(flagValues *map[string]FlagValue) // Function to be called when getting inputs, if flagValues is nil get inputs interactively
-	Run        func()                                 // Function to be called when updating k8s secrets
-	Flags      Flags                                  // Required and Optional flags
+	Name       string                                                // Unique Name
+	Caption    string                                                // Text to display in the CLI about registry details
+	Repository Repository                                            // Repository name
+	Option     int                                                   // Option to be choose the CLI registry list
+	Read       func(reg *Registry, flagValues *map[string]FlagValue) // Function to be called when getting inputs, if flagValues is nil get inputs interactively
+	Run        func(reg *Registry)                                   // Function to be called when updating k8s secrets
+	Flags      Flags                                                 // Required and Optional flags
+}
+
+// Repository represents a Docker repository of a Docker registry
+type Repository struct {
+	Name      string
+	ServerUrl string
+	Username  string
+	Password  string
+	KeyFile   string
 }
 
 // Flags represents Required and Optional flags that supports the specified registry type
@@ -59,20 +68,22 @@ var optionToExec int
 
 // ReadInputsInteractive reads inputs with respect to the selected registry type interactively
 func ReadInputsInteractive() {
-	registries[optionToExec].Read(nil)
+	reg := registries[optionToExec]
+	reg.Read(reg, nil)
 }
 
 // ReadInputsFromFlags reads inputs from flags with respect to the selected registry type
 func ReadInputsFromFlags(flagValues *map[string]FlagValue) {
-	registries[optionToExec].Read(flagValues)
+	reg := registries[optionToExec]
+	reg.Read(reg, flagValues)
 }
 
 // UpdateConfigsSecrets updates controller config with registry type and creates secrets with credentials
 func UpdateConfigsSecrets() {
 	// set registry first since this can throw error if api operator not installed. If error occur no need to rollback secret.
-	updateDockerRegistryConfig(registries[optionToExec].Name, *registries[optionToExec].Repository)
+	updateDockerRegistryConfig(registries[optionToExec].Name, registries[optionToExec].Repository.Name)
 	// create secret
-	registries[optionToExec].Run()
+	registries[optionToExec].Run(registries[optionToExec])
 }
 
 // ChooseRegistryInteractive lists registries in the CLI and reads a choice from user

--- a/import-export-cli/operator/registry/registry.go
+++ b/import-export-cli/operator/registry/registry.go
@@ -145,7 +145,6 @@ func ValidateFlags(flagsValues *map[string]FlagValue) {
 
 // updateDockerRegistryConfig sets the repository type value and the repository in the config: `controller-config`
 func updateDockerRegistryConfig(registryType string, repository string) {
-	// get controller config config map
 	registryConfigMapYaml, _ := box.Get("/kubernetes_resources/docker_registry_conf.yaml")
 
 	registryConfigMap := make(map[interface{}]interface{})

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -104,8 +104,8 @@ const LogPrefixError = "[ERROR]: "
 const SearchAndTag = "&"
 
 // Regex Validation
+const RepoValidRegex = `^[\w\d\-\.\:]*\/?[\w\d\-]+$`
 const UsernameValidRegex = `^[\w\d\-]*$`
-const PositiveNoValidRegex = `^[1-9]\d*$`
 const UrlValidRegex = `^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$`
 
 // Other


### PR DESCRIPTION
## Purpose
- Introduce new struct for registry repository.
  ```go
  // Repository represents a Docker repository of a Docker registry
  type Repository struct {
    Name      string
    ServerUrl string
    Username  string
    Password  string
    KeyFile   string
  }
  ```
- Expand registry list
  ```sh
  $ apictl install api-operator
  Choose registry type:
  1: Docker Hub
  2: Amazon ECR
  3: GCR
  4: HTTP Private Registry
  5: HTTPS Private Registry
  6: Quay.io
  Choose a number: 1:
  ```
- Support prefix "docker.io/" to be compatible with older version of API-CTL.
- Use a clone of HTTPS registry struct for HTTP and Quay.io registries.
- Relevant API Operator changes https://github.com/wso2/k8s-api-operator/pull/381
- Relevant Issue https://github.com/wso2/k8s-api-operator/issues/349
## Tests
- Tested with
  - HTTP private registry
  - DockerHub
  - Quay.io
  - GCR
  - EKS
- Tested interactive and batch mode (CI/CD mode)