### PR TITLE
[2.x] Adding algoCombo parameter when load balancing is done

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -172,7 +172,8 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	if environmentParams.LoadBalanceEndpoints != nil {
 		environmentParams.LoadBalanceEndpoints.EndpointType = "load_balance"
 		// The default class of the algorithm to be used should be set to RoundRobin
-		environmentParams.LoadBalanceEndpoints.AlgorithmClassName = "org.apache.synapse.endpoints.algorithms.RoundRobin"
+		environmentParams.LoadBalanceEndpoints.AlgorithmClassName = utils.LoadBalanceAlgorithmClass
+		environmentParams.LoadBalanceEndpoints.AlgorithmCombName = utils.LoadBalanceAlgorithmClass
 		configData, err = json.Marshal(environmentParams.LoadBalanceEndpoints)
 		if err != nil {
 			return err

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -49,6 +49,8 @@ type LoadBalanceEndpointsData struct {
 	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
 	// Class name for algorithm to be used if load balancing should be done
 	AlgorithmClassName string `yaml:"algoClassName" json:"algoClassName,omitempty"`
+	// Combo for algorithm to be used if load balancing should be done
+	AlgorithmCombName string `yaml:"algoCombo" json:"algoCombo,omitempty"`
 }
 
 // FailoverEndpointsData contains details about endpoints mainly to be used in load balancing

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -98,3 +98,5 @@ const MigrationAPIsExportMetadataFileName = "migration-apis-export-metadata.yaml
 const LastSucceededApiFileName = "last-succeeded-api.log"
 const LastSuceededContentDelimiter = " " // space
 const DefaultResourceTenantDomain = "tenant-default"
+
+const LoadBalanceAlgorithmClass = "org.apache.synapse.endpoints.algorithms.RoundRobin"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/495

## Goals
If the user has specified load-balanced endpoints in the api_params.yaml file, the algoCombo attribute should be added with the required value.

## Approach
- By default when someone is setting up load balancing endpoints, internally added the below attribute with the below value to **endpointConfig** in api.json (api.yaml) file.
```
"algoCombo":"org.apache.synapse.endpoints.algorithms.RoundRobin"
```
## User stories
After setting up load balanced endpoints and importing that particular API, the user will not receive an error when updating the mediation sequence.

## Related PRs
https://github.com/wso2-support/carbon-apimgt/pull/1706

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.