### PR TITLE
Set up path separator supported for all Operating systems when running Integration Tests

### DIFF
--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -308,7 +308,7 @@ func CreateTempDir(t *testing.T, path string) {
 }
 
 func GetExportedPathFromOutput(output string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(output[strings.Index(output, "/"):], "\n", ""), " ", "")
+	return strings.ReplaceAll(strings.ReplaceAll(output[strings.Index(output, string(os.PathSeparator)):], "\n", ""), " ", "")
 }
 
 //Count number of files in a directory


### PR DESCRIPTION
## Purpose
Set up path separator supported for all Operating systems when running Integration Tests

