### PR TITLE
Remove username and repository name validation when configuring API Operator

### DIFF
--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -51,9 +51,6 @@ var DockerHubRegistry = &Registry{
 			if !utils.ValidateValue(repository, utils.RepoValidRegex) {
 				utils.HandleErrorAndExit("Invalid repository name: "+repository, nil)
 			}
-			if !utils.ValidateValue(username, utils.UsernameValidRegex) {
-				utils.HandleErrorAndExit("Invalid username : "+username, nil)
-			}
 
 			// if "--password-stdin" is supplied get password from stdin
 			if (*flagValues)[k8sUtils.FlagBmPasswordStdin].Value.(bool) {
@@ -98,7 +95,7 @@ func readDockerHubInputs() (string, string, string) {
 		}
 
 		username, err = utils.ReadInputString("Enter username", utils.Default{Value: "", IsDefault: false},
-			utils.UsernameValidRegex, true)
+			"", true)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading username from user", err)
 		}

--- a/import-export-cli/operator/registry/dockerhub.go
+++ b/import-export-cli/operator/registry/dockerhub.go
@@ -47,11 +47,6 @@ var DockerHubRegistry = &Registry{
 			username = (*flagValues)[k8sUtils.FlagBmUsername].Value.(string)
 			password = (*flagValues)[k8sUtils.FlagBmPassword].Value.(string)
 
-			// validate required inputs
-			if !utils.ValidateValue(repository, utils.RepoValidRegex) {
-				utils.HandleErrorAndExit("Invalid repository name: "+repository, nil)
-			}
-
 			// if "--password-stdin" is supplied get password from stdin
 			if (*flagValues)[k8sUtils.FlagBmPasswordStdin].Value.(bool) {
 				pwStdin, err := utils.ReadPassword("Enter password")
@@ -88,8 +83,8 @@ func readDockerHubInputs() (string, string, string) {
 	var err error
 
 	for !isConfirm {
-		repository, err = utils.ReadInputString("Enter repository name", utils.Default{Value: "", IsDefault: false},
-			utils.RepoValidRegex, true)
+		repository, err = utils.ReadInputString("Enter repository name",
+			utils.Default{Value: "", IsDefault: false}, "", true)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading repository name from user", err)
 		}

--- a/import-export-cli/operator/registry/https.go
+++ b/import-export-cli/operator/registry/https.go
@@ -44,11 +44,6 @@ var HttpsRegistry = &Registry{
 			username = (*flagValues)[k8sUtils.FlagBmUsername].Value.(string)
 			password = (*flagValues)[k8sUtils.FlagBmPassword].Value.(string)
 
-			// validate required inputs
-			if !utils.ValidateValue(repository, utils.RepoValidRegex) {
-				utils.HandleErrorAndExit("Invalid repository name: "+repository, nil)
-			}
-
 			// if "--password-stdin" is supplied get password from stdin
 			if (*flagValues)[k8sUtils.FlagBmPasswordStdin].Value.(bool) {
 				pwStdin, err := utils.ReadPassword("Enter password")
@@ -97,7 +92,7 @@ func readHttpsRepInputs() (string, string, string) {
 
 	for !isConfirm {
 		repository, err = utils.ReadInputString("Enter repository",
-			utils.Default{Value: "", IsDefault: false}, utils.RepoValidRegex, true)
+			utils.Default{Value: "", IsDefault: false}, "", true)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading registry repository name from user", err)
 		}

--- a/import-export-cli/operator/registry/https.go
+++ b/import-export-cli/operator/registry/https.go
@@ -49,11 +49,6 @@ var HttpsRegistry = &Registry{
 				utils.HandleErrorAndExit("Invalid repository name: "+repository, nil)
 			}
 
-			// validate optional inputs
-			if username != "" && !utils.ValidateValue(username, utils.UsernameValidRegex) {
-				utils.HandleErrorAndExit("Invalid username : "+username, nil)
-			}
-
 			// if "--password-stdin" is supplied get password from stdin
 			if (*flagValues)[k8sUtils.FlagBmPasswordStdin].Value.(bool) {
 				pwStdin, err := utils.ReadPassword("Enter password")
@@ -108,7 +103,7 @@ func readHttpsRepInputs() (string, string, string) {
 		}
 
 		username, err = utils.ReadInputString("Enter username", utils.Default{Value: "", IsDefault: false},
-			utils.UsernameValidRegex, true)
+			"", true)
 		if err != nil {
 			utils.HandleErrorAndExit("Error reading username from user", err)
 		}

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -125,7 +125,6 @@ const SearchAndTag = "&"
 
 // Regex Validation
 const RepoValidRegex = `^[\w\d\-\.\:]*\/?[\w\d\-]+$`
-const UsernameValidRegex = `^[\w\d\-]*$`
 const UrlValidRegex = `^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$`
 
 // Other

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -123,10 +123,6 @@ const LogPrefixError = "[ERROR]: "
 // String Constants
 const SearchAndTag = "&"
 
-// Regex Validation
-const RepoValidRegex = `^[\w\d\-\.\:]*\/?[\w\d\-]+$`
-const UrlValidRegex = `^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$`
-
 // Other
 const DefaultTokenValidityPeriod = 3600
 const DefaultHttpRequestTimeout = 10000


### PR DESCRIPTION
## Purpose
- fix https://github.com/wso2/product-apim-tooling/issues/480
- Remove the whole validation for username.

## Samples

### 1. Interactive mode
```sh
$ apictl install api-operator

Choose registry type:
1: Docker Hub
2: Amazon ECR
3: GCR
4: HTTP Private Registry
5: HTTPS Private Registry
6: Quay.io
Choose a number: 1: 4
Enter repository: foo.bar/dev/hello-world/new
Enter username: foo@bar.com
Enter password:

Repository: foo.bar/dev/hello-world/new
Username  : foo@bar.com
Confirm configurations: Y:
```

### 2. Batch mode
```sh
$ apictl install api-operator -f controller-configs --registry-type=HTTP --repository=192.168.8.132:5000/foo.bar/dev/hello-world/new --username=foo@bar.com --password=foo1234

configmap/controller-config unchanged
secret/apim-secret unchanged
secret/wso2am320-secret unchanged
configmap/docker-registry-config configured
configmap/dockerfile-template unchanged
configmap/mgw-conf-mustache unchanged
configmap/apim-config unchanged
configmap/hpa-configs unchanged
configmap/ingress-configs unchanged
configmap/kaniko-arguments unchanged
configmap/route-configs unchanged
configmap/istio-configs unchanged
configmap/mgw-deployment-configs unchanged
security.wso2.com/default-security-jwt unchanged
configmap/docker-registry-config configured
W0924 18:17:36.868954    7295 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.
secret/docker-registry-credentials configured
[Setting to K8s Mode]
```

### 3. Change registry - interactive
```
$ apictl change registry

Choose registry type:
1: Docker Hub
2: Amazon ECR
3: GCR
4: HTTP Private Registry
5: HTTPS Private Registry
6: Quay.io
Choose a number: 1: 5
Enter repository: foo.bar/dev/hello-world/new
Enter username:  foo.hello@bar.com
Enter password:

Repository: foo.bar/dev/hello-world/new
Username  : foo.hello@bar.com
Confirm configurations: Y:
```

### 4. Change registry - batch mode
```
$ apictl change registry --registry-type=HTTPS --registry-type=HTTPS --repository=helloworld:5000/foo.bar/dev/hello-world/new --username=foo@bar.com --password=foo1234

configmap/docker-registry-config configured
W0924 18:19:41.996494    7315 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.
secret/docker-registry-credentials configured
```