### PR TITLE
remove spaces in apiname and version when doing "apictl init"

### DIFF
--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -226,6 +226,9 @@ func Swagger2Populate(def *APIDefinition, document *loads.Document) error {
 		}
 	}
 
+	// trim spaces if available
+	def.ID.APIName = strings.ReplaceAll(def.ID.APIName, " ", "")
+	def.ID.Version = strings.ReplaceAll(def.ID.Version, " ", "")
 	def.Context = strings.ReplaceAll(def.Context, " ", "")
 	def.ContextTemplate = strings.ReplaceAll(def.ContextTemplate, " ", "")
 


### PR DESCRIPTION
## Purpose
Remove spaces in apiname and version when doing `apictl init --oas <definition>`

