### PR TITLE
Considering (-o) --owner flag when deleting an application

### DIFF
--- a/import-export-cli/cmd/deleteApp.go
+++ b/import-export-cli/cmd/deleteApp.go
@@ -14,13 +14,12 @@
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-*/
+ */
 
 package cmd
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
@@ -59,11 +58,13 @@ var DeleteAppCmd = &cobra.Command{
 	},
 }
 
-
 // executeDeleteAppCmd executes the delete app command
 func executeDeleteAppCmd(credential credentials.Credential) {
 	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, deleteAppEnvironment)
 	if preCommandErr == nil {
+		if deleteAppOwner == "" {
+			deleteAppOwner = credential.Username
+		}
 		resp, err := impl.DeleteApplication(accessToken, deleteAppEnvironment, deleteAppName, deleteAppOwner)
 		if err != nil {
 			utils.HandleErrorAndExit("Error while deleting Application ", err)
@@ -86,6 +87,5 @@ func init() {
 		"", "Environment from which the Application should be deleted")
 	// Mark required flags
 	_ = DeleteAppCmd.MarkFlagRequired("name")
-	_ = DeleteAppCmd.MarkFlagRequired("owner")
 	_ = DeleteAppCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/deleteApp.go
+++ b/import-export-cli/cmd/deleteApp.go
@@ -20,10 +20,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
+	"net/http"
+
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+
+	"github.com/spf13/cobra"
 )
 
 var deleteAppEnvironment string
@@ -41,10 +44,10 @@ NOTE: Both the flags (--name (-n), and --environment (-e)) are mandatory and the
 
 // DeleteAppCmd represents the delete app command
 var DeleteAppCmd = &cobra.Command{
-	Use:   deleteAppCmdLiteral + " (--name <name-of-the-application> --owner <owner-of-the-application> --environment " +
+	Use: deleteAppCmdLiteral + " (--name <name-of-the-application> --owner <owner-of-the-application> --environment " +
 		"<environment-from-which-the-application-should-be-deleted>)",
-	Short: deleteAppCmdShortDesc,
-	Long: deleteAppCmdLongDesc,
+	Short:   deleteAppCmdShortDesc,
+	Long:    deleteAppCmdLongDesc,
 	Example: deleteAppCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAppCmdLiteral + " called")
@@ -58,10 +61,10 @@ var DeleteAppCmd = &cobra.Command{
 
 
 // executeDeleteAppCmd executes the delete app command
-func executeDeleteAppCmd(credential credentials.Credential)  {
+func executeDeleteAppCmd(credential credentials.Credential) {
 	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, deleteAppEnvironment)
 	if preCommandErr == nil {
-		resp, err := impl.DeleteApplication(accessToken, deleteAppEnvironment, deleteAppName)
+		resp, err := impl.DeleteApplication(accessToken, deleteAppEnvironment, deleteAppName, deleteAppOwner)
 		if err != nil {
 			utils.HandleErrorAndExit("Error while deleting Application ", err)
 		}
@@ -83,5 +86,6 @@ func init() {
 		"", "Environment from which the Application should be deleted")
 	// Mark required flags
 	_ = DeleteAppCmd.MarkFlagRequired("name")
+	_ = DeleteAppCmd.MarkFlagRequired("owner")
 	_ = DeleteAppCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/git/gitUtils.go
+++ b/import-export-cli/git/gitUtils.go
@@ -232,7 +232,7 @@ func deployProjectDeletions(accessToken, environment string, deletedProjectsPerT
             }
             projectParam.ProjectInfo.Name = appInfo.Name
             projectParam.ProjectInfo.Owner = appInfo.Subscriber.Name
-            resp, err := impl.DeleteApplication(accessToken, environment, appInfo.Name)
+            resp, err := impl.DeleteApplication(accessToken, environment, appInfo.Name, appInfo.Subscriber.Name)
             if handleIfError(err, failedProjects, projectParam) {
                 continue
             }

--- a/import-export-cli/impl/deleteApp.go
+++ b/import-export-cli/impl/deleteApp.go
@@ -14,7 +14,7 @@
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-*/
+ */
 
 package impl
 
@@ -85,8 +85,13 @@ func getAppId(accessToken, environment, appName, appOwner string) (string, error
 		appData := &utils.AppList{}
 		data := []byte(resp.Body())
 		err = json.Unmarshal(data, &appData)
+		appId := ""
 		if appData.Count != 0 {
-			appId := appData.List[0].ApplicationID
+			for _, app := range appData.List {
+				if app.Name == appName {
+					appId = app.ApplicationID
+				}
+			}
 			return appId, err
 		}
 		return "", errors.New("Cannot find the application: " + appName + " for owner: " + appOwner)

--- a/import-export-cli/impl/deleteApp.go
+++ b/import-export-cli/impl/deleteApp.go
@@ -22,22 +22,26 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-resty/resty"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"net/http"
 	"strconv"
+
+	"github.com/go-resty/resty"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 // deleteApplication
 // @param deleteEndpoint : API Manager Developer Portal REST API Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
-func DeleteApplication(accessToken, environment, deleteAppName string) (*resty.Response, error) {
-	deleteEndpoint := utils.GetDevPortalApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath)
+func DeleteApplication(accessToken, environment, deleteAppName, deleteAppOwner string) (*resty.Response, error) {
+	deleteEndpoint := utils.GetAdminApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath)
 	deleteEndpoint = utils.AppendSlashToString(deleteEndpoint)
-	appId, err := getAppId(accessToken, environment, deleteAppName)
+	appId, err := getAppId(accessToken, environment, deleteAppName, deleteAppOwner)
 	if err != nil {
 		utils.HandleErrorAndExit("Error while getting App Id for deletion ", err)
+	}
+	if appId == "" {
+		utils.HandleErrorAndExit("Cannot find the application: "+deleteAppName+" for owner: "+deleteAppOwner, err)
 	}
 	url := deleteEndpoint + appId
 	utils.Logln(utils.LogPrefixInfo+"DeleteApplication: URL:", url)
@@ -49,11 +53,9 @@ func DeleteApplication(accessToken, environment, deleteAppName string) (*resty.R
 	if err != nil {
 		return nil, err
 	}
-
 	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent {
 		return nil, errors.New(strconv.Itoa(resp.StatusCode()) + ":<" + string(resp.Body()) + ">")
 	}
-
 	return resp, nil
 }
 
@@ -68,14 +70,15 @@ func PrintDeleteAppResponse(resp *resty.Response, err error) {
 // Get the ID of an Application if available
 // @param accessToken : Token to call the Developer Portal Rest API
 // @return appId, error
-func getAppId(accessToken, environment, appName string) (string, error) {
+func getAppId(accessToken, environment, appName, appOwner string) (string, error) {
 	// Application REST API endpoint of the environment from the config file
-	applicationEndpoint := utils.GetDevPortalApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath)
+	applicationEndpoint := utils.GetAdminApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath) +
+		"?user=" + appOwner + "&name=" + appName
 
 	// Prepping headers
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
-	resp, err := utils.InvokeGETRequestWithQueryParam("query", appName, applicationEndpoint, headers)
+	resp, err := utils.InvokeGETRequest(applicationEndpoint, headers)
 
 	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
 		// 200 OK or 201 Created
@@ -86,7 +89,7 @@ func getAppId(accessToken, environment, appName string) (string, error) {
 			appId := appData.List[0].ApplicationID
 			return appId, err
 		}
-		return "", nil
+		return "", errors.New("Cannot find the application: " + appName + " for owner: " + appOwner)
 
 	} else {
 		utils.Logf("Error: %s\n", resp.Error())


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/335

## Goals
Consider -o (--owner) flag when deleting an application with the modified Admin v1 REST APIs.

## Approach
- Modified the REST APIs that was used in the below tasks to new ones.
  1. Retrieving the applicationId based on the application name (-n/--name flag) and the owner’s name (-o/--owner flag)
      New REST API - **Admin v1 GET /applications:**
  2. Deleting the application specified by the applicationId.

## User stories
- A user who has the **apim:app_import_export** scope can delete an application that belongs to him/her.
- A user who has the **apim:app_import_export** scope can delete an application that belongs to another person in the same tenant.

## Documentation
Documentation changes should be done and will be tracked with https://github.com/wso2/product-apim-tooling/issues/391

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/8944

## Test environment
- go version go1.14.4 linux/amd64
- Ubuntu 20.04 LTS