### PR TITLE
[2.x] Adding the support to import Mutual SSL certificates using api_params.yaml file

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -78,6 +78,30 @@ type Cert struct {
 	Certificate string `json:"certificate"`
 }
 
+// MutualSslCert stores mutualssl certificate details
+type MutualSslCert struct {
+	// TierName of the certificate (eg:- Unlimited, Gold, Silver, Bronze)
+	TierName string `yaml:"tierName" json:"tierName"`
+	// Alias for certificate
+	Alias string `yaml:"alias" json:"alias"`
+	// Path for certificate file
+	Path string `yaml:"path" json:"-"`
+	// Certificate is used for internal purposes, it contains secret in base64
+	Certificate string `json:"certificate"`
+	// ApiIdentifier is used for internal purposes, it contains details of the API to be stored in client_certificates file
+	APIIdentifier APIIdentifier `json:"apiIdentifier"`
+}
+
+// ApiIdentifier stores API Identifier details
+type APIIdentifier struct {
+	// Name of the provider of the API
+	ProviderName string `json:"providerName"`
+	// Name of the API
+	APIName string `json:"apiName"`
+	// Version of the API
+	Version string `json:"version"`
+}
+
 // Environment represents an api environment
 type Environment struct {
 	// Name of the environment
@@ -91,7 +115,8 @@ type Environment struct {
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment
-	Certs []Cert `yaml:"certs"`
+	Certs          []Cert          `yaml:"certs"`
+	MutualSslCerts []MutualSslCert `yaml:"mutualSslCerts"`
 }
 
 // ApiParams represents environments defined in configuration file

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -86,6 +86,7 @@ const LogPrefixError = "[ERROR]: "
 
 // String Constants
 const SearchAndTag = "&"
+const APISecurityMutualSsl = "mutualssl"
 
 // Other
 const DefaultTokenValidityPeriod = "3600"

--- a/import-export-cli/utils/yaml.go
+++ b/import-export-cli/utils/yaml.go
@@ -4,23 +4,11 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
-	yaml2 "gopkg.in/yaml.v2"
 )
 
 // JsonToYaml converts a json string to yaml
 func JsonToYaml(jsonData []byte) ([]byte, error) {
-	var m yaml2.MapSlice
-	err := yaml2.Unmarshal(jsonData, &m)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := yaml2.Marshal(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
+	return yaml.JSONToYAML(jsonData)
 }
 
 // YamlToJson converts a yaml string to json


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/477
Fixes: https://github.com/wso2/product-apim-tooling/issues/370

## Goals
Implement the support to correctly import endpoint certificates and Mutual SSL certificates using the api_params.yaml file.

## Approach
- Introduced a new fields (which is almost similar to the field “certs”) named **mutualSslCerts** that can be used to import Mutual SSL certificates using the api_params.yaml file. This field is an array, which contains the objects that should have the sub fields as follows.
  - **tierName**: Name of the tier of the certificate
  - **alias**: Alias for the certificate
  - **path**: Filepath to locate the certificate
(Please refer the section **User stories** to understand the usage of these parameters more.)
- Replaced the old implementation of **JsonToYaml** with a call to **JSONToYaml** function in the library github.com/ghodss/yaml

## User stories
- You can enable Mutual SSL security by importing certificates as shown in the below example api_params.yaml file.
```
environments:
  - name: dev
    endpoints:
      production:
      sandbox:
  - name: production
    endpoints:
      production:
      sandbox:
    mutualSslCerts:
        - tierName: Unlimited
          alias: Alice
          path: /home/myname/Documents/Work/certificates/alice.crt
        - tierName: Gold
          alias: Bob
          path: /home/myname/Documents/Work/certificates/bob.crt
```
- After the API is imported to the APIM (2.6.0) the mutualssl certificates will be shown as below.
![image](https://user-images.githubusercontent.com/25246848/93757776-f3f28180-fc24-11ea-921b-f6148a5321a7.png)

## Release note
Support to import Mutual SSL certificates using api_params.yaml has been added to WSO2 APIMCLI 2.x.x.

## Documentation
Documentation changes need to be done.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/377

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64