### PR TITLE
Check namespace when updating API in k8s

### DIFF
--- a/import-export-cli/cmd/updateApi.go
+++ b/import-export-cli/cmd/updateApi.go
@@ -53,9 +53,17 @@ var updateApiCmd = &cobra.Command{
 		validateAddApiCommand()
 
 		// check the existence of the API
-		getApiErr := k8sUtils.ExecuteCommandWithoutPrintingErrors(k8sUtils.Kubectl, k8sUtils.K8sGet, k8sUtils.ApiOpCrdApi, flagApiName)
+		getApiErr := k8sUtils.ExecuteCommandWithoutOutputs(
+			k8sUtils.Kubectl, k8sUtils.K8sGet, k8sUtils.ApiOpCrdApi, flagApiName, "-n", flagNamespace)
 		if getApiErr != nil {
-			utils.HandleErrorAndExit(fmt.Sprintf("Could not find the API with the name \"%s\"", flagApiName), nil)
+			var errMsg string
+			if flagNamespace != "" {
+				errMsg = fmt.Sprintf("Could not find the API \"%s\" in the namespace \"%s\"",
+					flagApiName, flagNamespace)
+			} else {
+				errMsg = fmt.Sprintf("Could not find the API \"%s\"", flagApiName)
+			}
+			utils.HandleErrorAndExit(errMsg, nil)
 		}
 
 		//get current timestamp

--- a/import-export-cli/operator/utils/k8sUtils.go
+++ b/import-export-cli/operator/utils/k8sUtils.go
@@ -152,6 +152,12 @@ func ExecuteCommandWithoutPrintingErrors(command string, args ...string) error {
 	return cmd.Run()
 }
 
+// ExecuteCommandWithoutOutputs executes the command with args without printing outputs and errors
+func ExecuteCommandWithoutOutputs(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	return cmd.Run()
+}
+
 // ExecuteCommandFromStdin executes the command with args and prints output the standard output
 func ExecuteCommandFromStdin(stdInput string, command string, args ...string) error {
 	cmd := exec.Command(command, args...)


### PR DESCRIPTION
fix wso2/product-apim-tooling#473

## Purpose
Fix issue of not checking namespace when updating an API

## Test

All APIs deployed
```
$ kubectl get apis --all-namespaces
NAMESPACE   NAME                   INITIAL-REPLICAS   MODE         ENDPOINT   AGE
default     petstore-api-default   1                  privateJet              23m
hello       petstore-api           1                  privateJet              24m
```

#### Successful update
```
$ apictl update api -n petstore-api-default
creating API definition
api.wso2.com/petstore-api-default configured

$ apictl update api -n petstore-api --namespace hello
creating API definition
api.wso2.com/petstore-api configured
```

#### Error updating
```
$ apictl update api -n foo
apictl: Could not find the API "foo"
Exit status 1

$ apictl update api -n foo --namespace hello
apictl: Could not find the API "foo" in the namespace "hello"
Exit status 1
```