### PR TITLE
Fix for #385

### DIFF
--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -42,12 +42,12 @@ var removeEnvCmd = &cobra.Command{
 	Short:   removeEnvCmdShortDesc,
 	Long:    removeEnvCmdLongDesc,
 	Example: removeEnvCmdExamples,
-	Args: cobra.MinimumNArgs(1),
+	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		envToBeRemoved := args[0];
+		envToBeRemoved := args[0]
 
 		utils.Logln(utils.LogPrefixInfo + removeEnvCmdLiteral + " called")
-		executeRemoveEnvCmd(envToBeRemoved , utils.MainConfigFilePath, utils.EnvKeysAllFilePath)
+		executeRemoveEnvCmd(envToBeRemoved, utils.MainConfigFilePath, utils.EnvKeysAllFilePath)
 	},
 }
 
@@ -83,7 +83,7 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 		if store.Has(envName) {
 			err = runLogout(envName)
 			if err != nil {
-				return err
+				utils.Logln("Log out is unsuccessful. ",err)
 			}
 		}
 

--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -83,7 +83,7 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 		if store.Has(envName) {
 			err = runLogout(envName)
 			if err != nil {
-				utils.Logln("Log out is unsuccessful. ",err)
+				utils.Logln("Log out is unsuccessful. ", err)
 			}
 		}
 

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -89,12 +89,12 @@ func GetBasicAuth(credential Credential) string {
 }
 
 //Revoke access Token when user is logging out from environment
-func RevokeAccessToken(credential Credential, env string, token string)  error {
+func RevokeAccessToken(credential Credential, env string, token string) error {
 
 	//get revoke endpoint
-	tokenRevokeEndpoint := utils.GetTokenRevokeEndpoint(env,utils.MainConfigFilePath)
+	tokenRevokeEndpoint := utils.GetTokenRevokeEndpoint(env, utils.MainConfigFilePath)
 	//Encoding client secret and client Id
-	var b64EncodedClientIDClientSecret = utils.GetBase64EncodedCredentials(credential.ClientId,credential.ClientSecret)
+	var b64EncodedClientIDClientSecret = utils.GetBase64EncodedCredentials(credential.ClientId, credential.ClientSecret)
 	// set headers to request
 	headers := make(map[string]string)
 	headers[utils.HeaderContentType] = utils.HeaderValueXWWWFormUrlEncoded
@@ -107,17 +107,16 @@ func RevokeAccessToken(credential Credential, env string, token string)  error {
 	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenRevokeEndpoint)
 
 	if err != nil {
-		utils.HandleErrorAndExit("Unable to Connect.", err)
+		return err
 	}
 
 	//Check status code
 	if resp.StatusCode() != http.StatusOK {
-		utils.HandleErrorAndExit("Unable to connect.", errors.New("Status: "+resp.Status()))
-		return nil
+		return errors.New("Request didn't respond 200 OK for searching token revocation " +
+			"Status: " + resp.Status())
 	}
-
 	responseDataMap := make(map[string]string) // a map to hold response data
 	data := []byte(resp.Body())
 	json.Unmarshal(data, &responseDataMap) // add response data to the map
-	return  nil
+	return nil
 }

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -325,7 +325,7 @@ func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url stri
 	resp, err := InvokePOSTRequest(url, headers, body)
 
 	if err != nil {
-		HandleErrorAndExit("Unable to Connect.", err)
+		return nil, err
 	}
 
 	if resp.StatusCode() != http.StatusOK {

--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"github.com/renstrom/dedent"
 	"net/http"
-	"strings"
 	encodeURL "net/url"
+	"strings"
 )
 
 // ExecutePreCommandWithBasicAuth deals with generating tokens needed for executing a particular command


### PR DESCRIPTION
## Purpose
When the user tries to remove an environment without logging out and without server up and running it gives following error.
```
$ apictl remove env dev -k --verbose
Executed ImportExportCLI (apictl) on Thu, 02 Jul 2020 08:15:47 +0530
[INFO]: Insecure: true
[INFO]: env called
[INFO]: connecting to https://dev.apis.mobilestore.com:9443/oauth2/token
apictl: Unable to connect. Reason: Status: 401 
Exit status 1
```
In this scenario, the user should have the ability to remove even though the server is not running. 


## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/385

## Approach

- Gracefully handle this error in a way if a user tries this scenario that the user will be able to remove an environment without logging out.

## Automation tests
All the integration tests were passed after the fix


## Test environment
 OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0 
