### PR TITLE
Add "enableStore" property by default when importing APIs in Dev first Approach

### DIFF
--- a/import-export-cli/box/resources/init/default_api.yaml
+++ b/import-export-cli/box/resources/init/default_api.yaml
@@ -11,3 +11,4 @@ visibility: public
 transports: http,https
 productionUrl: http://localhost:8080
 sandboxUrl: http://localhost:8081
+enableStore: true

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -73,6 +73,7 @@ type APIDefinition struct {
 	AccessControl                      string             `json:"accessControl,omitempty" yaml:"accessControl,omitempty"`
 	Rating                             float64            `json:"rating,omitempty" yaml:"rating,omitempty"`
 	IsLatest                           bool               `json:"isLatest,omitempty" yaml:"isLatest,omitempty"`
+	EnableStore                        bool               `json:"enableStore,omitempty" yaml:"enableStore,omitempty"`
 	KeyManagers                        []string           `json:"keyManagers,omitempty" yaml:"keyManagers,omitempty"`
 }
 type ID struct {


### PR DESCRIPTION
## Purpose
APIs created with Dev first Approach using API Controller are not visible in Devportal even though APIs are in the published state.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/428

## Approach
This is caused by newly added RXT Field "enableStore" which is related to Admin portal. Therefore when an user initializing an API using API controller this field has to added by default and value should be true. Otherwise even though API is published it is not visible  in developer portal.

## User stories
Import Apis using Dev first approach

## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0
APICTL- 3.2.0
Go 1.14