### PR TITLE
[2.x] Fixing gateway environments setting issue when using api-params.yaml

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -200,8 +200,12 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	if _, err := api.SetP(string(mergedAPIEndpoints), "endpointConfig"); err != nil {
 		return err
 	}
-	if _, err := api.SetP(environmentParams.GatewayEnvironments, "environments"); err != nil {
-		return err
+
+	// replace original GatewayEnvironments only if they are present in api-params file
+	if environmentParams.GatewayEnvironments != nil {
+		if _, err := api.SetP(environmentParams.GatewayEnvironments, "environments"); err != nil {
+			return err
+		}
 	}
 
 	// if the mutualSslCert field is defined in the api_params.yaml, the apiSecurity type should contain mutualssl


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/497

## Goals
Backporting https://github.com/wso2/product-apim-tooling/pull/303

## Approach
Check whether the **gatewayEnvironments** has not been defined in the api_params.yaml file before importing the API.

## User stories
User story broken in https://github.com/wso2/product-apim-tooling/issues/497 will be fixed.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/303

## Test environment
- Ubuntu 20.04 LTS
- go version go1.14.4 linux/amd64