### PR TITLE
Fix for #470

### DIFF
--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -54,9 +54,10 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + addEnvCmdLiteral + ` -e prod
 --token https://gw.com:8243/token
 
 NOTE: The flag --environment (-e) is mandatory.
-You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin --token) without providing --apim flag.
+You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
 cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+
 // addEnvCmd represents the addEnv command
 var addEnvCmd = &cobra.Command{
 	Use:     addEnvCmdLiteral,

--- a/import-export-cli/cmd/keys.go
+++ b/import-export-cli/cmd/keys.go
@@ -132,6 +132,11 @@ func getKeys() {
 			if appKeys.Count != 0 {
 				//If the keys have not been generated and the application is updated
 				token, err := getNewToken(&appKeys.List[0], scopes)
+				//Assert token endpoint related fails and errors
+				if err != nil {
+					utils.HandleErrorAndExit("Error while generating token. ", err)
+				}
+
 				if accessToken != "" {
 					// Access Token generated successfully.
 					fmt.Println(token)
@@ -643,6 +648,10 @@ func getNewToken(key *utils.ApplicationKey, scopes []string) (string, error) {
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationJSON
 
 	resp, err := utils.InvokePOSTRequest(tokenEndpoint, headers, body)
+
+	if err != nil {
+		return "", errors.New("Token Endpoint is not valid. " + err.Error())
+	}
 
 	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
 		// 200 OK or 201 Created


### PR DESCRIPTION
## Purpose
If you have not provided a proper token endpoint you will receive a blank error message when trying to generate keys for a particular API.
A meaningful error message should be output to the user when generating keys if a wrong token endpoint was added.
This PR will solve this issue.

And this PR will correct the note message in addenv.go file as it needs to be stated.

> NOTE: The flag --environment (-e) is mandatory.
> You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
> If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
> cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`

## Goals
Fix for #470 

## Approach
When the token endpoint is Invalid the following error message will be provided as the output

**apictl: Error while generating token:  Reason: Token Endpoint is not valid. Post "https://localhost:9444/oauth2/token": dial tcp [::1]:9444: connect: connection refused**

Eg: 
```
./apictl get-keys -n SwaggerPetstoreNew -e dev1 --token  https://localhost:9444/oauth2/token --verbose
Executed ImportExportCLI (apictl) on Wed, 26 Aug 2020 11:00:29 +0530
[INFO]: Insecure: false
[INFO]: get-keys called
[INFO]: Retrieved credentials of the environment successfully
[INFO]: Getting ClientID, ClientSecret: Status - 200 
[INFO]: Called DCR endpoint successfully
[INFO]: connecting to https://localhost:9443/oauth2/token
[INFO]: Generated a token to access the Publisher and DevPortal REST APIs.
[INFO]: Retrieved available subscription tiers of the API or API Product:  [Bronze Unlimited]
[INFO]: Retrieved application throttling policy successfully:  10PerMin
[INFO]: Searched if application exists.
[INFO]: CLI application already exists
[INFO]: API or API Product name:  SwaggerPetstoreNew & version:  1.0.0 exists
[INFO]: API or API Product SwaggerPetstoreNew : 1.0.0 subscribed successfully.
apictl: Error while generating token:  Reason: Token Endpoint is not valid. Post "https://localhost:9444/oauth2/token": dial tcp [::1]:9444: connect: connection refused
Exit status 1
```

## Documentation
No doc changes required

## Test environment
OS: Ubuntu 20.04 LTS
APIM 3.2.0
APICTL RC2
