### PR TITLE
Added support to use different certificates for secure https communication

### DIFF
--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -125,6 +125,8 @@ func createConfigFiles() {
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedAppsDirName))
 	utils.CreateDirIfNotExist(filepath.Join(utils.DefaultExportDirPath, utils.ExportedMigrationArtifactsDirName))
 
+	utils.CreateDirIfNotExist(utils.DefaultCertDirPath)
+
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)
 		mainConfig.Config = utils.Config{utils.DefaultHttpRequestTimeout,

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -50,8 +50,10 @@ const DefaultExportDirName = "exported"
 const ExportedApisDirName = "apis"
 const ExportedAppsDirName = "apps"
 const ExportedMigrationArtifactsDirName = "migration"
+const CertificatesDirName = "certs"
 
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
+var DefaultCertDirPath = filepath.Join(ConfigDirPath, CertificatesDirName)
 
 const defaultApiApplicationImportExportSuffix = "api/am/admin/v0.16"
 const defaultApiListEndpointSuffix = "api/am/publisher/v1/apis"


### PR DESCRIPTION
After these changes, if the endpoint cert is signed by a CA, CA certs will be imported from system trusted certs and if there are other certs, they can be imported by adding to the .wso2apictl/certs directory.

Related git issue: #235