### PR TITLE
Move keys.json file to a sub directory inside the home directory and update ReadMe.md 

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -1,5 +1,5 @@
 # CLI for Importing and Exporting APIs and Applications
-## For WSO2 API Manager 3.1.0
+## For WSO2 API Manager 3.2.0
 
 Command Line tool for importing and exporting APIs/Applications between different API Environments
 
@@ -17,7 +17,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apictl.go -v 3.1.0 -f` to build for all platforms.
+    Execute `./build.sh -t apictl.go -v 3.2.0 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
 
@@ -52,8 +52,8 @@ Command Line tool for importing and exporting APIs/Applications between differen
     > NOTE: Directory structure for configuration files (`$HOME/.wso2apictl`) will be created upon execution of `apictl`
     
     Execute `apictl add-env --help` for detailed instructions
-    > The flags `--environment` (-e) and --token are mandatory
-      You can either provide only the 2 flags `--apim` and `--token`, or all the other 5 flags (`--registration` `--publisher` `--devportal` `--admin` `--token`) without providing `--apim` flag.
+    > The flag `--environment` (-e) is mandatory
+      You can either provide only the `--apim` flag, or all the other 5 flags (`--registration` `--publisher` `--devportal` `--admin` `--token`) without providing `--apim` flag.
       If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint.
     
 - ### Command Autocomplete

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -142,6 +142,11 @@ func createConfigFiles() {
 		}
 	}
 
+	err = utils.CreateDirIfNotExist(utils.LocalCredentialsDirectoryPath)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating local directory: "+utils.LocalCredentialsDirectoryName, err)
+	}
+
 	if !utils.IsFileExist(utils.EnvKeysAllFilePath) {
 		os.Create(utils.EnvKeysAllFilePath)
 	}

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DefaultConfigFile name
-var DefaultConfigFile = "keys.json"
+var DefaultConfigFile = ".wso2apictl.local/keys.json"
 
 // Credential for storing user details
 type Credential struct {

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -29,7 +29,7 @@ import (
 )
 
 // DefaultConfigFile name
-var DefaultConfigFile = ".wso2apictl.local/keys.json"
+var DefaultConfigFile = "keys.json"
 
 // Credential for storing user details
 type Credential struct {
@@ -65,7 +65,7 @@ func GetCredentialStore(f string) (Store, error) {
 
 // GetDefaultCredentialStore returns store from default path
 func GetDefaultCredentialStore() (Store, error) {
-	return GetCredentialStore(filepath.Join(utils.ConfigDirPath, DefaultConfigFile))
+	return GetCredentialStore(filepath.Join(utils.LocalCredentialsDirectoryPath, DefaultConfigFile))
 }
 
 // GetOAuthAccessToken generates an accesstoken for CLI

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -42,9 +42,11 @@ func getEnv(key, defaultValue string) string {
 
 var ConfigDirPath = filepath.Join(HomeDirectory, ConfigDirName)
 
-const EnvKeysAllFileName = "env_keys_all.yaml"
+const LocalCredentialsDirectoryName = ".wso2apictl.local"
+var LocalCredentialsDirectoryPath = filepath.Join(ConfigDirPath, LocalCredentialsDirectoryName)
 
-var EnvKeysAllFilePath = filepath.Join(ConfigDirPath, EnvKeysAllFileName)
+const EnvKeysAllFileName = "env_keys_all.yaml"
+var EnvKeysAllFilePath = filepath.Join(LocalCredentialsDirectoryPath, EnvKeysAllFileName)
 
 const MainConfigFileName = "main_config.yaml"
 const SampleMainConfigFileName = "main_config.yaml.sample"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -43,15 +43,13 @@ func getEnv(key, defaultValue string) string {
 var ConfigDirPath = filepath.Join(HomeDirectory, ConfigDirName)
 
 const LocalCredentialsDirectoryName = ".wso2apictl.local"
-var LocalCredentialsDirectoryPath = filepath.Join(ConfigDirPath, LocalCredentialsDirectoryName)
-
 const EnvKeysAllFileName = "env_keys_all.yaml"
-var EnvKeysAllFilePath = filepath.Join(LocalCredentialsDirectoryPath, EnvKeysAllFileName)
-
 const MainConfigFileName = "main_config.yaml"
 const SampleMainConfigFileName = "main_config.yaml.sample"
 const DefaultAPISpecFileName = "default_api.yaml"
 
+var LocalCredentialsDirectoryPath = filepath.Join(HomeDirectory, LocalCredentialsDirectoryName)
+var EnvKeysAllFilePath = filepath.Join(LocalCredentialsDirectoryPath, EnvKeysAllFileName)
 var MainConfigFilePath = filepath.Join(ConfigDirPath, MainConfigFileName)
 var SampleMainConfigFilePath = filepath.Join(ConfigDirPath, SampleMainConfigFileName)
 var DefaultAPISpecFilePath = filepath.Join(ConfigDirPath, DefaultAPISpecFileName)
@@ -146,7 +144,7 @@ var EnvReplaceFilePaths = []string{
 
 // project types
 const (
-	ProjectTypeNone         = "None"
+	ProjectTypeNone        = "None"
 	ProjectTypeApi         = "API"
 	ProjectTypeApiProduct  = "API Product"
 	ProjectTypeApplication = "Application"

--- a/import-export-cli/utils/utils.go
+++ b/import-export-cli/utils/utils.go
@@ -210,7 +210,7 @@ func WriteToFileSystem(exportAPIName, exportAPIVersion, exportEnvironment, expor
 	if err != nil {
 		HandleErrorAndExit("Error creating zip archive", err)
 	}
-	fmt.Println("Succesfully exported API!")
+	fmt.Println("Successfully exported API!")
 	fmt.Println("Find the exported API at " + pFile)
 
 }


### PR DESCRIPTION
## Purpose
The API Controller is being used in CI/CD tasks. When performing APICTL tasks you need to login to the environment by giving the username and the password as below. These credentials will be stored in a file named keys.json when the user logged in. To avoid this specific file is being mounted its required to move this keys.json file into a subdirectory inside of the home directory. This PR will support that task.

Furthermore, this PR will update the ReadMe.MD according to the latest release of the API controller tool.

## Goals

1. Fixes https://github.com/wso2/product-apim-tooling/issues/347
2. Update ReadMe.md file
3. Correcting a spelling mistake of a message

## Approach
### Part1
After this fix folder structure will be changed as follows.

```
   <HOME>
                 | .wso2apictl
                 |        |
                 |        |-------------exported
                 |                                |-------------apis
                 |                                |-------------apps
                 |                                |-------------api-products
                 |                                |-------------migration
                 |        |-------------mainConfig.yaml
                 |        |-------------mainConfig.yaml.sample
                 |        |-------------default_api.yaml
                 |
                 |.wso2apictl.local
                           |-------------keys.json
                           |-------------env_keys_all.yaml
```

## Documentation
Guidelines should be provided in the documents stating it's required not to mount this new subdirectory when performing CI/Cd process.
Adding a step to logout in CI/CD process for further security.


## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
APICTL- 3.2.0
Go 1.14
 
