### PR TITLE
Removing whitespace in the context and contextTemplate

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -679,6 +679,7 @@ func replaceEnvVariables(apiFilePath string) error {
 
 func populateAPIWithDefaults(def *v2.APIDefinition) (dirty bool) {
 	dirty = false
+	def.Context = strings.ReplaceAll(def.Context, " ", "")
 	if def.ContextTemplate == "" {
 		if !strings.Contains(def.Context, "{version}") {
 			def.ContextTemplate = path.Clean(def.Context + "/{version}")

--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -116,6 +116,7 @@ func getAPIProductID(name, version, environment, accessOAuthToken string) (strin
 
 func populateAPIProductWithDefaults(def *v2.APIProductDefinition) (dirty bool) {
 	dirty = false
+	def.Context = strings.ReplaceAll(def.Context, " ", "")
 	if def.ContextTemplate == "" {
 		if !strings.Contains(def.Context, "{version}") {
 			def.ContextTemplate = path.Clean(def.Context + "/{version}")

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Jeffail/gabs"
 	"github.com/go-openapi/loads"
 	"github.com/mitchellh/mapstructure"
-
 )
 
 func swagger2XWO2BasePath(document *loads.Document) (string, bool) {
@@ -226,6 +225,9 @@ func Swagger2Populate(def *APIDefinition, document *loads.Document) error {
 			def.Context = path.Clean(strings.ReplaceAll(basepath, "{version}", def.ID.Version))
 		}
 	}
+
+	def.Context = strings.ReplaceAll(def.Context, " ", "")
+	def.ContextTemplate = strings.ReplaceAll(def.ContextTemplate, " ", "")
 
 	cors, ok, err := swagger2XWSO2Cors(document)
 	if err != nil && ok {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/430

## Goals
From the UI (API Publisher), we do not allow spaces in the context (including the contextTemplate as well). From the APICTL side too we should handle it.

## Approach
- Remove if there are any spaces in the context or in the contextTemplate when executing **_apictl init_**.
- Remove if there are any spaces in the context or in the contextTemplate when executing **_apictl import-api_**.
- Remove if there are any spaces in the context or in the contextTemplate when executing **_apictl import api-product_**.

## User stories
User stories related to the scenario explained in https://github.com/wso2/product-apim-tooling/issues/430

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64