### PR TITLE
Remove --dry-run and render registry configs

### DIFF
--- a/import-export-cli/box/resources/kubernetes_resources/docker_credentials.yaml
+++ b/import-export-cli/box/resources/kubernetes_resources/docker_credentials.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+kind:
+metadata:
+  creationTimestamp: null
+  name:
+  namespace:

--- a/import-export-cli/go.mod
+++ b/import-export-cli/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	gopkg.in/yaml.v2 v2.2.8
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
-	sigs.k8s.io/yaml v1.2.0
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.18.2

--- a/import-export-cli/go.sum
+++ b/import-export-cli/go.sum
@@ -668,6 +668,7 @@ github.com/magiconair/properties v0.0.0-20170902060319-8d7837e64d3c h1:BDr2SMw3g
 github.com/magiconair/properties v0.0.0-20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.7.6 h1:U+1DqNen04MdEPgFiIwdOUiqZ8qPa37xgogX/sd3+54=
 github.com/magiconair/properties v1.7.6/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/import-export-cli/operator/utils/consts.go
+++ b/import-export-cli/operator/utils/consts.go
@@ -25,8 +25,8 @@ const K8sApply = "apply"
 const K8sDelete = "delete"
 const K8sRollOut = "rollout"
 const K8sGet = "get"
-const K8sConfigMap = "configmap"
-const K8sSecret = "secret"
+const K8sConfigMap = "ConfigMap"
+const K8sSecret = "Secret"
 const K8sSecretDockerRegType = "docker-registry"
 const K8sApi = "api"
 
@@ -79,6 +79,7 @@ const AwsCredentialsFile = "credentials"
 const GcrSvcAccKeySecret = "google-application-credentials"
 const GcrSvcAccKeyFile = "gcr_key.json"
 const GcrPullSecret = "gcr-pull-secret"
+const DockerConfigJson = ".dockerconfigjson"
 
 // Registry specific flags for batch mode
 const FlagBmRepository = "repository"


### PR DESCRIPTION
### Purpose
This PR removes the `--dry-run` flag which is deprecated in Kubernets v1.18+ and generates the secrets and configmaps for registries using a defined template.

Fixes https://github.com/wso2/k8s-api-operator/issues/425

Tested with HTTP, DockerHub, GCR registry types.