### PR TITLE
Return error without exiting when ouath token endpoint failed

### DIFF
--- a/import-export-cli/utils/tokenManagement.go
+++ b/import-export-cli/utils/tokenManagement.go
@@ -330,8 +330,8 @@ func GetOAuthTokens(username, password, b64EncodedClientIDClientSecret, url stri
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		HandleErrorAndExit("Unable to connect.", errors.New("Status: "+resp.Status()))
-		return nil, nil
+		return nil, errors.New("Unable to connect. " +
+			"Status: " + resp.Status())
 	}
 
 	responseDataMap := make(map[string]string) // a map to hold response data


### PR DESCRIPTION
### **Purpose**
Return error without exiting when the Oauth endpoint is failed to connect or response of the request failed to provide HTTP.Ok status (200,201).