### PR TITLE
Added support for public certificate installation for secure https communication

### DIFF
--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -127,6 +127,8 @@ func createConfigFiles() {
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedAppsDirName))
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedMigrationArtifactsDirName))
 
+	utils.CreateDirIfNotExist(DefaultCertDirPath)
+
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)
 		mainConfig.Config = utils.Config{utils.DefaultHttpRequestTimeout,

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -127,7 +127,7 @@ func createConfigFiles() {
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedAppsDirName))
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedMigrationArtifactsDirName))
 
-	utils.CreateDirIfNotExist(DefaultCertDirPath)
+	utils.CreateDirIfNotExist(utils.DefaultCertDirPath)
 
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -59,8 +59,10 @@ const ExportedApisDirName = "apis"
 const ExportedApiProductsDirName = "api-products"
 const ExportedAppsDirName = "apps"
 const ExportedMigrationArtifactsDirName = "migration"
+const CertificatesDirName = "certs"
 
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
+var DefaultCertDirPath = filepath.Join(ConfigDirPath, CertificatesDirName)
 
 const defaultApiApplicationImportExportSuffix = "api/am/admin/v1"
 const defaultApiListEndpointSuffix = "api/am/publisher/v1/apis"

--- a/import-export-cli/utils/httpUtils.go
+++ b/import-export-cli/utils/httpUtils.go
@@ -60,6 +60,8 @@ func IsValidUrl(urlStr string) bool {
 func ReadCertsFromDir() *x509.CertPool {
 	certs, err := x509.SystemCertPool()
 	if err != nil || certs == nil {
+		//if the OS is windows, systemCertPool will return an error. For windows, CA certificates has to be added
+		//to the .wso2apictl/certs directory.
 		certs = x509.NewCertPool()
 	}
 
@@ -72,8 +74,10 @@ func ReadCertsFromDir() *x509.CertPool {
 				fileData, err := ioutil.ReadFile(certFilePath)
 				if fileData != nil && err == nil {
 					if c, err := x509.ParseCertificate(fileData); err == nil {
+						//if the certificate is DER encoded, add it directly to the cert pool.
 						certs.AddCert(c)
 					} else {
+						//if the certificate is PEM encoded.
 						certs.AppendCertsFromPEM(fileData)
 					}
 				} else {

--- a/import-export-cli/utils/httpUtils.go
+++ b/import-export-cli/utils/httpUtils.go
@@ -71,12 +71,10 @@ func ReadCertsFromDir() *x509.CertPool {
 				certFilePath := filepath.Join(DefaultCertDirPath, certificate.Name())
 				fileData, err := ioutil.ReadFile(certFilePath)
 				if fileData != nil && err == nil {
-					pub, parseErr := x509.ParseCertificate(fileData)
-					// if cert is PEM encoded, pub == nil and DER encoded, pub != nil
- 					if pub == nil {
+					if c, err := x509.ParseCertificate(fileData); err == nil {
+						certs.AddCert(c)
+					} else {
 						certs.AppendCertsFromPEM(fileData)
-					} else if parseErr == nil {
-						certs.AddCert(pub)
 					}
 				} else {
 					fmt.Printf(PlainTextWarnMessage, certificate.Name())


### PR DESCRIPTION
Instead of creating the a new certificate pool, system cert pool with CA certs is imported. If new certificate needs to be added,  .pem or .crt files in a new directory ( .wso2apictl/certs) will be imported.

Related git issue: https://github.com/wso2/product-apim-tooling/issues/235