### PR TITLE
Adding Integration Tests - (Part 3)

### DIFF
--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -934,7 +934,7 @@ func TestChangeLifeCycleStatusOfApiFailWithAUserWithoutPermissions(t *testing.T)
 	testutils.ValidateChangeLifeCycleStatusOfAPIFailure(t, args)
 }
 
-func TestChangeLifeCycleStatusOfApiWithActiveSubscription(t *testing.T) {
+func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionWithAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword
 
@@ -961,6 +961,43 @@ func TestChangeLifeCycleStatusOfApiWithActiveSubscription(t *testing.T) {
 	//Change life cycle state of Api from PUBLISHED to CREATED
 	argsToLifeCycleStateChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
 		CtlUser:       testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Demote to Created",
+		ExpectedState: "CREATED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, argsToLifeCycleStateChange)
+	testutils.UnsubscribeAPI(dev, args.CtlUser.Username, args.CtlUser.Password, args.Api.ID)
+}
+
+func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	testutils.PublishAPI(dev, devopsUsername, devopsPassword, api.ID)
+
+	args := &testutils.ApiGetKeyTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:     api,
+		Apim:    dev,
+	}
+
+	//Create an active subscription for Api
+	testutils.ValidateGetKeysWithoutCleanup(t, args)
+
+	base.WaitForIndexing()
+
+	//Change life cycle state of Api from PUBLISHED to CREATED
+	argsToLifeCycleStateChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
 		APIM:          dev,
 		Api:           api,
 		Action:        "Demote to Created",

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -19,6 +19,7 @@
 package integration
 
 import (
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"testing"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
@@ -712,6 +713,38 @@ func TestDeleteApiSuperTenantUser(t *testing.T) {
 	}
 
 	testutils.ValidateAPIDelete(t, args)
+}
+
+func TestDeleteApiWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
+	adminUser := superAdminUser
+	adminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	var api *apim.API
+
+	// This will be the API that will be deleted by apictl, so no need to do cleaning
+	api = testutils.AddAPIWithoutCleaning(t, dev, adminUser, adminPassword)
+
+	args := &testutils.ApiGetKeyTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
+		Api:     api,
+		Apim:    dev,
+	}
+	//Publish created API
+	testutils.PublishAPI(dev, adminUser, adminPassword, api.ID)
+
+	testutils.ValidateGetKeysWithoutCleanup(t, args)
+	//args to delete API
+	argsToDelete := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
+		Api:     api,
+		SrcAPIM: dev,
+	}
+	base.WaitForIndexing()
+
+	//validate Api with active subscriptions delete failure
+	testutils.ValidateAPIDeleteFailure(t, argsToDelete)
 }
 
 func TestExportApisWithExportApisCommand(t *testing.T) {

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -738,3 +738,165 @@ func TestExportApisWithExportApisCommand(t *testing.T) {
 
 	testutils.ValidateAllApisOfATenantIsExported(t, args, apisAdded)
 }
+
+func TestChangeLifeCycleStatusOfApiAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	//Change life cycle state of Api from CREATED to PUBLISHED
+	args := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Publish",
+		ExpectedState: "PUBLISHED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, args)
+
+	//Change life cycle state of Api from PUBLISHED to CREATED
+	argsToNextChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Demote to Created",
+		ExpectedState: "CREATED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, argsToNextChange)
+}
+
+func TestChangeLifeCycleStatusOfApiDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	//Change life cycle state of Api from CREATED to PUBLISHED
+	args := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Publish",
+		ExpectedState: "PUBLISHED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, args)
+
+	//Change life cycle state of Api from PUBLISHED to CREATED
+	argsToNextChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Demote to Created",
+		ExpectedState: "CREATED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, argsToNextChange)
+}
+
+func TestChangeLifeCycleStatusOfApiAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	//Change life cycle state of Api from CREATED to PUBLISHED
+	args := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Publish",
+		ExpectedState: "PUBLISHED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, args)
+
+	//Change life cycle state of Api from PUBLISHED to CREATED
+	argsToNextChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Demote to Created",
+		ExpectedState: "CREATED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, argsToNextChange)
+}
+
+func TestChangeLifeCycleStatusOfApiDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	//Change life cycle state of Api from CREATED to PUBLISHED
+	args := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Publish",
+		ExpectedState: "PUBLISHED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, args)
+
+	//Change life cycle state of Api from PUBLISHED to CREATED
+	argsToNextChange := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Demote to Created",
+		ExpectedState: "CREATED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPI(t, argsToNextChange)
+}
+
+func TestChangeLifeCycleStatusOfApiFailWithAUserWithoutPermissions(t *testing.T) {
+	subscriberUsername := subscriber.UserName
+	subscriberDevopsPassword := subscriber.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	// Add the API to env
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	//Change life cycle state of Api from CREATED to PUBLISHED
+	args := &testutils.ApiChangeLifeCycleStatusTestArgs{
+		CtlUser:       testutils.Credentials{Username: subscriberUsername, Password: subscriberDevopsPassword},
+		APIM:          dev,
+		Api:           api,
+		Action:        "Publish",
+		ExpectedState: "PUBLISHED",
+	}
+
+	testutils.ValidateChangeLifeCycleStatusOfAPIFailure(t, args)
+}

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -572,3 +572,21 @@ func ValidateAPIProductDeleteFailure(t *testing.T, args *ApiProductImportExportT
 
 	assert.Equal(t, apiProductsListBeforeDelete.Count, apiProductsListAfterDelete.Count, "API Product delete is successful")
 }
+
+func ValidateAPIProductDeleteFailureWithExistingEnv(t *testing.T, args *ApiProductImportExportTestArgs) {
+
+	apiProductsListBeforeDelete := args.SrcAPIM.GetAPIProducts()
+
+	deleteAPIProductByCtl(t, args)
+
+	base.WaitForIndexing()
+	apiProductsListAfterDelete := args.SrcAPIM.GetAPIProducts()
+
+	assert.Equal(t, apiProductsListBeforeDelete.Count, apiProductsListAfterDelete.Count, "API Product delete is successful")
+
+	//Remove subscription and remove Api-Product for cleanup
+	t.Cleanup(func() {
+		UnsubscribeAPI(args.SrcAPIM, args.CtlUser.Username, args.CtlUser.Password, args.ApiProduct.ID)
+		deleteAPIProductByCtl(t, args)
+	})
+}

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -219,6 +219,12 @@ func listAPIs(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 	return output, err
 }
 
+func changeLifeCycleOfAPI(t *testing.T, args *ApiChangeLifeCycleStatusTestArgs) (string, error) {
+	output, err := base.Execute(t, "change-status", "api", "-a", args.Action, "-n", args.Api.Name,
+		"-v", args.Api.Version, "-e", args.APIM.EnvName, "-k", "--verbose")
+	return output, err
+}
+
 func ValidateAPIExportFailure(t *testing.T, args *ApiImportExportTestArgs) {
 	t.Helper()
 
@@ -528,4 +534,43 @@ func ImportApiFromProjectWithUpdate(t *testing.T, projectName string, client *ap
 func ExportApisWithOneCommand(t *testing.T, args *InitTestArgs) (string, error) {
 	output, error := base.Execute(t, "export-apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force", "--verbose")
 	return output, error
+}
+
+func ValidateChangeLifeCycleStatusOfAPI(t *testing.T, args *ApiChangeLifeCycleStatusTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.APIM.GetEnvName(), args.APIM.GetApimURL(), args.APIM.GetTokenURL())
+
+	// Login to apictl
+	base.Login(t, args.APIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	//Execute apictl command to change life cycle of an Api
+	output, _ := changeLifeCycleOfAPI(t, args)
+	//Assert apictl output
+	assert.Contains(t, output, "state changed successfully!", "Error while changing life cycle of API")
+
+	base.WaitForIndexing()
+	//Assert life cycle state after change
+	api := getAPI(t, args.APIM, args.Api.Name, args.CtlUser.Username, args.CtlUser.Password)
+	assert.Equal(t, args.ExpectedState, api.LifeCycleStatus, "Expected Life cycle state change is not equals to actual status")
+}
+
+func ValidateChangeLifeCycleStatusOfAPIFailure(t *testing.T, args *ApiChangeLifeCycleStatusTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.APIM.GetEnvName(), args.APIM.GetApimURL(), args.APIM.GetTokenURL())
+
+	// Login to apictl
+	base.Login(t, args.APIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	//Execute apictl command to change life cycle of an Api
+	output, _ := changeLifeCycleOfAPI(t, args)
+	//Assert apictl output
+	assert.NotContains(t, output, "state changed successfully!", "Error while changing life cycle of API")
 }

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -467,6 +467,21 @@ func ValidateAPIDelete(t *testing.T, args *ApiImportExportTestArgs) {
 	validateAPIIsDeleted(t, args.Api, apisListAfterDelete)
 }
 
+func ValidateAPIDeleteFailure(t *testing.T, args *ApiImportExportTestArgs) {
+	t.Helper()
+
+	apisListBeforeDelete := args.SrcAPIM.GetAPIs()
+
+	output, _ := deleteAPIByCtl(t, args)
+
+	apisListAfterDelete := args.SrcAPIM.GetAPIs()
+	base.WaitForIndexing()
+
+	// Validate whether the expected number of API count is there
+	assert.NotContains(t, output, " API deleted successfully!. Status: 200", "Api delete is success with active subscriptions")
+	assert.NotEqual(t, apisListBeforeDelete.Count, apisListAfterDelete.Count+1, "Expected number of APIs not deleted")
+}
+
 func exportApiImportedFromProject(t *testing.T, APIName string, APIVersion string, EnvName string) (string, error) {
 	return base.Execute(t, "export-api", "-n", APIName, "-v", APIVersion, "-e", EnvName)
 }

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -480,6 +480,10 @@ func ValidateAPIDeleteFailure(t *testing.T, args *ApiImportExportTestArgs) {
 	// Validate whether the expected number of API count is there
 	assert.NotContains(t, output, " API deleted successfully!. Status: 200", "Api delete is success with active subscriptions")
 	assert.NotEqual(t, apisListBeforeDelete.Count, apisListAfterDelete.Count+1, "Expected number of APIs not deleted")
+
+	t.Cleanup(func() {
+		UnsubscribeAPI(args.SrcAPIM, args.CtlUser.Username, args.CtlUser.Password, args.Api.ID)
+	})
 }
 
 func exportApiImportedFromProject(t *testing.T, APIName string, APIVersion string, EnvName string) (string, error) {
@@ -588,4 +592,5 @@ func ValidateChangeLifeCycleStatusOfAPIFailure(t *testing.T, args *ApiChangeLife
 	output, _ := changeLifeCycleOfAPI(t, args)
 	//Assert apictl output
 	assert.NotContains(t, output, "state changed successfully!", "Error while changing life cycle of API")
+	assert.NotEqual(t, args.Api.LifeCycleStatus, args.ExpectedState, "Life Cycle State changed successfully")
 }

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -215,6 +215,8 @@ func ValidateAppDelete(t *testing.T, args *AppImportExportTestArgs) {
 }
 
 func ValidateListAppsWithOwner(t *testing.T, envName string) {
+	//Clean up existing default apictl app
+	base.Execute(t, "delete", "app", "-n", "default-apictl-app", "-e", envName, "-k", "--verbose")
 	response := ListAppsWithOwner(t, envName, "admin")
 	assert.Equal(t, 5, len(response), "Failed when listing Applications with owner as Admin")
 

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -34,7 +34,7 @@ func InitProjectWithOasFlag(t *testing.T, args *InitTestArgs) (string, error) {
 	base.SetupEnvWithoutTokenFlag(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL())
 	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	output, err := base.Execute(t, "init", args.InitFlag, "--oas", args.OasFlag, "--verbose")
+	output, err := base.Execute(t, "init", args.InitFlag, "--oas", args.OasFlag, "--verbose", "-f")
 	return output, err
 }
 

--- a/import-export-cli/integration/testutils/keys_testUtils.go
+++ b/import-export-cli/integration/testutils/keys_testUtils.go
@@ -127,3 +127,34 @@ func ValidateGetKeys(t *testing.T, args *ApiGetKeyTestArgs) {
 		UnsubscribeAPI(args.Apim, args.CtlUser.Username, args.CtlUser.Password, args.ApiProduct.ID)
 	}
 }
+
+func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs) {
+	t.Helper()
+
+	base.SetupEnv(t, args.Apim.GetEnvName(), args.Apim.GetApimURL(), args.Apim.GetTokenURL())
+	base.Login(t, args.Apim.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	var err error
+	var result string
+	if args.Api != nil {
+		result, err = GetKeys(t, args.Api.Provider, args.Api.Name, args.Api.Version, args.Apim.GetEnvName())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		assert.Nil(t, err, "Error while getting key")
+
+		invokeAPI(t, getResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
+	}
+
+	if args.ApiProduct != nil {
+		result, err = GetKeys(t, args.ApiProduct.Provider, args.ApiProduct.Name, utils.DefaultApiProductVersion, args.Apim.GetEnvName())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		assert.Nil(t, err, "Error while getting key")
+
+		invokeAPIProduct(t, getResourceURLForAPIProduct(args.Apim, args.ApiProduct), base.GetValueOfUniformResponse(result), 200)
+	}
+}

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -85,3 +85,13 @@ type InitTestArgs struct {
 	APIName        string
 	srcAPIM        *apim.Client
 }
+
+type ApiChangeLifeCycleStatusTestArgs struct {
+	ApiProvider   Credentials
+	CtlUser       Credentials
+	Api           *apim.API
+	APIM          *apim.Client
+	Action        string
+	Provider      string
+	ExpectedState string
+}


### PR DESCRIPTION
## Purpose
Adding Integration tests to apictl integration test suite

## Goals
Automating Integration tests

## Automation tests
### Covered Automated Tests from this PR

**Tests Related to APIs**

1. Delete API with a active subscription (TestDeleteApiWithActiveSubscriptionsSuperTenantUser)
2. Change Life Cycle state of an API as Admin super tenant user (TestChangeLifeCycleStatusOfApiAdminSuperTenantUser)
3. Change Life Cycle state of an API as Devops super tenant user (TestChangeLifeCycleStatusOfApiDevopsSuperTenantUser)
4. Change Life Cycle state of an API as Admin tenant user (TestChangeLifeCycleStatusOfApiAdminTenantUser)
5. Change Life Cycle state of an API as Devops tenant user (TestChangeLifeCycleStatusOfApiDevopsTenantUser)
6. Change Life Cycle state of an API as a user without proper permissions (TestChangeLifeCycleStatusOfApiFailWithAUserWithoutPermissions)
7. Change Life Cycle state of an API with active subscriptions as Admin super tenant user (TestChangeLifeCycleStatusOfApiWithActiveSubscriptionWithAdminSuperTenantUser)
8. Change Life Cycle state of an API with active subscriptions as Devops super tenant user (TestChangeLifeCycleStatusOfApiWithActiveSubscriptionWithDevopsSuperTenantUser)


**Tests Related to API Products**

1. Delete API Product with a active subscription (TestDeleteApiProductWithActiveSubscriptionsSuperTenantUser)

**Tests Related to Keys**

1. Get keys consecutively for an API (TestGetKeysConsecutivelyAdminSuperTenantUser)
2. Get keys consecutively for an API Product (TestGetKeysConsecutivelyForAPIProductAdminSuperTenantUser)

## Test environment
OS - Ubuntu 20.04 LTS
Java - JDK 1.8_252
APIM - 3.2.0 -RC5
