### PR TITLE
[3.2.x] [FrontPort] Adding the support to import Mutual SSL certificates using api_params.yaml file

### DIFF
--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -216,7 +216,7 @@ func importAPIProduct(endpoint, httpMethod, filePath, accessToken string, extraP
 }
 
 // preProcessDependentAPIs pre processes dependent APIs
-func preProcessDependentAPIs(apiProductFilePath, importEnvironment string) error {
+func preProcessDependentAPIs(apiProductFilePath, importEnvironment string, importAPIProductPreserveProvider bool) error {
 	// Check whether the APIs directory exists
 	apisDirectoryPath := apiProductFilePath + string(os.PathSeparator) + "APIs"
 	_, err := os.Stat(apisDirectoryPath)
@@ -242,7 +242,7 @@ func preProcessDependentAPIs(apiProductFilePath, importEnvironment string) error
 		// Check whether api_params.yaml file is available inside the particular API directory
 		if utils.IsFileExist(paramsPath) {
 			// Reading API params file and populate api.yaml
-			err := injectParamsToAPI(apiDirectoryPath, paramsPath, importEnvironment)
+			err := injectParamsToAPI(apiDirectoryPath, paramsPath, importEnvironment, importAPIProductPreserveProvider)
 			if err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func ImportAPIProduct(accessOAuthToken, adminEndpoint, importEnvironment, import
 	apiProductFilePath := tmpPath
 
 	// Pre Process dependent APIs
-	err = preProcessDependentAPIs(apiProductFilePath, importEnvironment)
+	err = preProcessDependentAPIs(apiProductFilePath, importEnvironment, importAPIProductPreserveProvider)
 	if err != nil {
 		return err
 	}

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -109,6 +109,30 @@ type Cert struct {
 	Certificate string `json:"certificate"`
 }
 
+// MutualSslCert stores mutualssl certificate details
+type MutualSslCert struct {
+	// TierName of the certificate (eg:- Unlimited, Gold, Silver, Bronze)
+	TierName string `yaml:"tierName" json:"tierName"`
+	// Alias for certificate
+	Alias string `yaml:"alias" json:"alias"`
+	// Path for certificate file
+	Path string `yaml:"path" json:"-"`
+	// Certificate is used for internal purposes, it contains secret in base64
+	Certificate string `json:"certificate"`
+	// ApiIdentifier is used for internal purposes, it contains details of the API to be stored in client_certificates file
+	APIIdentifier APIIdentifier `json:"apiIdentifier"`
+}
+
+// ApiIdentifier stores API Identifier details
+type APIIdentifier struct {
+	// Name of the provider of the API
+	ProviderName string `json:"providerName"`
+	// Name of the API
+	APIName string `json:"apiName"`
+	// Version of the API
+	Version string `json:"version"`
+}
+
 // Environment represents an api environment
 type Environment struct {
 	// Name of the environment
@@ -131,7 +155,8 @@ type Environment struct {
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment
-	Certs []Cert `yaml:"certs"`
+	Certs          []Cert          `yaml:"certs"`
+	MutualSslCerts []MutualSslCert `yaml:"mutualSslCerts"`
 	// VCS params for the environment
 	VCS APIVCSParams `yaml:"vcs"`
 }

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -69,6 +69,7 @@ const ExportedApiProductsDirName = "api-products"
 const ExportedAppsDirName = "apps"
 const ExportedMigrationArtifactsDirName = "migration"
 const CertificatesDirName = "certs"
+const APISecurityMutualSsl = "mutualssl"
 
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
 var DefaultCertDirPath = filepath.Join(ConfigDirPath, CertificatesDirName)


### PR DESCRIPTION
### Purpose
Implement the support to correctly import endpoint certificates and Mutual SSL certificates using the api_params.yaml file.

### Goals
Fixes: #477 for 3.2.x branch

### Approach

 Introduced a new field (which is almost similar to the field “certs”) named mutualSslCerts that can be used to import Mutual SSL certificates using the api_params.YAML file. This field is an array, which contains the objects that should have the subfields as follows.

- **tierName**: Name of the tier of the certificate
- **alias**: Alias for the certificate
- **path**: Filepath to locate the certificate

(Please refer the section User stories to understand the usage of these parameters more.)

### User stories
You can enable Mutual SSL security by importing certificates as shown in the below example api_params.yaml file.
```
environments:
  - name: dev
    endpoints:
      production:
      sandbox:
  - name: production
    endpoints:
      production:
      sandbox:
    mutualSslCerts:
        - tierName: Unlimited
          alias: Alice
          path: /home/myname/Documents/Work/certificates/alice.crt
        - tierName: Gold
          alias: Bob
          path: /home/myname/Documents/Work/certificates/bob.crt
```
After the API is imported to the APIM (3.2.0) the mutualssl certificates will be shown as below.

![54](https://user-images.githubusercontent.com/42435576/93881217-3e92fd00-fcfc-11ea-9031-27575f27d4fd.png)

### Release notes
Support to import Mutual SSL certificates using api_params.yaml has been added to WSO2 APICTL latest version.

### Documentation
Documentation changes need to be done.

**Test environment**
Ubuntu 20.04 LTS
Java JDK 1.8_245
APIM 3.2.0
APICTL 3.2.0