### PR TITLE
Improving integration tests by adding basic tests for APIs, API Products and Applications for Internal/devops role

### DIFF
--- a/import-export-cli/integration/adminservices/constants.go
+++ b/import-export-cli/integration/adminservices/constants.go
@@ -24,3 +24,12 @@ const (
 	umSerNS     = "http://service.ws.um.carbon.wso2.org"
 	xsdNS       = "http://beans.common.stratos.carbon.wso2.org/xsd"
 )
+
+const AdminUsername = "admin"
+const AdminPassword = "admin"
+const PublisherUsername = "publisher"
+const CreatorUsername = "creator"
+const SubscriberUsername = "subscriber"
+const DevopsUsername = "devops"
+const Password = "password"
+const Tenant1 = "test.com"

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -19,8 +19,9 @@
 package integration
 
 import (
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 )
@@ -66,6 +67,31 @@ func TestExportImportApiAdminSuperTenantUser(t *testing.T) {
 	args := &testutils.ApiImportExportTestArgs{
 		ApiProvider: testutils.Credentials{Username: apiCreator, Password: apiCreatorPassword},
 		CtlUser:     testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API from one environment and import to another environment as super tenant user with
+// Internal/devops role by specifying the provider name
+func TestExportImportApiDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: apiCreator, Password: apiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
 		Api:         api,
 		SrcAPIM:     dev,
 		DestAPIM:    prod,
@@ -121,6 +147,31 @@ func TestExportImportApiAdminTenantUser(t *testing.T) {
 	testutils.ValidateAPIExportImport(t, args)
 }
 
+// Export an API from one environment and import to another environment as tenant user with
+// Internal/devops role by specifying the provider name
+func TestExportImportApiDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
 // Export an API as super tenant admin without specifying the provider
 func TestExportApiAdminSuperTenantUserWithoutProvider(t *testing.T) {
 	adminUsername := superAdminUser
@@ -144,6 +195,29 @@ func TestExportApiAdminSuperTenantUserWithoutProvider(t *testing.T) {
 	testutils.ValidateAPIExport(t, args)
 }
 
+// Export an API as super tenant user with Internal/devops role without specifying the provider
+func TestExportApiDevopsSuperTenantUserWithoutProvider(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser:  testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:      api,
+		SrcAPIM:  dev,
+		DestAPIM: prod,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+}
+
 // Export an API as tenant admin without specifying the provider
 func TestExportApiAdminTenantUserWithoutProvider(t *testing.T) {
 	tenantAdminUsername := superAdminUser + "@" + TENANT1
@@ -159,6 +233,29 @@ func TestExportApiAdminTenantUserWithoutProvider(t *testing.T) {
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser:  testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		Api:      api,
+		SrcAPIM:  dev,
+		DestAPIM: prod,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+}
+
+// Export an API as tenant user with Internal/devops role without specifying the provider
+func TestExportApiDevopsTenantUserWithoutProvider(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser:  testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
 		Api:      api,
 		SrcAPIM:  dev,
 		DestAPIM: prod,
@@ -191,6 +288,30 @@ func TestExportApiAdminTenantUserFromAnotherTenant(t *testing.T) {
 	testutils.ValidateAPIExportFailure(t, args)
 }
 
+// Export an API using a tenant user with Internal/devops role by specifying the provider name - API is in a different tenant
+func TestExportApiDevopsTenantUserFromAnotherTenant(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportFailure(t, args)
+}
+
 // Export an API using a tenant user without specifying the provider name - API is in a different tenant
 func TestExportApiAdminTenantUserFromAnotherTenantWithoutProvider(t *testing.T) {
 	tenantAdminUsername := superAdminUser + "@" + TENANT1
@@ -206,6 +327,29 @@ func TestExportApiAdminTenantUserFromAnotherTenantWithoutProvider(t *testing.T) 
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser:  testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		Api:      api,
+		SrcAPIM:  dev,
+		DestAPIM: prod,
+	}
+
+	testutils.ValidateAPIExportFailure(t, args)
+}
+
+// Export an API using a tenant user with Internal/devops role without specifying the provider name - API is in a different tenant
+func TestExportApiDevopsTenantUserFromAnotherTenantWithoutProvider(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser:  testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
 		Api:      api,
 		SrcAPIM:  dev,
 		DestAPIM: prod,
@@ -249,6 +393,41 @@ func TestExportImportApiCrossTenantUserWithoutPreserveProvider(t *testing.T) {
 	testutils.ValidateAPIImport(t, args)
 }
 
+// Export an API from one environment as super tenant user with Internal/devops role
+// and import to another environment as cross tenant user with Internal/devops role (with preserve-provider=false)
+func TestExportImportApiCrossTenantDevopsUserWithoutPreserveProvider(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	// Since --preserve-provider=false both the apiProvider and the ctlUser is tenant user with Internal/devops role
+	args.ApiProvider = testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword}
+	args.CtlUser = testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword}
+
+	// Import the API to env2 as tenant user with Internal/devops role across domains
+	testutils.ValidateAPIImport(t, args)
+}
+
 // Export an API from one environment as super tenant admin and import to another environment as cross tenant admin
 // (without preserve-provider=false)
 func TestExportImportApiCrossTenantUser(t *testing.T) {
@@ -283,6 +462,41 @@ func TestExportImportApiCrossTenantUser(t *testing.T) {
 	testutils.ValidateAPIImportFailure(t, args)
 }
 
+// Export an API from one environment as super tenant user with Internal/devops role
+// and import to another environment as cross tenant user with Internal/devops role (without preserve-provider=false)
+func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	// Since --preserve-provider=false is not specified, the apiProvider remain as it is and the ctlUser is tenant user
+	// with Internal/devops role
+	args.CtlUser = testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword}
+
+	// Import the API to env2 as tenant admin across domains
+	testutils.ValidateAPIImportFailure(t, args)
+}
+
 func TestListApisAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword
@@ -305,6 +519,28 @@ func TestListApisAdminSuperTenantUser(t *testing.T) {
 	testutils.ValidateAPIsList(t, args)
 }
 
+func TestListApisDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsList(t, args)
+}
+
 func TestListApisAdminTenantUser(t *testing.T) {
 	tenantAdminUsername := superAdminUser + "@" + TENANT1
 	tenantAdminPassword := superAdminPassword
@@ -321,6 +557,28 @@ func TestListApisAdminTenantUser(t *testing.T) {
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsList(t, args)
+}
+
+func TestListApisDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
 		SrcAPIM: dev,
 	}
 
@@ -353,6 +611,32 @@ func TestDeleteApiAdminSuperTenantUser(t *testing.T) {
 	testutils.ValidateAPIDelete(t, args)
 }
 
+func TestDeleteApiDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	var api *apim.API
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		api = testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	// This will be the API that will be deleted by apictl, so no need to do cleaning
+	api = testutils.AddAPIWithoutCleaning(t, dev, apiCreator, apiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:     api,
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIDelete(t, args)
+}
+
 func TestDeleteApiAdminTenantUser(t *testing.T) {
 	tenantAdminUsername := superAdminUser + "@" + TENANT1
 	tenantAdminPassword := superAdminPassword
@@ -372,6 +656,32 @@ func TestDeleteApiAdminTenantUser(t *testing.T) {
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		Api:     api,
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIDelete(t, args)
+}
+
+func TestDeleteApiDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	var api *apim.API
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		api = testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+	}
+
+	// This will be the API that will be deleted by apictl, so no need to do cleaning
+	api = testutils.AddAPIWithoutCleaning(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
 		Api:     api,
 		SrcAPIM: dev,
 	}

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -44,20 +44,21 @@ type Environment struct {
 }
 
 const (
-	superAdminUser     = "admin"
-	superAdminPassword = "admin"
+	superAdminUser     = adminservices.AdminUsername
+	superAdminPassword = adminservices.AdminPassword
 
 	userMgtService   = "RemoteUserStoreManagerService"
 	tenantMgtService = "TenantMgtAdminService"
 
-	TENANT1 = "test.com"
+	TENANT1 = adminservices.Tenant1
 )
 
 var (
 	Users = map[string][]adminservices.User{
-		"creator":    {{UserName: "creator", Password: "password", Roles: []string{"Internal/creator"}}},
-		"publisher":  {{UserName: "publisher", Password: "password", Roles: []string{"Internal/publisher"}}},
-		"subscriber": {{UserName: "subscriber", Password: "password", Roles: []string{"Internal/subscriber"}}},
+		"creator":    {{UserName: adminservices.CreatorUsername, Password: adminservices.Password, Roles: []string{"Internal/creator"}}},
+		"publisher":  {{UserName: adminservices.PublisherUsername, Password: adminservices.Password, Roles: []string{"Internal/publisher"}}},
+		"subscriber": {{UserName: adminservices.SubscriberUsername, Password: adminservices.Password, Roles: []string{"Internal/subscriber"}}},
+		"devops":     {{UserName: adminservices.DevopsUsername, Password: adminservices.Password, Roles: []string{"Internal/devops"}}},
 	}
 
 	yamlConfig YamlConfig
@@ -65,12 +66,13 @@ var (
 	envs = map[string]Environment{}
 
 	tenants = []adminservices.Tenant{
-		{AdminUserName: "admin", AdminPassword: "admin", Domain: TENANT1},
+		{AdminUserName: adminservices.AdminUsername, AdminPassword: adminservices.AdminPassword, Domain: adminservices.Tenant1},
 	}
 
 	creator    = Users["creator"][0]
 	subscriber = Users["subscriber"][0]
 	publisher  = Users["publisher"][0]
+	devops     = Users["devops"][0]
 
 	apimClients []*apim.Client
 )

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -20,16 +20,18 @@ package testutils
 
 import (
 	"encoding/json"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/adminservices"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 func AddAPIProductFromJSONWithoutCleaning(t *testing.T, client *apim.Client, username string, password string, apisList map[string]*apim.API) *apim.APIProduct {
@@ -42,7 +44,13 @@ func AddAPIProductFromJSONWithoutCleaning(t *testing.T, client *apim.Client, use
 }
 
 func getAPIProduct(t *testing.T, client *apim.Client, name string, username string, password string) *apim.APIProduct {
-	client.Login(username, password)
+	if username == adminservices.DevopsUsername {
+		client.Login(adminservices.AdminUsername, adminservices.AdminPassword)
+	} else if username == adminservices.DevopsUsername+"@"+adminservices.Tenant1 {
+		client.Login(adminservices.AdminUsername+"@"+adminservices.Tenant1, adminservices.AdminPassword)
+	} else {
+		client.Login(username, password)
+	}
 	apiProductInfo := client.GetAPIProductByName(name)
 	return client.GetAPIProduct(apiProductInfo.ID)
 }

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -19,15 +19,17 @@
 package testutils
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/adminservices"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 func AddAPI(t *testing.T, client *apim.Client, username string, password string) *apim.API {
@@ -95,7 +97,13 @@ func AddAPIProductFromJSON(t *testing.T, client *apim.Client, username string, p
 }
 
 func getAPI(t *testing.T, client *apim.Client, name string, username string, password string) *apim.API {
-	client.Login(username, password)
+	if username == adminservices.DevopsUsername {
+		client.Login(adminservices.AdminUsername, adminservices.AdminPassword)
+	} else if username == adminservices.DevopsUsername+"@"+adminservices.Tenant1 {
+		client.Login(adminservices.AdminUsername+"@"+adminservices.Tenant1, adminservices.AdminPassword)
+	} else {
+		client.Login(username, password)
+	}
 	apiInfo := client.GetAPIByName(name)
 	return client.GetAPI(apiInfo.ID)
 }

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -19,13 +19,14 @@
 package testutils
 
 import (
+	"path/filepath"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"path/filepath"
-	"testing"
-	"time"
 )
 
 func AddApp(t *testing.T, client *apim.Client, username string, password string) *apim.Application {


### PR DESCRIPTION
## Purpose
With the introduction of new Internal/devops role, the intergration tests should be designed and added.

## Goals
Add integration tests to import/export, list and delete for APIs/API Products/Applications using a user with the Internal/devops role.

## Approach
- Designed integration tests for the above-stated tasks by considering the existing tests that are available for Admin and Non Admin users.

## User stories
- APIs related test scenarios
  - Export an API from one environment and import to another environment as super tenant user with Internal/devops role by specifying the provider name
  - Export an API from one environment and import to another environment as tenant user with Internal/devops role by specifying the provider name
  - Export an API as super tenant user with Internal/devops role without specifying the provider
  - Export an API as tenant user with Internal/devops role without specifying the provider
  - Export an API using a tenant user with Internal/devops role by specifying the provider name - API is in a different tenant
  - Export an API using a tenant user with Internal/devops role without specifying the provider name - API is in a different tenant
  - Export an API from one environment as super tenant user with Internal/devops role and import to another environment as cross tenant user with Internal/devops role (with preserve-provider=false)
  - Export an API from one environment as super tenant user with Internal/devops role and import to another environment as cross tenant user with Internal/devops role (without preserve-provider=false)
  - List APIs as super tenant user with Internal/devops role
  - List APIs as tenant user with Internal/devops role
  - Delete an API as super tenant user with Internal/devops
  - Delete an API as tenant user with Internal/devops

- API Products related test scenarios
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant user with Internal/devops role
  - Export an API Product with its dependent APIs from one environment and import it as super tenant user with Internal/devops role when dependent APIs are already in that environment and you do not want to update those APIs.
  - Export an API Product with its dependent APIs from one environment and import it as super tenant user with Internal/devops role when dependent APIs are already in that environment and you want to update those APIs.
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant user with Internal/devops role and try to update that API Product (without updating dependent APIs)
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as super tenant user with Internal/devops role and try to update that API Product and dependent APIs.
  - Export an API Product with its dependent APIs from one environment and import to another environment freshly as cross tenant user with Internal/devops role
  - Export an API Product with its dependent APIs from one environment as super tenant user with Internal/devops role and import to another environment freshly as tenant admin and try to update that API Product and dependent APIs.
  - List API Products as super tenant user with Internal/devops role
  - List API Products as tenant user with Internal/devops role
  - Delete an API Product as super tenant user with Internal/devops
  - Delete an API Product as tenant user with Internal/devops

- Applications related test scenarios
  - List Apps as super tenant user with Internal/devops role
  - List Apps as tenant user with Internal/devops role
  - Export an application (created by super tenant user) and import it to another environment while preserving the owner by a user with Internal/devops role
  - Import an already export App with already generated Keys with --update flag (Using a user with Internal/devops role)
  - Export an application (created by tenant user) and import it to another environment while preserving the owner by a user with Internal/devops role
  - Export an application (created by a super tenant user) and import it to another tenant domain by a user with Internal/devops role

## Test environment
- Ubuntu 20.04.4 LTS
- go version go1.14.4 linux/amd64