### PR TITLE
Revamping Delete, Install, Uninstall, Change, Add and Update commands along with new "k8s" scope in API Controller

### DIFF
--- a/import-export-cli/cmd/add.go
+++ b/import-export-cli/cmd/add.go
@@ -22,22 +22,37 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const addCmdLiteral = "add"
-const addCmdShortDesc = "Add an API to the kubernetes cluster"
-const addCmdLongDesc = `Add an API from a Swagger file to the kubernetes cluster. JSON and YAML formats are accepted.
-To execute kubernetes commands set mode to Kubernetes`
-const addCmdExamples = utils.ProjectName + " " + addCmdLiteral + " " + addApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+const AddCmdLiteral = "add"
+const AddCmdShortDesc = "Add Environment to Config file"
+const AddCmdLongDesc = `Add new environment and its related endpoints to the config file`
+const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
+--apim  https://localhost:9443 
 
-` + utils.ProjectName + " " + addCmdLiteral + " " + addApiCmdLiteral + " " + `-n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2 --override=true`
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
+--registration https://idp.com:9443 \
+--publisher https://apim.com:9443 \
+--devportal  https://apps.com:9443 \
+--admin  https://apim.com:9443 \
+--token https://gw.com:8243/token
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:     addCmdLiteral,
-	Short:   addCmdShortDesc,
-	Long:    addCmdLongDesc,
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+--apim https://apim.com:9443 \
+--registration https://idp.com:9443 \
+--token https://gw.com:8243/token
+
+NOTE: The flag --environment (-e) is mandatory.
+You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
+If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
+cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+
+// AddCmd represents the add command
+var AddCmd = &cobra.Command{
+	Use:     AddCmdLiteral,
+	Short:   AddCmdShortDesc,
+	Long:    AddCmdLongDesc,
 	Example: addCmdExamples,
 }
 
 func init() {
-	RootCmd.AddCommand(addCmd)
+	RootCmd.AddCommand(AddCmd)
 }

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -63,10 +63,11 @@ var addEnvCmd = &cobra.Command{
 	Short:   addEnvCmdShortDesc,
 	Long:    addEnvCmdLongDesc,
 	Example: addEnvCmdExamples,
+	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		envToBeAdded = args[0]
 
-		utils.Logln(utils.LogPrefixInfo + AddEnvCmdLiteral + " called")
+		utils.Logln(utils.LogPrefixInfo + AddCmdLiteral + " " + AddEnvCmdLiteralTrimmed + " called")
 		executeAddEnvCmd(utils.MainConfigFilePath)
 	},
 }

--- a/import-export-cli/cmd/changeAPIStatus.go
+++ b/import-export-cli/cmd/changeAPIStatus.go
@@ -65,7 +65,7 @@ var ChangeAPIStatusCmd = &cobra.Command{
 func executeChangeAPIStatusCmd(credential credentials.Credential) {
 	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, apiStateChangeEnvironment)
 	if preCommandErr == nil {
-		resp, err := impl.ChangeAPIStatusInEnv(credential, accessToken, apiStateChangeEnvironment, apiStateChangeAction,
+		resp, err := impl.ChangeAPIStatusInEnv(accessToken, apiStateChangeEnvironment, apiStateChangeAction,
 			apiNameForStateChange, apiVersionForStateChange, apiProviderForStateChange)
 		if err != nil {
 			utils.HandleErrorAndExit("Error while changing the API status", err)

--- a/import-export-cli/cmd/delete.go
+++ b/import-export-cli/cmd/delete.go
@@ -14,7 +14,7 @@
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-*/
+ */
 
 package cmd
 
@@ -28,16 +28,13 @@ import (
 // Delete command related usage Info
 const deleteCmdLiteral = "delete"
 const deleteCmdShortDesc = "Delete an API/APIProduct/Application in an environment"
-const deleteCmdLongDesc = `Delete an API available in the environment specified by flag (--environment, -e) in default mode
-Delete an API Product available in the environment specified by flag (--environment, -e) in default mode
-Delete an Application of a specific user in the environment specified by flag (--environment, -e) in default mode
-Delete resources by filenames, stdin, resources and names, or by resources and label selector in kubernetes mode`
+const deleteCmdLongDesc = `Delete an API available in the environment specified by flag (--environment, -e)
+Delete an API Product available in the environment specified by flag (--environment, -e)
+Delete an Application of a specific user in the environment specified by flag (--environment, -e)`
 
-const deleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral  + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+const deleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
 ` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPIProductCmdLiteral + ` -n TwitterAPI -r admin -e dev 
-` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAppCmdLiteral + ` -n TestApplication -o admin -e dev
-` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
-` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAppCmdLiteral + ` -n TestApplication -o admin -e dev`
 
 // DeleteCmd represents the delete command
 var DeleteCmd = &cobra.Command{

--- a/import-export-cli/cmd/deleteAPI.go
+++ b/import-export-cli/cmd/deleteAPI.go
@@ -36,22 +36,19 @@ var deleteAPIProvider string
 // DeleteAPI command related usage info
 const deleteAPICmdLiteral = "api"
 const deleteAPICmdShortDesc = "Delete API"
-const deleteAPICmdLongDesc = "Delete an API from an environment in default mode and delete API resources by API name or label selector in kubernetes mode"
+const deleteAPICmdLongDesc = "Delete an API from an environment"
 
-const deleteAPICmdExamplesDefault = "Default Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
-` + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -e production
+const deleteAPICmdExamplesDefault = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 -e production
 NOTE: The 3 flags (--name (-n), --version (-v), and --environment (-e)) are mandatory.`
-
-const deleteAPICmdExamplesKubernetes = "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
-` + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
 
 // DeleteAPICmd represents the delete api command
 var DeleteAPICmd = &cobra.Command{
 	Use: deleteAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment " +
-		"<environment-from-which-the-api-should-be-deleted>)" + " [Flags]" + "\nKubernetes Mode:\n" + "  " + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
+		"<environment-from-which-the-api-should-be-deleted>)",
 	Short:              deleteAPICmdShortDesc,
 	Long:               deleteAPICmdLongDesc,
-	Example:            deleteAPICmdExamplesDefault + deleteAPICmdExamplesKubernetes,
+	Example:            deleteAPICmdExamplesDefault,
 	DisableFlagParsing: isK8sEnabled(),
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")

--- a/import-export-cli/cmd/deprecated/addApi.go
+++ b/import-export-cli/cmd/deprecated/addApi.go
@@ -62,11 +62,12 @@ const addApiExamples = utils.ProjectName + " add/update " + addApiCmdLiteral +
 
 // addApiCmdDeprecated represents the api command
 var addApiCmdDeprecated = &cobra.Command{
-	Use:        addApiCmdLiteral,
-	Short:      addApiCmdShortDesc,
-	Long:       addApiLongDesc,
-	Example:    addApiExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sAddCmdLiteral + " " + cmd.AddApiCmdLiteral + "\".",
+	Use:     addApiCmdLiteral,
+	Short:   addApiCmdShortDesc,
+	Long:    addApiLongDesc,
+	Example: addApiExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sAddCmdLiteral + " " + cmd.AddApiCmdLiteral +
+		"\" " + "instead of \"" + cmd.AddCmdLiteral + " " + addApiCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + addApiCmdLiteral + " called")
 		handleAddApi("")

--- a/import-export-cli/cmd/deprecated/addApi.go
+++ b/import-export-cli/cmd/deprecated/addApi.go
@@ -15,18 +15,12 @@
 * specific language governing permissions and limitations
 * under the License.
  */
-package cmd
+package deprecated
 
 import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/ghodss/yaml"
-	"github.com/spf13/cobra"
-	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
-	"github.com/wso2/product-apim-tooling/import-export-cli/box"
-	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"io"
 	"io/ioutil"
 	"log"
@@ -36,6 +30,14 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/product-apim-tooling/import-export-cli/box"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 var flagApiName string
@@ -51,19 +53,20 @@ var flagImage string
 var flagHostname string
 
 const addApiCmdLiteral = "api"
-const addApiCmdShortDesc = "handle APIs in kubernetes cluster "
+const addApiCmdShortDesc = "Handle APIs in kubernetes cluster "
 const addApiLongDesc = `Add, Update and Delete APIs in kubernetes cluster. JSON and YAML formats are accepted.
 available modes are as follows
 * kubernetes`
 const addApiExamples = utils.ProjectName + " add/update " + addApiCmdLiteral +
 	` -n petstore --from-file=./Swagger.json --replicas=3 --namespace=wso2`
 
-// addApiCmd represents the api command
-var addApiCmd = &cobra.Command{
-	Use:     addApiCmdLiteral,
-	Short:   addApiCmdShortDesc,
-	Long:    addApiLongDesc,
-	Example: addApiExamples,
+// addApiCmdDeprecated represents the api command
+var addApiCmdDeprecated = &cobra.Command{
+	Use:        addApiCmdLiteral,
+	Short:      addApiCmdShortDesc,
+	Long:       addApiLongDesc,
+	Example:    addApiExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sAddCmdLiteral + " " + cmd.AddApiCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + addApiCmdLiteral + " called")
 		handleAddApi("")
@@ -364,27 +367,27 @@ func rollbackConfigs(apiCr *wso2v1alpha1.API) {
 }
 
 func init() {
-	addCmd.AddCommand(addApiCmd)
-	addApiCmd.Flags().StringVarP(&flagApiEndPoint, "apiEndPoint", "a", "", "")
-	addApiCmd.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
-	addApiCmd.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{},
+	cmd.AddCmd.AddCommand(addApiCmdDeprecated)
+	addApiCmdDeprecated.Flags().StringVarP(&flagApiEndPoint, "apiEndPoint", "a", "", "")
+	addApiCmdDeprecated.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
+	addApiCmdDeprecated.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{},
 		"Path to swagger file")
-	addApiCmd.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
-	addApiCmd.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
-	addApiCmd.Flags().BoolVarP(&flagOverride, "override", "", false,
+	addApiCmdDeprecated.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
+	addApiCmdDeprecated.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
+	addApiCmdDeprecated.Flags().BoolVarP(&flagOverride, "override", "", false,
 		"Property to override the existing docker image with the given name and version")
-	addApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "",
+	addApiCmdDeprecated.Flags().StringVarP(&flagApiVersion, "version", "v", "",
 		"Property to override the API version")
-	addApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
+	addApiCmdDeprecated.Flags().StringVarP(&flagApiMode, "mode", "m", "",
 		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v",
 			utils.PrivateJetModeConst, utils.SidecarModeConst))
-	addApiCmd.Flags().StringArrayVarP(&flagEnv, "env", "e", []string{},
+	addApiCmdDeprecated.Flags().StringArrayVarP(&flagEnv, "env", "e", []string{},
 		"Environment variables to be passed to deployment")
-	addApiCmd.Flags().StringVarP(&flagImage, "image", "i", "",
+	addApiCmdDeprecated.Flags().StringVarP(&flagImage, "image", "i", "",
 		"Image of the API. If specified, ignores the value of --override")
-	addApiCmd.Flags().StringVarP(&flagHostname, "hostname", "", "",
+	addApiCmdDeprecated.Flags().StringVarP(&flagHostname, "hostname", "", "",
 		"Ingress hostname that the API is being exposed")
 
-	addApiCmd.MarkFlagRequired("name")
-	addApiCmd.MarkFlagRequired("from-file")
+	addApiCmdDeprecated.MarkFlagRequired("name")
+	addApiCmdDeprecated.MarkFlagRequired("from-file")
 }

--- a/import-export-cli/cmd/deprecated/addEnv.go
+++ b/import-export-cli/cmd/deprecated/addEnv.go
@@ -16,16 +16,16 @@
 * under the License.
  */
 
-package cmd
+package deprecated
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-var envToBeAdded string // Name of the environment to be added
-
+var flagAddEnvName string           // name of the environment to be added
 var flagTokenEndpoint string        // token endpoint of the environment to be added
 var flagPublisherEndpoint string    // Publisher endpoint of the environment to be added
 var flagDevPortalEndpoint string    // DevPortal endpoint of the environment to be added
@@ -34,39 +34,38 @@ var flagApiManagerEndpoint string   // api manager endpoint of the environment t
 var flagAdminEndpoint string        // admin endpoint of the environment to be added
 
 // AddEnv command related Info
-const AddEnvCmdLiteral = "env [environment]"
-const AddEnvCmdLiteralTrimmed = "env"
+const addEnvCmdLiteral = "add-env"
 const addEnvCmdShortDesc = "Add Environment to Config file"
 const addEnvCmdLongDesc = "Add new environment and its related endpoints to the config file"
-const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
+const addEnvCmdExamples = utils.ProjectName + ` ` + addEnvCmdLiteral + ` -e production \
 --apim  https://localhost:9443 
 
-` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
+` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -e test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
 --token https://gw.com:8243/token
 
-` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+` + utils.ProjectName + ` ` + addEnvCmdLiteral + ` -e dev \
 --apim https://apim.com:9443 \
 --registration https://idp.com:9443 \
 --token https://gw.com:8243/token
 
+NOTE: The flag --environment (-e) is mandatory.
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
 cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
 
-// addEnvCmd represents the addEnv command
-var addEnvCmd = &cobra.Command{
-	Use:     AddEnvCmdLiteral,
-	Short:   addEnvCmdShortDesc,
-	Long:    addEnvCmdLongDesc,
-	Example: addEnvCmdExamples,
+// addEnvCmdDeprecated represents the addEnv command
+var addEnvCmdDeprecated = &cobra.Command{
+	Use:        addEnvCmdLiteral,
+	Short:      addEnvCmdShortDesc,
+	Long:       addEnvCmdLongDesc,
+	Example:    addEnvCmdExamples,
+	Deprecated: "instead use \"" + cmd.AddCmdLiteral + " " + cmd.AddEnvCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
-		envToBeAdded = args[0]
-
-		utils.Logln(utils.LogPrefixInfo + AddEnvCmdLiteral + " called")
+		utils.Logln(utils.LogPrefixInfo + addEnvCmdLiteral + " called")
 		executeAddEnvCmd(utils.MainConfigFilePath)
 	},
 }
@@ -80,7 +79,7 @@ func executeAddEnvCmd(mainConfigFilePath string) {
 	envEndpoints.DevPortalEndpoint = flagDevPortalEndpoint
 	envEndpoints.AdminEndpoint = flagAdminEndpoint
 	envEndpoints.TokenEndpoint = flagTokenEndpoint
-	err := impl.AddEnv(envToBeAdded, envEndpoints, mainConfigFilePath, AddEnvCmdLiteral)
+	err := impl.AddEnv(flagAddEnvName, envEndpoints, mainConfigFilePath, addEnvCmdLiteral)
 	if err != nil {
 		utils.HandleErrorAndExit("Error adding environment", err)
 	}
@@ -88,14 +87,15 @@ func executeAddEnvCmd(mainConfigFilePath string) {
 
 // init using Cobra
 func init() {
-	AddCmd.AddCommand(addEnvCmd)
+	cmd.RootCmd.AddCommand(addEnvCmdDeprecated)
 
-	addEnvCmd.Flags().StringVar(&flagApiManagerEndpoint, "apim", "", "API Manager endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagPublisherEndpoint, "publisher", "", "Publisher endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagDevPortalEndpoint, "devportal", "", "DevPortal endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagTokenEndpoint, "token", "", "Token endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagRegistrationEndpoint, "registration", "",
+	addEnvCmdDeprecated.Flags().StringVarP(&flagAddEnvName, "environment", "e", "", "Name of the environment to be added")
+	addEnvCmdDeprecated.Flags().StringVar(&flagApiManagerEndpoint, "apim", "", "API Manager endpoint for the environment")
+	addEnvCmdDeprecated.Flags().StringVar(&flagPublisherEndpoint, "publisher", "", "Publisher endpoint for the environment")
+	addEnvCmdDeprecated.Flags().StringVar(&flagDevPortalEndpoint, "devportal", "", "DevPortal endpoint for the environment")
+	addEnvCmdDeprecated.Flags().StringVar(&flagTokenEndpoint, "token", "", "Token endpoint for the environment")
+	addEnvCmdDeprecated.Flags().StringVar(&flagRegistrationEndpoint, "registration", "",
 		"Registration endpoint for the environment")
-	addEnvCmd.Flags().StringVar(&flagAdminEndpoint, "admin", "", "Admin endpoint for the environment")
-	_ = addEnvCmd.MarkFlagRequired("environment")
+	addEnvCmdDeprecated.Flags().StringVar(&flagAdminEndpoint, "admin", "", "Admin endpoint for the environment")
+	_ = addEnvCmdDeprecated.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/deprecated/changeDockerRegistry.go
+++ b/import-export-cli/cmd/deprecated/changeDockerRegistry.go
@@ -16,12 +16,14 @@
 * under the License.
  */
 
-package cmd
+package deprecated
 
 import (
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
 	"github.com/wso2/product-apim-tooling/import-export-cli/operator/registry"
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -32,12 +34,13 @@ const changeCmdShortDesc = "Change a configuration in K8s cluster resource"
 const changeCmdLongDesc = "Change a configuration in K8s cluster resource"
 const changeCmdExamples = utils.ProjectName + ` ` + changeCmdLiteral + ` ` + changeDockerRegistryCmdLiteral
 
-// changeCmd represents the change command
-var changeCmd = &cobra.Command{
-	Use:     changeCmdLiteral,
-	Short:   changeCmdShortDesc,
-	Long:    changeCmdLongDesc,
-	Example: changeCmdExamples,
+// changeCmdDeprecated represents the change command
+var changeCmdDeprecated = &cobra.Command{
+	Use:        changeCmdLiteral,
+	Short:      changeCmdShortDesc,
+	Long:       changeCmdLongDesc,
+	Example:    changeCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sChangeCmdLiteral + "\".",
 }
 
 const changeDockerRegistryCmdLiteral = "registry"
@@ -45,12 +48,13 @@ const changeDockerRegistryCmdShortDesc = "Change the registry"
 const changeDockerRegistryCmdLongDesc = "Change the registry to be pushed the built micro-gateway image"
 const changeDockerRegistryCmdExamples = utils.ProjectName + ` ` + changeCmdLiteral + ` ` + changeDockerRegistryCmdLiteral
 
-// changeDockerRegistryCmd represents the change registry command
-var changeDockerRegistryCmd = &cobra.Command{
-	Use:     changeDockerRegistryCmdLiteral,
-	Short:   changeDockerRegistryCmdShortDesc,
-	Long:    changeDockerRegistryCmdLongDesc,
-	Example: changeDockerRegistryCmdExamples,
+// changeDockerRegistryCmdDeprecated represents the change registry command
+var changeDockerRegistryCmdDeprecated = &cobra.Command{
+	Use:        changeDockerRegistryCmdLiteral,
+	Short:      changeDockerRegistryCmdShortDesc,
+	Long:       changeDockerRegistryCmdLongDesc,
+	Example:    changeDockerRegistryCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sChangeCmdLiteral + " " + cmd.K8sChangeDockerRegistryCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, changeCmdLiteral, changeDockerRegistryCmdLiteral))
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
@@ -80,16 +84,16 @@ var changeDockerRegistryCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(changeCmd)
-	changeCmd.AddCommand(changeDockerRegistryCmd)
+	cmd.RootCmd.AddCommand(changeCmdDeprecated)
+	changeCmdDeprecated.AddCommand(changeDockerRegistryCmdDeprecated)
 
 	// flags for installing api-operator in batch mode
 	// only the flag "registry-type" is required and others are registry specific flags
 	// same flags defined in 'installApiOperator'
-	changeDockerRegistryCmd.Flags().StringVarP(&flagBmRegistryType, "registry-type", "R", "", "Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP")
-	changeDockerRegistryCmd.Flags().StringVarP(&flagBmRepository, k8sUtils.FlagBmRepository, "r", "", "Repository name or URI")
-	changeDockerRegistryCmd.Flags().StringVarP(&flagBmUsername, k8sUtils.FlagBmUsername, "u", "", "Username of the repository")
-	changeDockerRegistryCmd.Flags().StringVarP(&flagBmPassword, k8sUtils.FlagBmPassword, "p", "", "Password of the given user")
-	changeDockerRegistryCmd.Flags().BoolVar(&flagBmPasswordStdin, k8sUtils.FlagBmPasswordStdin, false, "Prompt for password of the given user in the stdin")
-	changeDockerRegistryCmd.Flags().StringVarP(&flagBmKeyFile, k8sUtils.FlagBmKeyFile, "c", "", "Credentials file")
+	changeDockerRegistryCmdDeprecated.Flags().StringVarP(&flagBmRegistryType, "registry-type", "R", "", "Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP")
+	changeDockerRegistryCmdDeprecated.Flags().StringVarP(&flagBmRepository, k8sUtils.FlagBmRepository, "r", "", "Repository name or URI")
+	changeDockerRegistryCmdDeprecated.Flags().StringVarP(&flagBmUsername, k8sUtils.FlagBmUsername, "u", "", "Username of the repository")
+	changeDockerRegistryCmdDeprecated.Flags().StringVarP(&flagBmPassword, k8sUtils.FlagBmPassword, "p", "", "Password of the given user")
+	changeDockerRegistryCmdDeprecated.Flags().BoolVar(&flagBmPasswordStdin, k8sUtils.FlagBmPasswordStdin, false, "Prompt for password of the given user in the stdin")
+	changeDockerRegistryCmdDeprecated.Flags().StringVarP(&flagBmKeyFile, k8sUtils.FlagBmKeyFile, "c", "", "Credentials file")
 }

--- a/import-export-cli/cmd/deprecated/changeDockerRegistry.go
+++ b/import-export-cli/cmd/deprecated/changeDockerRegistry.go
@@ -50,11 +50,12 @@ const changeDockerRegistryCmdExamples = utils.ProjectName + ` ` + changeCmdLiter
 
 // changeDockerRegistryCmdDeprecated represents the change registry command
 var changeDockerRegistryCmdDeprecated = &cobra.Command{
-	Use:        changeDockerRegistryCmdLiteral,
-	Short:      changeDockerRegistryCmdShortDesc,
-	Long:       changeDockerRegistryCmdLongDesc,
-	Example:    changeDockerRegistryCmdExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sChangeCmdLiteral + " " + cmd.K8sChangeDockerRegistryCmdLiteral + "\".",
+	Use:     changeDockerRegistryCmdLiteral,
+	Short:   changeDockerRegistryCmdShortDesc,
+	Long:    changeDockerRegistryCmdLongDesc,
+	Example: changeDockerRegistryCmdExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sChangeCmdLiteral + " " + cmd.K8sChangeDockerRegistryCmdLiteral +
+		"\" " + "instead of \"" + changeCmdLiteral + " " + changeDockerRegistryCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, changeCmdLiteral, changeDockerRegistryCmdLiteral))
 		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)

--- a/import-export-cli/cmd/deprecated/install.go
+++ b/import-export-cli/cmd/deprecated/install.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deprecated
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const installCmdLiteral = "install"
+const installCmdShortDesc = "Install an operator in the configured K8s cluster"
+const installCmdLongDesc = "Install an operator in the configured K8s cluster"
+const installCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral
+
+// installCmdDeprecated represents the install command
+var installCmdDeprecated = &cobra.Command{
+	Use:        installCmdLiteral,
+	Short:      installCmdShortDesc,
+	Long:       installCmdLongDesc,
+	Example:    installCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + "\".",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(installCmdDeprecated)
+}

--- a/import-export-cli/cmd/deprecated/installApiOperator.go
+++ b/import-export-cli/cmd/deprecated/installApiOperator.go
@@ -1,0 +1,130 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deprecated
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	"github.com/wso2/product-apim-tooling/import-export-cli/operator/registry"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const installApiOperatorCmdLiteral = "api-operator"
+const installApiOperatorCmdShortDesc = "Install API Operator"
+const installApiOperatorCmdLongDesc = "Install API Operator in the configured K8s cluster"
+const installApiOperatorCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + ` -f path/to/operator/configs
+` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
+
+// flags
+var flagApiOperatorFile string
+
+// flags for installing api-operator in batch mode
+var flagBmRegistryType string
+var flagBmRepository string
+var flagBmUsername string
+var flagBmPassword string
+var flagBmPasswordStdin bool
+var flagBmKeyFile string
+
+// installApiOperatorCmdDeprecated represents the install api-operator command
+var installApiOperatorCmdDeprecated = &cobra.Command{
+	Use:        installApiOperatorCmdLiteral,
+	Short:      installApiOperatorCmdShortDesc,
+	Long:       installApiOperatorCmdLongDesc,
+	Example:    installApiOperatorCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallApiOperatorCmdLiteral + "\".",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installApiOperatorCmdLiteral))
+
+		// is -f or --from-file flag specified
+		isLocalInstallation := flagApiOperatorFile != ""
+		configFile := flagApiOperatorFile
+
+		// check version before getting inputs (in interactive mode)
+		if !isLocalInstallation {
+			// getting API Operator version
+			operatorVersion, err := k8sUtils.GetVersion(
+				"API Operator",
+				k8sUtils.ApiOperatorVersionEnvVariable,
+				k8sUtils.DefaultApiOperatorVersion,
+				k8sUtils.ApiOperatorVersionValidationUrlTemplate,
+				k8sUtils.ApiOperatorFindVersionUrl,
+			)
+			if err != nil {
+				utils.HandleErrorAndExit("Error in API Operator version", err)
+			}
+			configFile = fmt.Sprintf(k8sUtils.ApiOperatorConfigsUrlTemplate, operatorVersion)
+		}
+
+		// check for installation mode: interactive or batch mode
+		// and get inputs
+		if flagBmRegistryType == "" {
+			// run api-operator installation in interactive mode
+			// read inputs for docker registry
+			registry.ChooseRegistryInteractive()
+			registry.ReadInputsInteractive()
+		} else {
+			// run api-operator installation in batch mode
+			// set registry type
+			registry.SetRegistry(flagBmRegistryType)
+
+			flagsValues := getGivenFlagsValues()
+			registry.ValidateFlags(flagsValues)       // validate flags with respect to registry type
+			registry.ReadInputsFromFlags(flagsValues) // read values from flags with respect to registry type
+		}
+
+		// installing operator and configs if -f flag given
+		// otherwise settings configs only
+		k8sUtils.CreateControllerConfigs(configFile, 20, k8sUtils.ApiOpCrdSecurity)
+		registry.UpdateConfigsSecrets()
+
+		fmt.Println("[Setting to K8s Mode]")
+		utils.SetToK8sMode()
+	},
+}
+
+// getGivenFlagsValues returns flags that user given in the batch mode except the "registry type"
+func getGivenFlagsValues() *map[string]registry.FlagValue {
+	flags := make(map[string]registry.FlagValue)
+	flags[k8sUtils.FlagBmRepository] = registry.FlagValue{Value: flagBmRepository, IsProvided: flagBmRepository != ""}
+	flags[k8sUtils.FlagBmUsername] = registry.FlagValue{Value: flagBmUsername, IsProvided: flagBmUsername != ""}
+	flags[k8sUtils.FlagBmPassword] = registry.FlagValue{Value: flagBmPassword, IsProvided: flagBmPassword != ""}
+	flags[k8sUtils.FlagBmPasswordStdin] = registry.FlagValue{Value: flagBmPasswordStdin, IsProvided: flagBmPasswordStdin}
+	flags[k8sUtils.FlagBmKeyFile] = registry.FlagValue{Value: flagBmKeyFile, IsProvided: flagBmKeyFile != ""}
+
+	return &flags
+}
+
+func init() {
+	installCmdDeprecated.AddCommand(installApiOperatorCmdDeprecated)
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagApiOperatorFile, "from-file", "f", "", "Path to API Operator directory")
+
+	// flags for installing api-operator in batch mode
+	// only the flag "registry-type" is required and others are registry specific flags
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagBmRegistryType, "registry-type", "R", "", "Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP")
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagBmRepository, k8sUtils.FlagBmRepository, "r", "", "Repository name or URI")
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagBmUsername, k8sUtils.FlagBmUsername, "u", "", "Username of the repository")
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagBmPassword, k8sUtils.FlagBmPassword, "p", "", "Password of the given user")
+	installApiOperatorCmdDeprecated.Flags().BoolVar(&flagBmPasswordStdin, k8sUtils.FlagBmPasswordStdin, false, "Prompt for password of the given user in the stdin")
+	installApiOperatorCmdDeprecated.Flags().StringVarP(&flagBmKeyFile, k8sUtils.FlagBmKeyFile, "c", "", "Credentials file")
+}

--- a/import-export-cli/cmd/deprecated/installApiOperator.go
+++ b/import-export-cli/cmd/deprecated/installApiOperator.go
@@ -48,11 +48,12 @@ var flagBmKeyFile string
 
 // installApiOperatorCmdDeprecated represents the install api-operator command
 var installApiOperatorCmdDeprecated = &cobra.Command{
-	Use:        installApiOperatorCmdLiteral,
-	Short:      installApiOperatorCmdShortDesc,
-	Long:       installApiOperatorCmdLongDesc,
-	Example:    installApiOperatorCmdExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallApiOperatorCmdLiteral + "\".",
+	Use:     installApiOperatorCmdLiteral,
+	Short:   installApiOperatorCmdShortDesc,
+	Long:    installApiOperatorCmdLongDesc,
+	Example: installApiOperatorCmdExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallApiOperatorCmdLiteral +
+		"\" " + "instead of \"" + installCmdLiteral + " " + installApiOperatorCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installApiOperatorCmdLiteral))
 

--- a/import-export-cli/cmd/deprecated/installWso2amOperator.go
+++ b/import-export-cli/cmd/deprecated/installWso2amOperator.go
@@ -40,11 +40,12 @@ var flagWso2AmOperatorFile string
 
 // installWso2amOperatorCmdDeprecated represents the 'install wso2am-operator' command
 var installWso2amOperatorCmdDeprecated = &cobra.Command{
-	Use:        installWso2amOperatorCmdLiteral,
-	Short:      installWso2amOperatorCmdShortDesc,
-	Long:       installWso2amOperatorCmdLongDesc,
-	Example:    installWso2amOperatorCmdExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallWso2amOperatorCmdLiteral + "\".",
+	Use:     installWso2amOperatorCmdLiteral,
+	Short:   installWso2amOperatorCmdShortDesc,
+	Long:    installWso2amOperatorCmdLongDesc,
+	Example: installWso2amOperatorCmdExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallWso2amOperatorCmdLiteral +
+		"\" " + "instead of \"" + installCmdLiteral + " " + installWso2amOperatorCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installWso2amOperatorCmdLiteral))
 

--- a/import-export-cli/cmd/deprecated/installWso2amOperator.go
+++ b/import-export-cli/cmd/deprecated/installWso2amOperator.go
@@ -1,0 +1,82 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deprecated
+
+import (
+	"fmt"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+const installWso2amOperatorCmdLiteral = "wso2am-operator"
+const installWso2amOperatorCmdShortDesc = "Install WSO2AM Operator"
+const installWso2amOperatorCmdLongDesc = "Install WSO2AM Operator in the configured K8s cluster"
+const installWso2amOperatorCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + ` -f path/to/operator/configs
+` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
+
+// flags
+var flagWso2AmOperatorFile string
+
+// installWso2amOperatorCmdDeprecated represents the 'install wso2am-operator' command
+var installWso2amOperatorCmdDeprecated = &cobra.Command{
+	Use:        installWso2amOperatorCmdLiteral,
+	Short:      installWso2amOperatorCmdShortDesc,
+	Long:       installWso2amOperatorCmdLongDesc,
+	Example:    installWso2amOperatorCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sInstallCmdLiteral + " " + cmd.K8sInstallWso2amOperatorCmdLiteral + "\".",
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installWso2amOperatorCmdLiteral))
+
+		// is -f or --from-file flag specified
+		isLocalInstallation := flagWso2AmOperatorFile != ""
+		configFile := flagWso2AmOperatorFile
+
+		if !isLocalInstallation {
+			// getting API Operator version
+			operatorVersion, err := k8sUtils.GetVersion(
+				"WSO2AM Operator",
+				k8sUtils.Wso2AmOperatorVersionEnvVariable,
+				k8sUtils.DefaultWso2AmOperatorVersion,
+				k8sUtils.Wso2AmOperatorVersionValidationUrlTemplate,
+				k8sUtils.Wso2AmOperatorFindVersionUrl,
+			)
+			if err != nil {
+				utils.HandleErrorAndExit("Error in WSO2AM Operator version", err)
+			}
+			configFile = fmt.Sprintf(k8sUtils.Wso2AmOperatorConfigsUrlTemplate, operatorVersion)
+		}
+
+		// installing operator and configs if -f flag given
+		// otherwise settings configs only
+		k8sUtils.CreateControllerConfigs(configFile, 20, k8sUtils.Wso2amOpCrdApimanager)
+
+		fmt.Println("[Setting to K8s Mode]")
+		utils.SetToK8sMode()
+	},
+}
+
+func init() {
+	installCmdDeprecated.AddCommand(installWso2amOperatorCmdDeprecated)
+	installWso2amOperatorCmdDeprecated.Flags().StringVarP(&flagWso2AmOperatorFile, "from-file", "f", "", "Path to wso2am-operator directory")
+}

--- a/import-export-cli/cmd/deprecated/uninstall.go
+++ b/import-export-cli/cmd/deprecated/uninstall.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deprecated
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const uninstallCmdLiteral = "uninstall"
+const uninstallCmdShortDesc = "Uninstall an operator in the configured K8s cluster"
+const uninstallCmdLongDesc = "Uninstall an operator in the configured K8s cluster"
+const uninstallCmdExamples = utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral
+
+// uninstallCmd represents the uninstall command
+var uninstallCmdDeprecated = &cobra.Command{
+	Use:        uninstallCmdLiteral,
+	Short:      uninstallCmdShortDesc,
+	Long:       uninstallCmdLongDesc,
+	Example:    uninstallCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + "\".",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(uninstallCmdDeprecated)
+}

--- a/import-export-cli/cmd/deprecated/uninstallApiOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallApiOperator.go
@@ -73,11 +73,14 @@ var uninstallApiOperatorCmdDeprecated = &cobra.Command{
 			fmt.Printf("Removing namespace: %s\nThis operation will take some minutes...\n", k8sUtils.ApiOpWso2Namespace)
 
 			deleteErrors := []error{
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "namespace", k8sUtils.ApiOpWso2Namespace),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdApi),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdSecurity),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdRateLimiting),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdTargetEndpoint),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.Namespace, k8sUtils.ApiOpWso2Namespace),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.ApiOperator),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.ApiOperator),
+
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdApi),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdSecurity),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdRateLimiting),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdTargetEndpoint),
 			}
 
 			for _, err := range deleteErrors {

--- a/import-export-cli/cmd/deprecated/uninstallApiOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallApiOperator.go
@@ -38,11 +38,12 @@ var flagForceUninstallApiOperator bool
 
 // uninstallApiOperatorCmdDeprecated represents the uninstall api-operator command
 var uninstallApiOperatorCmdDeprecated = &cobra.Command{
-	Use:        uninstallApiOperatorCmdLiteral,
-	Short:      uninstallApiOperatorCmdShortDesc,
-	Long:       uninstallApiOperatorCmdLongDesc,
-	Example:    uninstallApiOperatorCmdExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallApiOperatorCmdLiteral + "\".",
+	Use:     uninstallApiOperatorCmdLiteral,
+	Short:   uninstallApiOperatorCmdShortDesc,
+	Long:    uninstallApiOperatorCmdLongDesc,
+	Example: uninstallApiOperatorCmdExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallApiOperatorCmdLiteral +
+		"\" " + "instead of \"" + uninstallCmdLiteral + " " + uninstallApiOperatorCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		isConfirm := flagForceUninstallApiOperator
 

--- a/import-export-cli/cmd/deprecated/uninstallApiOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallApiOperator.go
@@ -1,0 +1,97 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deprecated
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const uninstallApiOperatorCmdLiteral = "api-operator"
+const uninstallApiOperatorCmdShortDesc = "Uninstall API Operator"
+const uninstallApiOperatorCmdLongDesc = "Uninstall API Operator in the configured K8s cluster"
+const uninstallApiOperatorCmdExamples = utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral + ` --force`
+
+var flagForceUninstallApiOperator bool
+
+// uninstallApiOperatorCmdDeprecated represents the uninstall api-operator command
+var uninstallApiOperatorCmdDeprecated = &cobra.Command{
+	Use:        uninstallApiOperatorCmdLiteral,
+	Short:      uninstallApiOperatorCmdShortDesc,
+	Long:       uninstallApiOperatorCmdLongDesc,
+	Example:    uninstallApiOperatorCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallApiOperatorCmdLiteral + "\".",
+	Run: func(cmd *cobra.Command, args []string) {
+		isConfirm := flagForceUninstallApiOperator
+
+		if !flagForceUninstallApiOperator {
+			isConfirmStr, err := utils.ReadInputString(
+				fmt.Sprintf("\nUninstall \"%s\" and all related resources: APIs, Securities, Rate Limitings and Target Endpoints\n"+
+					"[WARNING] Remove the namespace: %s\n"+
+					"Are you sure",
+					k8sUtils.ApiOperator, k8sUtils.ApiOpWso2Namespace),
+				utils.Default{Value: "N", IsDefault: true},
+				"",
+				false,
+			)
+			if err != nil {
+				utils.HandleErrorAndExit("Error reading user input Confirmation", err)
+			}
+
+			isConfirmStr = strings.ToUpper(isConfirmStr)
+			isConfirm = isConfirmStr == "Y" || isConfirmStr == "YES"
+		}
+
+		if isConfirm {
+			fmt.Println("Deleting kubernetes resources for API Operator")
+
+			// delete the namespace "wso2-system"
+			// namespace, "wso2-system" contains all the artifacts and configs
+			// deleting the namespace: "wso2-system", will remove all the artifacts and configs
+			fmt.Printf("Removing namespace: %s\nThis operation will take some minutes...\n", k8sUtils.ApiOpWso2Namespace)
+
+			deleteErrors := []error{
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "namespace", k8sUtils.ApiOpWso2Namespace),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdApi),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdSecurity),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdRateLimiting),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.ApiOpCrdTargetEndpoint),
+			}
+
+			for _, err := range deleteErrors {
+				if err != nil {
+					utils.HandleErrorAndExit("Error uninstalling API Operator", err)
+				}
+			}
+		} else {
+			fmt.Println("Cancelled")
+		}
+	},
+}
+
+func init() {
+	uninstallCmdDeprecated.AddCommand(uninstallApiOperatorCmdDeprecated)
+	uninstallApiOperatorCmdDeprecated.Flags().BoolVar(&flagForceUninstallApiOperator, "force", false, "Force uninstall API Operator")
+}

--- a/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
@@ -16,13 +16,15 @@
 * under the License.
  */
 
-package cmd
+package deprecated
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -35,12 +37,13 @@ const uninstallWso2amOperatorCmdExamples = utils.ProjectName + ` ` + uninstallCm
 
 var flagForceUninstallWso2amOperator bool
 
-// uninstallWso2amOperatorCmd represents the uninstallWso2amOperator command
-var uninstallWso2amOperatorCmd = &cobra.Command{
-	Use:     uninstallWso2amOperatorCmdLiteral,
-	Short:   uninstallWso2amOperatorCmdShortDesc,
-	Long:    uninstallWso2amOperatorCmdLongDesc,
-	Example: uninstallWso2amOperatorCmdExamples,
+// uninstallWso2amOperatorCmdDeprecated represents the uninstallWso2amOperator command
+var uninstallWso2amOperatorCmdDeprecated = &cobra.Command{
+	Use:        uninstallWso2amOperatorCmdLiteral,
+	Short:      uninstallWso2amOperatorCmdShortDesc,
+	Long:       uninstallWso2amOperatorCmdLongDesc,
+	Example:    uninstallWso2amOperatorCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallWso2amOperatorCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		isConfirm := flagForceUninstallWso2amOperator
 
@@ -71,10 +74,8 @@ var uninstallWso2amOperatorCmd = &cobra.Command{
 			fmt.Printf("Removing namespace: %s\nThis operation will take some minutes...\n", k8sUtils.ApiOpWso2Namespace)
 
 			deleteErrors := []error{
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.Namespace, k8sUtils.ApiOpWso2Namespace),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.Wso2amRole),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.Wso2amRoleBinding),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.Wso2amOpCrdApimanager),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "namespace", k8sUtils.ApiOpWso2Namespace),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.Wso2amOpCrdApimanager),
 			}
 
 			for _, err := range deleteErrors {
@@ -89,6 +90,6 @@ var uninstallWso2amOperatorCmd = &cobra.Command{
 }
 
 func init() {
-	uninstallCmd.AddCommand(uninstallWso2amOperatorCmd)
-	uninstallWso2amOperatorCmd.Flags().BoolVar(&flagForceUninstallWso2amOperator, "force", false, "Force uninstall WSO2AM Operator")
+	uninstallCmdDeprecated.AddCommand(uninstallWso2amOperatorCmdDeprecated)
+	uninstallWso2amOperatorCmdDeprecated.Flags().BoolVar(&flagForceUninstallWso2amOperator, "force", false, "Force uninstall WSO2AM Operator")
 }

--- a/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
@@ -74,8 +74,10 @@ var uninstallWso2amOperatorCmdDeprecated = &cobra.Command{
 			fmt.Printf("Removing namespace: %s\nThis operation will take some minutes...\n", k8sUtils.ApiOpWso2Namespace)
 
 			deleteErrors := []error{
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "namespace", k8sUtils.ApiOpWso2Namespace),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, "crd", k8sUtils.Wso2amOpCrdApimanager),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.Namespace, k8sUtils.ApiOpWso2Namespace),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.Wso2amRole),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.Wso2amRoleBinding),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.Wso2amOpCrdApimanager),
 			}
 
 			for _, err := range deleteErrors {

--- a/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
+++ b/import-export-cli/cmd/deprecated/uninstallWso2amOperator.go
@@ -39,11 +39,12 @@ var flagForceUninstallWso2amOperator bool
 
 // uninstallWso2amOperatorCmdDeprecated represents the uninstallWso2amOperator command
 var uninstallWso2amOperatorCmdDeprecated = &cobra.Command{
-	Use:        uninstallWso2amOperatorCmdLiteral,
-	Short:      uninstallWso2amOperatorCmdShortDesc,
-	Long:       uninstallWso2amOperatorCmdLongDesc,
-	Example:    uninstallWso2amOperatorCmdExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallWso2amOperatorCmdLiteral + "\".",
+	Use:     uninstallWso2amOperatorCmdLiteral,
+	Short:   uninstallWso2amOperatorCmdShortDesc,
+	Long:    uninstallWso2amOperatorCmdLongDesc,
+	Example: uninstallWso2amOperatorCmdExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUninstallCmdLiteral + " " + cmd.K8sUninstallWso2amOperatorCmdLiteral +
+		"\" " + "instead of \"" + uninstallCmdLiteral + " " + uninstallWso2amOperatorCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		isConfirm := flagForceUninstallWso2amOperator
 

--- a/import-export-cli/cmd/deprecated/updateApi.go
+++ b/import-export-cli/cmd/deprecated/updateApi.go
@@ -47,12 +47,12 @@ var updateCmdDeprecated = &cobra.Command{
 
 // updateApiCmd represents the updateApi command
 var updateApiCmdDeprecated = &cobra.Command{
-	Use:        addApiCmdLiteral,
-	Short:      addApiCmdShortDesc,
-	Long:       addApiLongDesc,
-	Example:    addApiExamples,
-	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUpdateCmdLiteral + " " + cmd.AddApiCmdLiteral + "\".",
-
+	Use:     addApiCmdLiteral,
+	Short:   addApiCmdShortDesc,
+	Long:    addApiLongDesc,
+	Example: addApiExamples,
+	Deprecated: "use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUpdateCmdLiteral + " " + cmd.AddApiCmdLiteral +
+		"\" " + "instead of \"" + updateCmdLiteral + " " + addApiCmdLiteral + "\".",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " called")
 		validateAddApiCommand()

--- a/import-export-cli/cmd/deprecated/updateApi.go
+++ b/import-export-cli/cmd/deprecated/updateApi.go
@@ -15,14 +15,16 @@
 * specific language governing permissions and limitations
 * under the License.
  */
-package cmd
+package deprecated
 
 import (
 	"fmt"
-	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"strings"
 	"time"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -35,19 +37,22 @@ const updateCmdExamples = utils.ProjectName + " " + updateCmdLiteral + " " + add
 ` + utils.ProjectName + " " + updateCmdLiteral + " " + addApiCmdLiteral + " " + `-n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2`
 
 // updateCmd represents the update command
-var updateCmd = &cobra.Command{
-	Use:     updateCmdLiteral,
-	Short:   updateCmdShortDesc,
-	Long:    updateCmdLongDesc,
-	Example: updateCmdExamples,
+var updateCmdDeprecated = &cobra.Command{
+	Use:        updateCmdLiteral,
+	Short:      updateCmdShortDesc,
+	Long:       updateCmdLongDesc,
+	Example:    updateCmdExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUpdateCmdLiteral + "\".",
 }
 
 // updateApiCmd represents the updateApi command
-var updateApiCmd = &cobra.Command{
-	Use:     addApiCmdLiteral,
-	Short:   addApiCmdShortDesc,
-	Long:    addApiLongDesc,
-	Example: addApiExamples,
+var updateApiCmdDeprecated = &cobra.Command{
+	Use:        addApiCmdLiteral,
+	Short:      addApiCmdShortDesc,
+	Long:       addApiLongDesc,
+	Example:    addApiExamples,
+	Deprecated: "instead use \"" + cmd.K8sCmdLiteral + " " + cmd.K8sUpdateCmdLiteral + " " + cmd.AddApiCmdLiteral + "\".",
+
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " called")
 		validateAddApiCommand()
@@ -73,13 +78,13 @@ var updateApiCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(updateCmd)
-	updateCmd.AddCommand(updateApiCmd)
-	updateApiCmd.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
-	updateApiCmd.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{}, "Path to swagger file")
-	updateApiCmd.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
-	updateApiCmd.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
-	updateApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Property to override the existing docker image with same name and version")
-	updateApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
+	cmd.RootCmd.AddCommand(updateCmdDeprecated)
+	updateCmdDeprecated.AddCommand(updateApiCmdDeprecated)
+	updateApiCmdDeprecated.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
+	updateApiCmdDeprecated.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{}, "Path to swagger file")
+	updateApiCmdDeprecated.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
+	updateApiCmdDeprecated.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
+	updateApiCmdDeprecated.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Property to override the existing docker image with same name and version")
+	updateApiCmdDeprecated.Flags().StringVarP(&flagApiMode, "mode", "m", "",
 		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v", utils.PrivateJetModeConst, utils.SidecarModeConst))
 }

--- a/import-export-cli/cmd/k8s.go
+++ b/import-export-cli/cmd/k8s.go
@@ -33,7 +33,7 @@ const k8sCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstal
 ` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallApiOperatorCmdLiteral + `
 ` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sAddCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
 ` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUpdateCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
-`
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sChangeCmdLiteral + ` ` + K8sChangeDockerRegistryCmdLiteral
 
 // K8sCmd represents the import command
 var K8sCmd = &cobra.Command{

--- a/import-export-cli/cmd/k8s.go
+++ b/import-export-cli/cmd/k8s.go
@@ -30,6 +30,7 @@ const k8sCmdShortDesc = "Kubernetes mode based commands"
 const k8sCmdLongDesc = `Kubernetes mode based commands such as install, uninstall, add/update api, change registry.`
 
 const k8sCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallApiOperatorCmdLiteral + `
 ` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sAddCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
 ` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUpdateCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
 `

--- a/import-export-cli/cmd/k8s.go
+++ b/import-export-cli/cmd/k8s.go
@@ -29,8 +29,9 @@ const k8sCmdShortDesc = "Kubernetes mode based commands"
 
 const k8sCmdLongDesc = `Kubernetes mode based commands such as install, uninstall, add/update api, change registry.`
 
-const k8sCmdExamples = utils.ProjectName + " " + K8sCmdLiteral + " " + K8sAddCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
-` + utils.ProjectName + " " + K8sCmdLiteral + " " + K8sUpdateCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+const k8sCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sAddCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUpdateCmdLiteral + ` ` + AddApiCmdLiteral + ` ` + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
 `
 
 // K8sCmd represents the import command

--- a/import-export-cli/cmd/k8s.go
+++ b/import-export-cli/cmd/k8s.go
@@ -1,0 +1,51 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// K8s command related usage Info
+const K8sCmdLiteral = "k8s"
+const k8sCmdShortDesc = "Kubernetes mode based commands"
+
+const k8sCmdLongDesc = `Kubernetes mode based commands such as install, uninstall, add/update api, change registry.`
+
+const k8sCmdExamples = utils.ProjectName + " " + K8sCmdLiteral + " " + K8sAddCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+` + utils.ProjectName + " " + K8sCmdLiteral + " " + K8sUpdateCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+`
+
+// K8sCmd represents the import command
+var K8sCmd = &cobra.Command{
+	Use:     K8sCmdLiteral,
+	Short:   k8sCmdShortDesc,
+	Long:    k8sCmdLongDesc,
+	Example: k8sCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + ImportCmdLiteral + " called")
+
+	},
+}
+
+// init using Cobra
+func init() {
+	RootCmd.AddCommand(K8sCmd)
+}

--- a/import-export-cli/cmd/k8sAdd.go
+++ b/import-export-cli/cmd/k8sAdd.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const K8sAddCmdLiteral = "add"
+const k8sAddCmdShortDesc = "Add an API to the kubernetes cluster"
+const k8sAddCmdLongDesc = `Add an API from a Swagger file to the kubernetes cluster. JSON and YAML formats are accepted.
+To execute kubernetes commands set mode to Kubernetes`
+const k8sAddCmdExamples = utils.ProjectName + " " + K8sCmdLiteral + " " + K8sAddCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+
+` + utils.ProjectName + " " + K8sCmdLiteral + " " + K8sAddCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2 --override=true`
+
+// K8sAddCmd represents the add command
+var K8sAddCmd = &cobra.Command{
+	Use:     K8sAddCmdLiteral,
+	Short:   k8sAddCmdShortDesc,
+	Long:    k8sAddCmdLongDesc,
+	Example: k8sAddCmdExamples,
+}
+
+func init() {
+	K8sCmd.AddCommand(K8sAddCmd)
+}

--- a/import-export-cli/cmd/k8sAddApi.go
+++ b/import-export-cli/cmd/k8sAddApi.go
@@ -1,0 +1,391 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	wso2v1alpha1 "github.com/wso2/k8s-api-operator/api-operator/pkg/apis/wso2/v1alpha1"
+	"github.com/wso2/product-apim-tooling/import-export-cli/box"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var flagApiName string
+var flagSwaggerFilePaths []string
+var flagReplicas int
+var flagNamespace string
+var flagOverride bool
+var flagApiVersion string
+var flagApiMode string
+var flagApiEndPoint string
+var flagEnv []string
+var flagImage string
+var flagHostname string
+
+const AddApiCmdLiteral = "api"
+const addApiCmdShortDesc = "Handle APIs in kubernetes cluster "
+const addApiLongDesc = `Add, Update and Delete APIs in kubernetes cluster. JSON and YAML formats are accepted.
+available modes are as follows
+* kubernetes`
+const addApiExamples = utils.ProjectName + " " + K8sCmdLiteral + " add/update " + AddApiCmdLiteral +
+	` -n petstore --from-file=./Swagger.json --replicas=3 --namespace=wso2`
+
+// addApiCmd represents the api command
+var addApiCmd = &cobra.Command{
+	Use:     AddApiCmdLiteral,
+	Short:   addApiCmdShortDesc,
+	Long:    addApiLongDesc,
+	Example: addApiExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + AddApiCmdLiteral + " called")
+		handleAddApi("")
+	},
+}
+
+func handleAddApi(nameSuffix string) {
+	validateAddApiCommand()
+
+	swaggerCmNames := make([]string, len(flagSwaggerFilePaths))
+	balInterceptorsCmNames := make([]string, 0, len(flagSwaggerFilePaths))
+	var javaInterceptorsCmNames []string
+
+	for i, flagSwaggerFilePath := range flagSwaggerFilePaths {
+		// log processing only if there are more projects
+		utils.Logln(fmt.Sprintf("%sProcessing swagger %v: %v", utils.LogPrefixInfo, i+1, flagSwaggerFilePath))
+
+		flagApiName = strings.ToLower(flagApiName)
+		swaggerCmNames[i] = fmt.Sprintf("%v-%v-swagger%s", flagApiName, i+1, nameSuffix)
+
+		fi, _ := os.Stat(flagSwaggerFilePath) // error already handled and ignore error
+		switch mode := fi.Mode(); {
+		//check if the swagger path is a Dir
+		case mode.IsDir():
+			//get swagger definition
+			swaggerPath := filepath.Join(flagSwaggerFilePath, filepath.FromSlash("Meta-information/swagger.yaml"))
+			//creating kubernetes configmap with swagger definition
+			fmt.Println("creating configmap with swagger definition")
+			errConf := createConfigMapWithNamespace(swaggerCmNames[i], swaggerPath, flagNamespace, k8sUtils.K8sCreate)
+			if errConf != nil {
+				utils.HandleErrorAndExit("Error creating configmap", errConf)
+			}
+
+			// copy all bal interceptors to the temp dir
+			balInterceptorsCmName := fmt.Sprintf("%v-%v-bal-intcpt%s", flagApiName, i+1, nameSuffix)
+			balFound := handleBalInterceptors(balInterceptorsCmName, flagSwaggerFilePath, "create", flagNamespace)
+			if balFound {
+				balInterceptorsCmNames = append(balInterceptorsCmNames, balInterceptorsCmName)
+			}
+
+			// handle java interceptors
+			tempJavaIntCms := handleJavaInterceptors(nameSuffix, flagSwaggerFilePath, "create", flagNamespace,
+				fmt.Sprintf("%v-%v", flagApiName, i+1))
+			if tempJavaIntCms != nil {
+				javaInterceptorsCmNames = append(javaInterceptorsCmNames, tempJavaIntCms...)
+			}
+		//check if the swagger path is a file
+		case mode.IsRegular():
+			//creating kubernetes configmap with swagger definition
+			fmt.Println("creating configmap with swagger definition")
+			errConf := createConfigMapWithNamespace(swaggerCmNames[i], flagSwaggerFilePath, flagNamespace,
+				k8sUtils.K8sCreate)
+			if errConf != nil {
+				utils.HandleErrorAndExit("Error creating configmap", errConf)
+			}
+		}
+	}
+
+	//create API
+	fmt.Println("creating API definition")
+	createAPI(swaggerCmNames, nameSuffix, balInterceptorsCmNames, javaInterceptorsCmNames)
+}
+
+// validateAddApiCommand validates for required flags and if invalid print error and exit
+// mode should be k8s
+func validateAddApiCommand() {
+	// validate mode
+	configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
+	if !configVars.Config.KubernetesMode {
+		utils.HandleErrorAndExit("set mode to kubernetes with command: apictl set --mode kubernetes",
+			errors.New("mode should be set to kubernetes"))
+	}
+
+	// validate --from-file flag values
+	for _, swaggerFilePath := range flagSwaggerFilePaths {
+		if _, err := os.Stat(swaggerFilePath); err != nil {
+			utils.HandleErrorAndExit("swagger file path or project not found", err)
+		}
+	}
+
+	// validate --mode flag
+	if flagApiMode != "" && flagApiMode != utils.PrivateJetModeConst && flagApiMode != utils.SidecarModeConst {
+		utils.HandleErrorAndExit(fmt.Sprintf("invalid api mode. available modes: %v, %v",
+			utils.PrivateJetModeConst, utils.SidecarModeConst), nil)
+	}
+
+	// validate --env flag
+	const envValidRegex = "^[-._a-zA-Z][-._a-zA-Z0-9]*$"
+	reg, err := regexp.Compile(envValidRegex)
+	if err != nil {
+		utils.HandleErrorAndExit("error in regex string", err)
+	}
+	for _, env := range flagEnv {
+		keyVal := strings.SplitN(env, "=", 2)
+		if keyVal[0] == "" || !reg.MatchString(keyVal[0]) {
+			utils.HandleErrorAndExit(fmt.Sprintf("invalid environment variable(s). "+
+				"key should follow the regex \"%s\"", envValidRegex), nil)
+		}
+	}
+}
+
+//create configmap with swagger definition
+func createConfigMapWithNamespace(configMapName string, filePath string, namespace string, operation string) error {
+	cmd := exec.Command(
+		k8sUtils.Kubectl,
+		operation,
+		"configmap",
+		configMapName,
+		"--from-file",
+		filePath,
+		"-n", namespace,
+	)
+	//print kubernetes error commands
+	var errBuf, outBuf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &errBuf)
+	cmd.Stdout = io.MultiWriter(os.Stdout, &outBuf)
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createAPI(configMapNames []string, timestamp string, balInterceptors []string, javaInterceptors []string) {
+	//get API definition from file
+	apiConfigMapData, _ := box.Get("/kubernetes_resources/api_cr.yaml")
+	apiCrd := &wso2v1alpha1.API{}
+	errUnmarshal := yaml.Unmarshal(apiConfigMapData, apiCrd)
+	if errUnmarshal != nil {
+		utils.HandleErrorAndExit("Error unmarshal api configmap into struct ", errUnmarshal)
+	}
+	//assigning values to API cr
+	apiCrd.Name = flagApiName
+	apiCrd.Namespace = flagNamespace
+	apiCrd.Spec.Definition.SwaggerConfigmapNames = configMapNames
+	apiCrd.Spec.Replicas = flagReplicas
+	apiCrd.Spec.Override = flagOverride
+	apiCrd.Spec.ApiEndPoint = flagApiEndPoint
+	apiCrd.Spec.EnvironmentVariables = flagEnv
+	apiCrd.Spec.Image = flagImage
+	apiCrd.Spec.IngressHostname = flagHostname
+
+	k8sOperation := k8sUtils.K8sCreate
+	k8sSaveConfig := true
+	if timestamp != "" {
+		//set update timestamp
+		apiCrd.Spec.UpdateTimeStamp = timestamp
+		k8sOperation = k8sUtils.K8sApply
+		k8sSaveConfig = false
+	}
+	if len(balInterceptors) > 0 {
+		// set bal interceptors configmap name in API cr
+		apiCrd.Spec.Definition.Interceptors.Ballerina = balInterceptors
+	}
+	if len(javaInterceptors) > 0 {
+		//set java interceptors configmaps names in API cr
+		apiCrd.Spec.Definition.Interceptors.Java = javaInterceptors
+	} else {
+		apiCrd.Spec.Definition.Interceptors.Java = []string{}
+	}
+	if flagApiMode != "" {
+		apiCrd.Spec.Mode = wso2v1alpha1.Mode(flagApiMode)
+	}
+	if flagApiVersion != "" {
+		apiCrd.Spec.Version = flagApiVersion
+	}
+	if flagApiEndPoint != "" {
+		apiCrd.Spec.ApiEndPoint = flagApiEndPoint
+	}
+	if flagReplicas != 0 {
+		apiCrd.Status.Replicas = flagReplicas
+	}
+	if flagHostname != "" {
+		apiCrd.Spec.IngressHostname = flagHostname
+	}
+
+	byteVal, errMarshal := yaml.Marshal(apiCrd)
+	if errMarshal != nil {
+		utils.HandleErrorAndExit("Error marshal api configmap ", errMarshal)
+	}
+	//write configmap to a temp file
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "apicr-*.yaml")
+	if err != nil {
+		log.Fatal("Cannot create temporary file", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err = tmpFile.Write(byteVal); err != nil {
+		log.Fatal("Failed to write to temporary file", err)
+	}
+	// Close the file
+	if err := tmpFile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	k8sArgs := []string{k8sOperation, "-f", tmpFile.Name(), "-n", flagNamespace}
+	if k8sSaveConfig {
+		k8sArgs = append(k8sArgs, "--save-config")
+	}
+
+	//execute kubernetes command to create or update api from file
+	errAddApi := k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sArgs...)
+	if errAddApi != nil {
+		fmt.Println("error configuring API")
+		// delete all configs if any error
+		rollbackConfigs(apiCrd)
+	}
+}
+
+func handleBalInterceptors(configMapName string, path string, operation string, namespace string) bool {
+	//get interceptors if available
+	interceptorsPath := filepath.Join(path, "Interceptors")
+	//check interceptors dir is not empty
+	file, err := os.Open(interceptorsPath)
+	if err != nil {
+		//Do nothing. This is to remove showing unnecessary errors.
+	} else {
+		defer file.Close()
+		if _, err = file.Readdir(1); err != nil {
+			return false
+		}
+
+		//creating kubernetes configmap with interceptors
+		fmt.Println("creating configmap with ballerina interceptors")
+		if err := createConfigMapWithNamespace(configMapName, interceptorsPath, namespace, operation); err != nil {
+			utils.HandleErrorAndExit("Error creating configmap for interceptors", err)
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func handleJavaInterceptors(nameSuffix string, path string, operation string, namespace string, cmPrefixName string) []string {
+	var interceptors []string
+	var javaInterceptorsConfNames []string
+	//get interceptors if available
+	interceptorsPath := filepath.Join(path, "libs")
+	//check interceptors dir is not empty
+	exists, err := utils.IsDirExists(interceptorsPath)
+	if !exists {
+		if err != nil {
+			fmt.Sprintf("Error: %s", err)
+		}
+	} else {
+		//get all jars in libs dir
+		errReadInterceptors := filepath.Walk(interceptorsPath, func(path string, info os.FileInfo, err error) error {
+			interceptors = append(interceptors, path)
+			return nil
+		})
+		if errReadInterceptors != nil {
+			utils.HandleErrorAndExit("cannot read interceptors in the libs", errReadInterceptors)
+		}
+	}
+
+	const jarExt = ".jar"
+	for _, filePath := range interceptors {
+		if filepath.Ext(filePath) == jarExt {
+			// creating kubernetes configmap for each java interceptor
+			// added the random number instead of file name to omit lengthy names and k8s resource name constraints
+			cmName := fmt.Sprintf("%s-%v-jar-intcpt%s", cmPrefixName, rand.Intn(10000), nameSuffix)
+			javaInterceptorsConfNames = append(javaInterceptorsConfNames, cmName)
+
+			fmt.Println("creating configmap with java interceptor " + cmName)
+			errConfInt := createConfigMapWithNamespace(cmName, filePath, namespace, operation)
+			if errConfInt != nil {
+				utils.HandleErrorAndExit("Error creating configmap for java-interceptor "+cmName, errConfInt)
+			}
+		}
+	}
+	return javaInterceptorsConfNames
+}
+
+// rollbackConfigs deletes configs defined in the API CR given
+func rollbackConfigs(apiCr *wso2v1alpha1.API) {
+	var rollbackConfMaps []string // configmap names to be deleted
+
+	// swagger configmaps
+	rollbackConfMaps = append(rollbackConfMaps, apiCr.Spec.Definition.SwaggerConfigmapNames...)
+	// ballerina interceptor configmaps
+	rollbackConfMaps = append(rollbackConfMaps, apiCr.Spec.Definition.Interceptors.Ballerina...)
+	// java interceptor configmaps
+	rollbackConfMaps = append(rollbackConfMaps, apiCr.Spec.Definition.Interceptors.Java...)
+
+	if len(rollbackConfMaps) == 0 {
+		return
+	}
+
+	// execute kubernetes command to delete
+	fmt.Println("Deleting created configs")
+	k8sArgs := []string{k8sUtils.K8sDelete, "cm"}
+	k8sArgs = append(k8sArgs, rollbackConfMaps...)
+
+	delConfErr := k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sArgs...)
+	if delConfErr != nil {
+		utils.HandleErrorAndExit("error deleting configmaps of the API: "+apiCr.Name, delConfErr)
+	}
+}
+
+func init() {
+	K8sAddCmd.AddCommand(addApiCmd)
+	addApiCmd.Flags().StringVarP(&flagApiEndPoint, "apiEndPoint", "a", "", "")
+	addApiCmd.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
+	addApiCmd.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{},
+		"Path to swagger file")
+	addApiCmd.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
+	addApiCmd.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
+	addApiCmd.Flags().BoolVarP(&flagOverride, "override", "", false,
+		"Property to override the existing docker image with the given name and version")
+	addApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "",
+		"Property to override the API version")
+	addApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
+		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v",
+			utils.PrivateJetModeConst, utils.SidecarModeConst))
+	addApiCmd.Flags().StringArrayVarP(&flagEnv, "env", "e", []string{},
+		"Environment variables to be passed to deployment")
+	addApiCmd.Flags().StringVarP(&flagImage, "image", "i", "",
+		"Image of the API. If specified, ignores the value of --override")
+	addApiCmd.Flags().StringVarP(&flagHostname, "hostname", "", "",
+		"Ingress hostname that the API is being exposed")
+
+	addApiCmd.MarkFlagRequired("name")
+	addApiCmd.MarkFlagRequired("from-file")
+}

--- a/import-export-cli/cmd/k8sChangeDockerRegistry.go
+++ b/import-export-cli/cmd/k8sChangeDockerRegistry.go
@@ -1,0 +1,96 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/operator/registry"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const K8sChangeCmdLiteral = "change"
+const k8sChangeCmdShortDesc = "Change a configuration in K8s cluster resource"
+const k8sChangeCmdLongDesc = "Change a configuration in K8s cluster resource"
+const k8sChangeCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sChangeCmdLiteral + ` ` + K8sChangeDockerRegistryCmdLiteral
+
+// changeCmd represents the change command
+var changeCmd = &cobra.Command{
+	Use:     K8sChangeCmdLiteral,
+	Short:   k8sChangeCmdShortDesc,
+	Long:    k8sChangeCmdLongDesc,
+	Example: k8sChangeCmdExamples,
+}
+
+const K8sChangeDockerRegistryCmdLiteral = "registry"
+const k8sChangeDockerRegistryCmdShortDesc = "Change the registry"
+const k8sChangeDockerRegistryCmdLongDesc = "Change the registry to be pushed the built micro-gateway image"
+const k8sChangeDockerRegistryCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sChangeCmdLiteral + ` ` + K8sChangeDockerRegistryCmdLiteral
+
+// changeDockerRegistryCmd represents the change registry command
+var changeDockerRegistryCmd = &cobra.Command{
+	Use:     K8sChangeDockerRegistryCmdLiteral,
+	Short:   k8sChangeDockerRegistryCmdShortDesc,
+	Long:    k8sChangeDockerRegistryCmdLongDesc,
+	Example: k8sChangeDockerRegistryCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, K8sChangeCmdLiteral, K8sChangeDockerRegistryCmdLiteral))
+		configVars := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
+		if !configVars.Config.KubernetesMode {
+			utils.HandleErrorAndExit("set mode to kubernetes with command: apictl set --mode kubernetes",
+				errors.New("mode should be set to kubernetes"))
+		}
+
+		// check for installation mode: interactive or batch mode
+		if flagBmRegistryType == "" {
+			// run in interactive mode
+			// read inputs for docker registry
+			registry.ChooseRegistryInteractive()
+			registry.ReadInputsInteractive()
+		} else {
+			// run in batch mode
+			// set registry type
+			registry.SetRegistry(flagBmRegistryType)
+
+			flagsValues := getGivenFlagsValues()
+			registry.ValidateFlags(flagsValues)       // validate flags with respect to registry type
+			registry.ReadInputsFromFlags(flagsValues) // read values from flags with respect to registry type
+		}
+
+		registry.UpdateConfigsSecrets()
+	},
+}
+
+func init() {
+	K8sCmd.AddCommand(changeCmd)
+	changeCmd.AddCommand(changeDockerRegistryCmd)
+
+	// flags for installing api-operator in batch mode
+	// only the flag "registry-type" is required and others are registry specific flags
+	// same flags defined in 'installApiOperator'
+	changeDockerRegistryCmd.Flags().StringVarP(&flagBmRegistryType, "registry-type", "R", "", "Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP")
+	changeDockerRegistryCmd.Flags().StringVarP(&flagBmRepository, k8sUtils.FlagBmRepository, "r", "", "Repository name or URI")
+	changeDockerRegistryCmd.Flags().StringVarP(&flagBmUsername, k8sUtils.FlagBmUsername, "u", "", "Username of the repository")
+	changeDockerRegistryCmd.Flags().StringVarP(&flagBmPassword, k8sUtils.FlagBmPassword, "p", "", "Password of the given user")
+	changeDockerRegistryCmd.Flags().BoolVar(&flagBmPasswordStdin, k8sUtils.FlagBmPasswordStdin, false, "Prompt for password of the given user in the stdin")
+	changeDockerRegistryCmd.Flags().StringVarP(&flagBmKeyFile, k8sUtils.FlagBmKeyFile, "c", "", "Credentials file")
+}

--- a/import-export-cli/cmd/k8sDelete.go
+++ b/import-export-cli/cmd/k8sDelete.go
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+// Delete command related usage Info
+const k8sDeleteCmdLiteral = "delete"
+const k8sDeleteCmdShortDesc = "Delete resources related to kubernetes"
+const k8sDeleteCmdLongDesc = `Delete resources by filenames, stdin, resources and names, or by resources and label selector in kubernetes mode`
+
+const k8sDeleteCmdExamples = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` petstore
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + deleteAPICmdLiteral + ` -l name=myLabel`
+
+// k8sDeleteCmd represents the delete command
+var k8sDeleteCmd = &cobra.Command{
+	Use:                k8sDeleteCmdLiteral,
+	Short:              k8sDeleteCmdShortDesc,
+	Long:               k8sDeleteCmdLongDesc,
+	Example:            k8sDeleteCmdExamples,
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + k8sDeleteCmdLiteral + " called")
+		k8sArgs := []string{k8sUtils.K8sDelete}
+		k8sArgs = append(k8sArgs, args...)
+		executeKubernetes(k8sArgs...)
+	},
+}
+
+func init() {
+	K8sCmd.AddCommand(k8sDeleteCmd)
+}

--- a/import-export-cli/cmd/k8sDeleteAPI.go
+++ b/import-export-cli/cmd/k8sDeleteAPI.go
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// k8sDeleteAPI command related usage info
+const k8sDeleteAPICmdLiteral = "api"
+const k8sDeleteAPICmdShortDesc = "Delete API resources"
+const k8sDeleteAPICmdLongDesc = "Delete API resources by API name or label selector in kubernetes mode"
+
+const k8sDeleteAPICmdExamples = utils.ProjectName + ` ` + k8sDeleteCmdLiteral + ` ` + k8sDeleteAPICmdLiteral + ` petstore
+` + "  " + utils.ProjectName + ` ` + k8sDeleteCmdLiteral + ` ` + k8sDeleteAPICmdLiteral + ` -l name=myLabel`
+
+// k8sDeleteAPICmd represents the delete api command in kubernetes mode
+var k8sDeleteAPICmd = &cobra.Command{
+	Use:                utils.ProjectName + ` ` + k8sDeleteCmdLiteral + ` ` + k8sDeleteAPICmdLiteral + " (<name-of-the-api> or -l name=<name-of-the-label>)",
+	Short:              k8sDeleteAPICmdShortDesc,
+	Long:               k8sDeleteAPICmdLongDesc,
+	Example:            k8sDeleteAPICmdExamples,
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")
+		k8sArgs := []string{k8sUtils.K8sDelete, k8sUtils.K8sApi}
+		k8sArgs = append(k8sArgs, args...)
+		executeKubernetes(k8sArgs...)
+	},
+}
+
+// Init using Cobra
+func init() {
+	k8sDeleteCmd.AddCommand(k8sDeleteAPICmd)
+}

--- a/import-export-cli/cmd/k8sDeleteAPI.go
+++ b/import-export-cli/cmd/k8sDeleteAPI.go
@@ -41,7 +41,7 @@ var k8sDeleteAPICmd = &cobra.Command{
 	DisableFlagParsing: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteAPICmdLiteral + " called")
-		k8sArgs := []string{k8sUtils.K8sDelete, k8sUtils.K8sApi}
+		k8sArgs := []string{k8sUtils.K8sDelete, k8sUtils.ApiOpCrdApi}
 		k8sArgs = append(k8sArgs, args...)
 		executeKubernetes(k8sArgs...)
 	},

--- a/import-export-cli/cmd/k8sInstall.go
+++ b/import-export-cli/cmd/k8sInstall.go
@@ -23,19 +23,19 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const installCmdLiteral = "install"
-const installCmdShortDesc = "Install an operator in the configured K8s cluster"
-const installCmdLongDesc = "Install an operator in the configured K8s cluster"
-const installCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral
+const K8sInstallCmdLiteral = "install"
+const k8sInstallCmdShortDesc = "Install an operator in the configured K8s cluster"
+const k8sInstallCmdLongDesc = "Install an operator in the configured K8s cluster"
+const k8sInstallCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral
 
 // installCmd represents the install command
 var installCmd = &cobra.Command{
-	Use:     installCmdLiteral,
-	Short:   installCmdShortDesc,
-	Long:    installCmdLongDesc,
-	Example: installCmdExamples,
+	Use:     K8sInstallCmdLiteral,
+	Short:   k8sInstallCmdShortDesc,
+	Long:    k8sInstallCmdLongDesc,
+	Example: k8sInstallCmdExamples,
 }
 
 func init() {
-	RootCmd.AddCommand(installCmd)
+	K8sCmd.AddCommand(installCmd)
 }

--- a/import-export-cli/cmd/k8sInstallApiOperator.go
+++ b/import-export-cli/cmd/k8sInstallApiOperator.go
@@ -20,18 +20,19 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/operator/registry"
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const installApiOperatorCmdLiteral = "api-operator"
-const installApiOperatorCmdShortDesc = "Install API Operator"
-const installApiOperatorCmdLongDesc = "Install API Operator in the configured K8s cluster"
-const installApiOperatorCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + `
-` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + ` -f path/to/operator/configs
-` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installApiOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
+const K8sInstallApiOperatorCmdLiteral = "api-operator"
+const k8sInstallApiOperatorCmdShortDesc = "Install API Operator"
+const k8sInstallApiOperatorCmdLongDesc = "Install API Operator in the configured K8s cluster"
+const k8sInstallApiOperatorCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral + ` -f path/to/operator/configs
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallApiOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
 
 // flags
 var flagApiOperatorFile string
@@ -46,12 +47,12 @@ var flagBmKeyFile string
 
 // installApiOperatorCmd represents the install api-operator command
 var installApiOperatorCmd = &cobra.Command{
-	Use:     installApiOperatorCmdLiteral,
-	Short:   installApiOperatorCmdShortDesc,
-	Long:    installApiOperatorCmdLongDesc,
-	Example: installApiOperatorCmdExamples,
+	Use:     K8sInstallApiOperatorCmdLiteral,
+	Short:   k8sInstallApiOperatorCmdShortDesc,
+	Long:    k8sInstallApiOperatorCmdLongDesc,
+	Example: k8sInstallApiOperatorCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installApiOperatorCmdLiteral))
+		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, K8sInstallCmdLiteral, K8sInstallApiOperatorCmdLiteral))
 
 		// is -f or --from-file flag specified
 		isLocalInstallation := flagApiOperatorFile != ""

--- a/import-export-cli/cmd/k8sInstallWso2amOperator.go
+++ b/import-export-cli/cmd/k8sInstallWso2amOperator.go
@@ -20,30 +20,31 @@ package cmd
 
 import (
 	"fmt"
+
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 
 	"github.com/spf13/cobra"
 )
 
-const installWso2amOperatorCmdLiteral = "wso2am-operator"
-const installWso2amOperatorCmdShortDesc = "Install WSO2AM Operator"
-const installWso2amOperatorCmdLongDesc = "Install WSO2AM Operator in the configured K8s cluster"
-const installWso2amOperatorCmdExamples = utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + `
-` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + ` -f path/to/operator/configs
-` + utils.ProjectName + ` ` + installCmdLiteral + ` ` + installWso2amOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
+const K8sInstallWso2amOperatorCmdLiteral = "wso2am-operator"
+const k8sInstallWso2amOperatorCmdShortDesc = "Install WSO2AM Operator"
+const k8sInstallWso2amOperatorCmdLongDesc = "Install WSO2AM Operator in the configured K8s cluster"
+const k8sInstallWso2amOperatorCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallWso2amOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallWso2amOperatorCmdLiteral + ` -f path/to/operator/configs
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sInstallCmdLiteral + ` ` + K8sInstallWso2amOperatorCmdLiteral + ` -f path/to/operator/config/file.yaml`
 
 // flags
 var flagWso2AmOperatorFile string
 
 // installWso2amOperatorCmd represents the 'install wso2am-operator' command
 var installWso2amOperatorCmd = &cobra.Command{
-	Use:     installWso2amOperatorCmdLiteral,
-	Short:   installWso2amOperatorCmdShortDesc,
-	Long:    installWso2amOperatorCmdLongDesc,
-	Example: installWso2amOperatorCmdExamples,
+	Use:     K8sInstallWso2amOperatorCmdLiteral,
+	Short:   k8sInstallWso2amOperatorCmdShortDesc,
+	Long:    k8sInstallWso2amOperatorCmdLongDesc,
+	Example: k8sInstallWso2amOperatorCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, installCmdLiteral, installWso2amOperatorCmdLiteral))
+		utils.Logln(fmt.Sprintf("%s%s %s called", utils.LogPrefixInfo, K8sInstallCmdLiteral, K8sInstallWso2amOperatorCmdLiteral))
 
 		// is -f or --from-file flag specified
 		isLocalInstallation := flagWso2AmOperatorFile != ""

--- a/import-export-cli/cmd/k8sUninstall.go
+++ b/import-export-cli/cmd/k8sUninstall.go
@@ -23,19 +23,19 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const uninstallCmdLiteral = "uninstall"
-const uninstallCmdShortDesc = "Uninstall an operator in the configured K8s cluster"
-const uninstallCmdLongDesc = "Uninstall an operator in the configured K8s cluster"
-const uninstallCmdExamples = utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral
+const K8sUninstallCmdLiteral = "uninstall"
+const k8sUninstallCmdShortDesc = "Uninstall an operator in the configured K8s cluster"
+const k8sUninstallCmdLongDesc = "Uninstall an operator in the configured K8s cluster"
+const k8sUninstallCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallApiOperatorCmdLiteral
 
 // uninstallCmd represents the uninstall command
 var uninstallCmd = &cobra.Command{
-	Use:     uninstallCmdLiteral,
-	Short:   uninstallCmdShortDesc,
-	Long:    uninstallCmdLongDesc,
-	Example: uninstallCmdExamples,
+	Use:     K8sUninstallCmdLiteral,
+	Short:   k8sUninstallCmdShortDesc,
+	Long:    k8sUninstallCmdLongDesc,
+	Example: k8sUninstallCmdExamples,
 }
 
 func init() {
-	RootCmd.AddCommand(uninstallCmd)
+	K8sCmd.AddCommand(uninstallCmd)
 }

--- a/import-export-cli/cmd/k8sUninstallApiOperator.go
+++ b/import-export-cli/cmd/k8sUninstallApiOperator.go
@@ -1,0 +1,98 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const K8sUninstallApiOperatorCmdLiteral = "api-operator"
+const k8sUninstallApiOperatorCmdShortDesc = "Uninstall API Operator"
+const k8sUninstallApiOperatorCmdLongDesc = "Uninstall API Operator in the configured K8s cluster"
+const k8sUninstallApiOperatorCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallApiOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallApiOperatorCmdLiteral + ` --force`
+
+var flagForceUninstallApiOperator bool
+
+// uninstallApiOperatorCmd represents the uninstall api-operator command
+var uninstallApiOperatorCmd = &cobra.Command{
+	Use:     K8sUninstallApiOperatorCmdLiteral,
+	Short:   k8sUninstallApiOperatorCmdShortDesc,
+	Long:    k8sUninstallApiOperatorCmdLongDesc,
+	Example: k8sUninstallApiOperatorCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		isConfirm := flagForceUninstallApiOperator
+
+		if !flagForceUninstallApiOperator {
+			isConfirmStr, err := utils.ReadInputString(
+				fmt.Sprintf("\nUninstall \"%s\" and all related resources: APIs, Securities, Rate Limitings and Target Endpoints\n"+
+					"[WARNING] Remove the namespace: %s\n"+
+					"Are you sure",
+					k8sUtils.ApiOperator, k8sUtils.ApiOpWso2Namespace),
+				utils.Default{Value: "N", IsDefault: true},
+				"",
+				false,
+			)
+			if err != nil {
+				utils.HandleErrorAndExit("Error reading user input Confirmation", err)
+			}
+
+			isConfirmStr = strings.ToUpper(isConfirmStr)
+			isConfirm = isConfirmStr == "Y" || isConfirmStr == "YES"
+		}
+
+		if isConfirm {
+			fmt.Println("Deleting kubernetes resources for API Operator")
+
+			// delete the namespace "wso2-system"
+			// namespace, "wso2-system" contains all the artifacts and configs
+			// deleting the namespace: "wso2-system", will remove all the artifacts and configs
+			fmt.Printf("Removing namespace: %s\nThis operation will take some minutes...\n", k8sUtils.ApiOpWso2Namespace)
+
+			deleteErrors := []error{
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.Namespace, k8sUtils.ApiOpWso2Namespace),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.ApiOperator),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.ApiOperator),
+
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdApi),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdSecurity),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdRateLimiting),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdTargetEndpoint),
+			}
+
+			for _, err := range deleteErrors {
+				if err != nil {
+					utils.HandleErrorAndExit("Error uninstalling API Operator", err)
+				}
+			}
+		} else {
+			fmt.Println("Cancelled")
+		}
+	},
+}
+
+func init() {
+	uninstallCmd.AddCommand(uninstallApiOperatorCmd)
+	uninstallApiOperatorCmd.Flags().BoolVar(&flagForceUninstallApiOperator, "force", false, "Force uninstall API Operator")
+}

--- a/import-export-cli/cmd/k8sUninstallWso2amOperator.go
+++ b/import-export-cli/cmd/k8sUninstallWso2amOperator.go
@@ -20,35 +20,37 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
+	"strings"
+
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"strings"
+
+	"github.com/spf13/cobra"
 )
 
-const uninstallApiOperatorCmdLiteral = "api-operator"
-const uninstallApiOperatorCmdShortDesc = "Uninstall API Operator"
-const uninstallApiOperatorCmdLongDesc = "Uninstall API Operator in the configured K8s cluster"
-const uninstallApiOperatorCmdExamples = utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral + `
-` + utils.ProjectName + ` ` + uninstallCmdLiteral + ` ` + uninstallApiOperatorCmdLiteral + ` --force`
+const K8sUninstallWso2amOperatorCmdLiteral = "wso2am-operator"
+const k8sUninstallWso2amOperatorCmdShortDesc = "Uninstall WSO2AM Operator"
+const k8sUninstallWso2amOperatorCmdLongDesc = "Uninstall WSO2AM Operator in the configured K8s cluster"
+const k8sUninstallWso2amOperatorCmdExamples = utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallWso2amOperatorCmdLiteral + `
+` + utils.ProjectName + ` ` + K8sCmdLiteral + ` ` + K8sUninstallCmdLiteral + ` ` + K8sUninstallWso2amOperatorCmdLiteral + ` --force`
 
-var flagForceUninstallApiOperator bool
+var flagForceUninstallWso2amOperator bool
 
-// uninstallApiOperatorCmd represents the uninstall api-operator command
-var uninstallApiOperatorCmd = &cobra.Command{
-	Use:     uninstallApiOperatorCmdLiteral,
-	Short:   uninstallApiOperatorCmdShortDesc,
-	Long:    uninstallApiOperatorCmdLongDesc,
-	Example: uninstallApiOperatorCmdExamples,
+// uninstallWso2amOperatorCmd represents the uninstallWso2amOperator command
+var uninstallWso2amOperatorCmd = &cobra.Command{
+	Use:     K8sUninstallWso2amOperatorCmdLiteral,
+	Short:   k8sUninstallWso2amOperatorCmdShortDesc,
+	Long:    k8sUninstallWso2amOperatorCmdLongDesc,
+	Example: k8sUninstallWso2amOperatorCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		isConfirm := flagForceUninstallApiOperator
+		isConfirm := flagForceUninstallWso2amOperator
 
-		if !flagForceUninstallApiOperator {
+		if !flagForceUninstallWso2amOperator {
 			isConfirmStr, err := utils.ReadInputString(
-				fmt.Sprintf("\nUninstall \"%s\" and all related resources: APIs, Securities, Rate Limitings and Target Endpoints\n"+
+				fmt.Sprintf("\nUninstall \"%s\" and all related resources: Apimanagers\n"+
 					"[WARNING] Remove the namespace: %s\n"+
 					"Are you sure",
-					k8sUtils.ApiOperator, k8sUtils.ApiOpWso2Namespace),
+					k8sUtils.Wso2amOperator, k8sUtils.ApiOpWso2Namespace),
 				utils.Default{Value: "N", IsDefault: true},
 				"",
 				false,
@@ -71,13 +73,9 @@ var uninstallApiOperatorCmd = &cobra.Command{
 
 			deleteErrors := []error{
 				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.Namespace, k8sUtils.ApiOpWso2Namespace),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.ApiOperator),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.ApiOperator),
-
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdApi),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdSecurity),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdRateLimiting),
-				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.ApiOpCrdTargetEndpoint),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRole, k8sUtils.Wso2amRole),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.ClusterRoleBinding, k8sUtils.Wso2amRoleBinding),
+				k8sUtils.ExecuteCommand(k8sUtils.Kubectl, k8sUtils.K8sDelete, k8sUtils.CrdKind, k8sUtils.Wso2amOpCrdApimanager),
 			}
 
 			for _, err := range deleteErrors {
@@ -92,6 +90,6 @@ var uninstallApiOperatorCmd = &cobra.Command{
 }
 
 func init() {
-	uninstallCmd.AddCommand(uninstallApiOperatorCmd)
-	uninstallApiOperatorCmd.Flags().BoolVar(&flagForceUninstallApiOperator, "force", false, "Force uninstall API Operator")
+	uninstallCmd.AddCommand(uninstallWso2amOperatorCmd)
+	uninstallWso2amOperatorCmd.Flags().BoolVar(&flagForceUninstallWso2amOperator, "force", false, "Force uninstall WSO2AM Operator")
 }

--- a/import-export-cli/cmd/k8sUpdateApi.go
+++ b/import-export-cli/cmd/k8sUpdateApi.go
@@ -1,0 +1,86 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+
+	"github.com/spf13/cobra"
+)
+
+const K8sUpdateCmdLiteral = "update"
+const k8sUpdateCmdShortDesc = "Update an API to the kubernetes cluster"
+const k8sUpdateCmdLongDesc = `Update an existing API with Swagger file in the kubernetes cluster. JSON and YAML formats are accepted.`
+const k8sUpdateCmdExamples = utils.ProjectName + " " + K8sCmdLiteral + " " + K8sUpdateCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+
+` + utils.ProjectName + " " + K8sCmdLiteral + " " + K8sUpdateCmdLiteral + " " + AddApiCmdLiteral + " " + `-n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2`
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:     K8sUpdateCmdLiteral,
+	Short:   k8sUpdateCmdShortDesc,
+	Long:    k8sUpdateCmdLongDesc,
+	Example: k8sUpdateCmdExamples,
+}
+
+// updateApiCmd represents the updateApi command
+var updateApiCmd = &cobra.Command{
+	Use:     AddApiCmdLiteral,
+	Short:   addApiCmdShortDesc,
+	Long:    addApiLongDesc,
+	Example: addApiExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + K8sUpdateCmdLiteral + " called")
+		validateAddApiCommand()
+
+		// check the existence of the API
+		getApiErr := k8sUtils.ExecuteCommandWithoutOutputs(
+			k8sUtils.Kubectl, k8sUtils.K8sGet, k8sUtils.ApiOpCrdApi, flagApiName, "-n", flagNamespace)
+		if getApiErr != nil {
+			var errMsg string
+			if flagNamespace != "" {
+				errMsg = fmt.Sprintf("Could not find the API \"%s\" in the namespace \"%s\"",
+					flagApiName, flagNamespace)
+			} else {
+				errMsg = fmt.Sprintf("Could not find the API \"%s\"", flagApiName)
+			}
+			utils.HandleErrorAndExit(errMsg, nil)
+		}
+
+		//get current timestamp
+		timestampSuffix := time.Now().Format("2Jan2006150405")
+		handleAddApi("-" + strings.ToLower(timestampSuffix))
+	},
+}
+
+func init() {
+	K8sCmd.AddCommand(updateCmd)
+	updateCmd.AddCommand(updateApiCmd)
+	updateApiCmd.Flags().StringVarP(&flagApiName, "name", "n", "", "Name of the API")
+	updateApiCmd.Flags().StringArrayVarP(&flagSwaggerFilePaths, "from-file", "f", []string{}, "Path to swagger file")
+	updateApiCmd.Flags().IntVar(&flagReplicas, "replicas", 1, "replica set")
+	updateApiCmd.Flags().StringVar(&flagNamespace, "namespace", "", "namespace of API")
+	updateApiCmd.Flags().StringVarP(&flagApiVersion, "version", "v", "", "Property to override the existing docker image with same name and version")
+	updateApiCmd.Flags().StringVarP(&flagApiMode, "mode", "m", "",
+		fmt.Sprintf("Property to override the deploying mode. Available modes: %v, %v", utils.PrivateJetModeConst, utils.SidecarModeConst))
+}

--- a/import-export-cli/cmd/login.go
+++ b/import-export-cli/cmd/login.go
@@ -91,7 +91,7 @@ var loginCmd = &cobra.Command{
 
 func runLogin(store credentials.Store, environment, username, password string) error {
 	if !utils.EnvExistsInMainConfigFile(environment, utils.MainConfigFilePath) {
-		fmt.Println(environment, "does not exists. Add it using add-env")
+		fmt.Println(environment, "does not exists. Add it using add env")
 		os.Exit(1)
 	}
 

--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -29,12 +30,13 @@ import (
 var envToBeRemoved string // name of the environment to be removed
 
 // RemoveEnv command related Info
-const removeEnvCmdLiteral = "env"
+const removeEnvCmdLiteral = "env [environment]"
+const removeEnvCmdLiteralTrimmed = "env"
 const removeEnvCmdShortDesc = "Remove Environment from Config file"
 
 const removeEnvCmdLongDesc = `Remove Environment and its related endpoints from the config file`
 
-const removeEnvCmdExamples = utils.ProjectName + ` ` + removeCmdLiteral + ` ` + removeEnvCmdLiteral + `  production`
+const removeEnvCmdExamples = utils.ProjectName + ` ` + removeCmdLiteral + ` ` + removeEnvCmdLiteralTrimmed + ` production`
 
 // removeEnvCmd represents the removeEnv command
 var removeEnvCmd = &cobra.Command{
@@ -99,7 +101,7 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 	}
 
 	fmt.Println("Successfully removed environment '" + envName + "'")
-	fmt.Println("Execute '" + utils.ProjectName + " add-env" + " --help' to see how to add a new environment")
+	fmt.Println("Execute '" + utils.ProjectName + " " + AddCmdLiteral + " " + AddEnvCmdLiteralTrimmed + " --help' to see how to add a new environment")
 
 	return nil
 }

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -21,9 +21,10 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"strings"
 )
 
 var flagHttpRequestTimeout int
@@ -42,15 +43,12 @@ const setCmdShortDesc = "Set configuration parameters"
 const setCmdLongDesc = `Set configuration parameters. Use at least one of the following flags
 * --http-request-timeout <time-in-milli-seconds>
 * --export-directory <path-to-directory-where-apis-should-be-saved>
-* --mode <mode-of-apictl>
 * --vcs-deletion-enabled <enable-or-disable-project-deletion-via-vcs>
 * --vcs-config-path <path-to-custom-vcs-config-file>`
 
 const setCmdExamples = utils.ProjectName + ` ` + setCmdLiteral + ` --http-request-timeout 3600 --export-directory /home/user/exported-apis
 ` + utils.ProjectName + ` ` + setCmdLiteral + ` --http-request-timeout 5000 --export-directory C:\Documents\exported
 ` + utils.ProjectName + ` ` + setCmdLiteral + ` --http-request-timeout 5000
-` + utils.ProjectName + ` ` + setCmdLiteral + ` --mode kubernetes
-` + utils.ProjectName + ` ` + setCmdLiteral + ` --mode default
 ` + utils.ProjectName + ` ` + setCmdLiteral + ` --vcs-deletion-enabled=true
 ` + utils.ProjectName + ` ` + setCmdLiteral + ` --vcs-config-path /home/user/custom/vcs-config.yaml`
 
@@ -152,6 +150,7 @@ func init() {
 	SetCmd.Flags().StringVarP(&flagKubernetesMode, "mode", "m", utils.DefaultEnvironmentName, "If mode is set to \"k8s\", apictl "+
 		"is capable of executing Kubectl commands. For example \"apictl get pods\" -> \"kubectl get pods\". To go back "+
 		"to the default mode, set the mode to \"default\"")
+	SetCmd.Flags().MarkDeprecated("mode", "if you want to run the commands in kubernetes mode use 'k8s' after 'apictl' (eg: apictl k8s add)")
 	SetCmd.Flags().BoolVar(&flagVCSDeletionEnabled, "vcs-deletion-enabled", false,
 		"Specifies whether project deletion is allowed during deployment.")
 	SetCmd.Flags().StringVar(&flagVCSConfigPath, flagVCSConfigPathName, "",

--- a/import-export-cli/cmd/vcsDeploy.go
+++ b/import-export-cli/cmd/vcsDeploy.go
@@ -51,7 +51,7 @@ var DeployCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deployCmdLiteral + " called")
 		if !utils.EnvExistsInMainConfigFile(flagVCSDeployEnvName, utils.MainConfigFilePath) {
-			fmt.Println(flagVCSDeployEnvName, "does not exists. Add it using add-env")
+			fmt.Println(flagVCSDeployEnvName, "does not exists. Add it using add env")
 			os.Exit(1)
 		}
 

--- a/import-export-cli/cmd/vcsStatus.go
+++ b/import-export-cli/cmd/vcsStatus.go
@@ -14,21 +14,22 @@
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-*/
+ */
 
 package cmd
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/git"
 	"github.com/wso2/product-apim-tooling/import-export-cli/specs/params"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"os"
-	"strconv"
 )
 
-var flagVCSStatusEnvName string           // name of the environment to be added
+var flagVCSStatusEnvName string // name of the environment to be added
 
 // push command related usage Info
 const vcsStatusCmdLiteral = "status"
@@ -36,7 +37,7 @@ const vcsStatusCmdShortDesc = "Shows the list of projects that are ready to depl
 const vcsStatusCmdLongDesc = `Shows the list of projects that are ready to deploy to the specified environment by --environment(-e)
 NOTE: --environment (-e) flag is mandatory`
 
-const vcsStatusCmdCmdExamples = utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsStatusCmdLiteral  + ` -e dev`
+const vcsStatusCmdCmdExamples = utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsStatusCmdLiteral + ` -e dev`
 
 // pushCmd represents the push command
 var VCSStatusCmd = &cobra.Command{
@@ -47,7 +48,7 @@ var VCSStatusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + vcsStatusCmdLiteral + " called")
 		if !utils.EnvExistsInMainConfigFile(flagVCSStatusEnvName, utils.MainConfigFilePath) {
-			fmt.Println(flagVCSStatusEnvName, "does not exists. Add it using add-env")
+			fmt.Println(flagVCSStatusEnvName, "does not exists. Add it using add env")
 			os.Exit(1)
 		}
 
@@ -57,7 +58,7 @@ var VCSStatusCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println("Projects to Deploy (" + strconv.Itoa(totalProjectsToUpdate) + ")");
+		fmt.Println("Projects to Deploy (" + strconv.Itoa(totalProjectsToUpdate) + ")")
 		printProjectsToUpdate(utils.ProjectTypeApi, updatedProjectsPerType[utils.ProjectTypeApi])
 		printProjectsToUpdate(utils.ProjectTypeApiProduct, updatedProjectsPerType[utils.ProjectTypeApiProduct])
 		printProjectsToUpdate(utils.ProjectTypeApplication, updatedProjectsPerType[utils.ProjectTypeApplication])
@@ -87,7 +88,7 @@ func printProjectsToUpdate(projectType string, projects []*params.ProjectParams)
 func init() {
 	VCSCmd.AddCommand(VCSStatusCmd)
 
-	VCSStatusCmd.Flags().StringVarP(&flagVCSStatusEnvName, "environment", "e", "", "Name of the " +
+	VCSStatusCmd.Flags().StringVarP(&flagVCSStatusEnvName, "environment", "e", "", "Name of the "+
 		"environment to check the project(s) status")
 
 	_ = VCSStatusCmd.MarkFlagRequired("environment")

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -21,28 +21,18 @@ apictl [flags]
 
 ### SEE ALSO
 
-* [apictl add](apictl_add.md)	 - Add an API to the kubernetes cluster
-* [apictl add-env](apictl_add-env.md)	 - Add Environment to Config file
-* [apictl change](apictl_change.md)	 - Change a configuration in K8s cluster resource
+* [apictl add](apictl_add.md)	 - Add Environment to Config file
 * [apictl change-status](apictl_change-status.md)	 - Change Status of an API
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
-* [apictl export](apictl_export.md)	 - Export an API Product in an environment
-* [apictl export-api](apictl_export-api.md)	 - Export API
-* [apictl export-apis](apictl_export-apis.md)	 - Export APIs for migration
-* [apictl export-app](apictl_export-app.md)	 - Export App
-* [apictl get-keys](apictl_get-keys.md)	 - Generate access token to invoke the API or API Product
-* [apictl import](apictl_import.md)	 - Import an API Product to an environment
-* [apictl import-api](apictl_import-api.md)	 - Import API
-* [apictl import-app](apictl_import-app.md)	 - Import App
+* [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+* [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
 * [apictl init](apictl_init.md)	 - Initialize a new project in given path
-* [apictl install](apictl_install.md)	 - Install an operator in the configured K8s cluster
-* [apictl list](apictl_list.md)	 - List APIs/APIProducts/Applications in an environment or List the environments
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
 * [apictl login](apictl_login.md)	 - Login to an API Manager
 * [apictl logout](apictl_logout.md)	 - Logout to from an API Manager
 * [apictl remove](apictl_remove.md)	 - Remove an environment
 * [apictl set](apictl_set.md)	 - Set configuration parameters
-* [apictl uninstall](apictl_uninstall.md)	 - Uninstall an operator in the configured K8s cluster
-* [apictl update](apictl_update.md)	 - Update an API to the kubernetes cluster
 * [apictl vcs](apictl_vcs.md)	 - Checks status and deploys projects
 * [apictl version](apictl_version.md)	 - Display Version on current apictl
 

--- a/import-export-cli/docs/apictl_add_env.md
+++ b/import-export-cli/docs/apictl_add_env.md
@@ -1,10 +1,14 @@
-## apictl add
+## apictl add env
 
 Add Environment to Config file
 
 ### Synopsis
 
 Add new environment and its related endpoints to the config file
+
+```
+apictl add env [environment] [flags]
+```
 
 ### Examples
 
@@ -24,7 +28,6 @@ apictl add env dev \
 --registration https://idp.com:9443 \
 --token https://gw.com:8243/token
 
-NOTE: The flag --environment (-e) is mandatory.
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
 cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
@@ -33,7 +36,13 @@ cases --token flag is optional and use it to specify the gateway token endpoint.
 ### Options
 
 ```
-  -h, --help   help for add
+      --admin string          Admin endpoint for the environment
+      --apim string           API Manager endpoint for the environment
+      --devportal string      DevPortal endpoint for the environment
+  -h, --help                  help for env
+      --publisher string      Publisher endpoint for the environment
+      --registration string   Registration endpoint for the environment
+      --token string          Token endpoint for the environment
 ```
 
 ### Options inherited from parent commands
@@ -45,6 +54,5 @@ cases --token flag is optional and use it to specify the gateway token endpoint.
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
-* [apictl add env](apictl_add_env.md)	 - Add Environment to Config file
+* [apictl add](apictl_add.md)	 - Add Environment to Config file
 

--- a/import-export-cli/docs/apictl_delete.md
+++ b/import-export-cli/docs/apictl_delete.md
@@ -4,10 +4,9 @@ Delete an API/APIProduct/Application in an environment
 
 ### Synopsis
 
-Delete an API available in the environment specified by flag (--environment, -e) in default mode
-Delete an API Product available in the environment specified by flag (--environment, -e) in default mode
-Delete an Application of a specific user in the environment specified by flag (--environment, -e) in default mode
-Delete resources by filenames, stdin, resources and names, or by resources and label selector in kubernetes mode
+Delete an API available in the environment specified by flag (--environment, -e)
+Delete an API Product available in the environment specified by flag (--environment, -e)
+Delete an Application of a specific user in the environment specified by flag (--environment, -e)
 
 ```
 apictl delete [flags]
@@ -19,8 +18,6 @@ apictl delete [flags]
 apictl delete api -n TwitterAPI -v 1.0.0 -r admin -e dev
 apictl delete api-product -n TwitterAPI -r admin -e dev 
 apictl delete app -n TestApplication -o admin -e dev
-apictl delete api petstore
-apictl delete api -l name=myLabel
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_delete_api.md
+++ b/import-export-cli/docs/apictl_delete_api.md
@@ -4,24 +4,18 @@ Delete API
 
 ### Synopsis
 
-Delete an API from an environment in default mode and delete API resources by API name or label selector in kubernetes mode
+Delete an API from an environment
 
 ```
-apictl delete api (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment <environment-from-which-the-api-should-be-deleted>) [Flags]
-Kubernetes Mode:
-  apictl delete api (<name-of-the-api> or -l name=<name-of-the-label>) [flags]
+apictl delete api (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment <environment-from-which-the-api-should-be-deleted>) [flags]
 ```
 
 ### Examples
 
 ```
-Default Mode:
-  apictl delete api -n TwitterAPI -v 1.0.0 -r admin -e dev
-  apictl delete api -n FacebookAPI -v 2.1.0 -e production
+apictl delete api -n TwitterAPI -v 1.0.0 -r admin -e dev
+apictl delete api -n FacebookAPI -v 2.1.0 -e production
 NOTE: The 3 flags (--name (-n), --version (-v), and --environment (-e)) are mandatory.
-Kubernetes Mode:
-  apictl delete api petstore
-  apictl delete api -l name=myLabel
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_export.md
+++ b/import-export-cli/docs/apictl_export.md
@@ -1,10 +1,13 @@
 ## apictl export
 
-Export an API Product in an environment
+Export an API/API Product/Application in an environment
 
 ### Synopsis
 
+Export an API available in the environment specified by flag (--environment, -e)
+Export APIs available in the environment specified by flag (--environment, -e)
 Export an API Product available in the environment specified by flag (--environment, -e)
+Export an Application of a specific user (--owner, -o) in the environment specified by flag (--environment, -e)
 
 ```
 apictl export [flags]
@@ -13,7 +16,10 @@ apictl export [flags]
 ### Examples
 
 ```
+apictl export api -n TwitterAPI -v 1.0.0 -r admin -e dev
+apictl export apis -e dev
 apictl export api-product -n LeasingAPIProduct -e dev
+apictl export app -n SampleApp -o admin -e dev
 ```
 
 ### Options
@@ -32,5 +38,8 @@ apictl export api-product -n LeasingAPIProduct -e dev
 ### SEE ALSO
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl export api](apictl_export_api.md)	 - Export API
 * [apictl export api-product](apictl_export_api-product.md)	 - Export API Product
+* [apictl export apis](apictl_export_apis.md)	 - Export APIs for migration
+* [apictl export app](apictl_export_app.md)	 - Export App
 

--- a/import-export-cli/docs/apictl_export_api-product.md
+++ b/import-export-cli/docs/apictl_export_api-product.md
@@ -37,5 +37,5 @@ NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory
 
 ### SEE ALSO
 
-* [apictl export](apictl_export.md)	 - Export an API Product in an environment
+* [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
 

--- a/import-export-cli/docs/apictl_export_api.md
+++ b/import-export-cli/docs/apictl_export_api.md
@@ -1,0 +1,43 @@
+## apictl export api
+
+Export API
+
+### Synopsis
+
+Export an API from an environment
+
+```
+apictl export api (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --environment <environment-from-which-the-api-should-be-exported>) [flags]
+```
+
+### Examples
+
+```
+apictl export api -n TwitterAPI -v 1.0.0 -r admin -e dev
+apictl export api -n FacebookAPI -v 2.1.0 -r admin -e production
+NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to which the API should be exported
+      --format string        File format of exported archive(json or yaml) (default "YAML")
+  -h, --help                 help for api
+  -n, --name string          Name of the API to be exported
+      --preserveStatus       Preserve API status when exporting. Otherwise API will be exported in CREATED status (default true)
+  -r, --provider string      Provider of the API
+  -v, --version string       Version of the API to be exported
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
+

--- a/import-export-cli/docs/apictl_export_apis.md
+++ b/import-export-cli/docs/apictl_export_apis.md
@@ -1,0 +1,41 @@
+## apictl export apis
+
+Export APIs for migration
+
+### Synopsis
+
+Export all the APIs of a tenant from one environment, to be imported into another environment
+
+```
+apictl export apis (--environment <environment-from-which-artifacts-should-be-exported> --format <export-format> --preserveStatus --force) [flags]
+```
+
+### Examples
+
+```
+apictl export apis -e production --force
+apictl export apis -e production
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from which the APIs should be exported
+      --force                Clean all the previously exported APIs of the given target tenant, in the given environment if any, and to export APIs from beginning
+      --format string        File format of exported archives(json or yaml) (default "YAML")
+  -h, --help                 help for apis
+      --preserveStatus       Preserve API status when exporting. Otherwise API will be exported in CREATED status (default true)
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
+

--- a/import-export-cli/docs/apictl_export_app.md
+++ b/import-export-cli/docs/apictl_export_app.md
@@ -1,0 +1,41 @@
+## apictl export app
+
+Export App
+
+### Synopsis
+
+Export an Application from a specified  environment
+
+```
+apictl export app (--name <name-of-the-application> --owner <owner-of-the-application> --environment <environment-from-which-the-app-should-be-exported>) [flags]
+```
+
+### Examples
+
+```
+apictl export app -n SampleApp -o admin -e dev
+apictl export app -n SampleApp -o admin -e prod
+NOTE: All the 3 flags (--name (-n), --owner (-o) and --environment (-e)) are mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to which the Application should be exported
+  -h, --help                 help for app
+  -n, --name string          Name of the Application to be exported
+  -o, --owner string         Owner of the Application to be exported
+      --withKeys             Export keys for the application 
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
+

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -1,0 +1,47 @@
+## apictl get
+
+Get APIs/APIProducts/Applications in an environment or Get the environments
+
+### Synopsis
+
+Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
+Display a list containing all the API Products available in the environment specified by flag (--environment, -e)/
+Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)
+OR
+List all the environments
+
+```
+apictl get [flags]
+```
+
+### Examples
+
+```
+apictl get envs
+apictl get apis -e dev
+apictl get api-products -e dev
+apictl get apps -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl get api-products](apictl_get_api-products.md)	 - Display a list of API Products in an environment
+* [apictl get apis](apictl_get_apis.md)	 - Display a list of APIs in an environment
+* [apictl get apps](apictl_get_apps.md)	 - Display a list of Applications in an environment specific to an owner
+* [apictl get envs](apictl_get_envs.md)	 - Display the list of environments
+* [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API or API Product
+

--- a/import-export-cli/docs/apictl_get_api-products.md
+++ b/import-export-cli/docs/apictl_get_api-products.md
@@ -1,0 +1,44 @@
+## apictl get api-products
+
+Display a list of API Products in an environment
+
+### Synopsis
+
+Display a list of API Products in the environment specified by the flag --environment, -e
+
+```
+apictl get api-products [flags]
+```
+
+### Examples
+
+```
+apictl get api-products -e dev
+apictl get api-products -e dev -q provider:devops
+apictl get api-products -e prod -q provider:admin context:/myproduct
+apictl get api-products -e prod -l 25
+apictl get api-products -e staging
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print API Products using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for api-products
+  -l, --limit string         Maximum number of API Products to return (default "25")
+  -q, --query string         Query pattern
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_get_apis.md
+++ b/import-export-cli/docs/apictl_get_apis.md
@@ -1,0 +1,44 @@
+## apictl get apis
+
+Display a list of APIs in an environment
+
+### Synopsis
+
+Display a list of APIs in the environment specified by the flag --environment, -e
+
+```
+apictl get apis [flags]
+```
+
+### Examples
+
+```
+apictl get apis -e dev
+apictl get apis -e dev -q version:1.0.0
+apictl get apis -e prod -q provider:admin
+apictl get apis -e prod -l 100
+apictl get apis -e staging
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for apis
+  -l, --limit string         Maximum number of apis to return (default "25")
+  -q, --query string         Query pattern
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_get_apps.md
+++ b/import-export-cli/docs/apictl_get_apps.md
@@ -1,0 +1,44 @@
+## apictl get apps
+
+Display a list of Applications in an environment specific to an owner
+
+### Synopsis
+
+Display a list of Applications of the user in the environment specified by the flag --environment, -e
+
+```
+apictl get apps [flags]
+```
+
+### Examples
+
+```
+apictl get apps -e dev 
+apictl get apps -e dev -o sampleUser
+apictl get apps -e prod -o sampleUser
+apictl get apps -e staging -o sampleUser
+apictl get apps -e dev -l 40
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print outputusing Go templates. Use "{{jsonPretty .}}" to list all fields
+  -h, --help                 help for apps
+  -l, --limit string         Maximum number of applications to return (default "25")
+  -o, --owner string         Owner of the Application
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_get_envs.md
+++ b/import-export-cli/docs/apictl_get_envs.md
@@ -1,0 +1,36 @@
+## apictl get envs
+
+Display the list of environments
+
+### Synopsis
+
+Display a list of environments defined in 'main_config.yaml' file
+
+```
+apictl get envs [flags]
+```
+
+### Examples
+
+```
+apictl list envs
+```
+
+### Options
+
+```
+      --format string   Pretty-print environments using go templates (default "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}")
+  -h, --help            help for envs
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_get_keys.md
+++ b/import-export-cli/docs/apictl_get_keys.md
@@ -1,0 +1,42 @@
+## apictl get keys
+
+Generate access token to invoke the API or API Product
+
+### Synopsis
+
+Generate JWT token to invoke the API or API Product by subscribing to a default application for testing purposes
+
+```
+apictl get keys [flags]
+```
+
+### Examples
+
+```
+apictl get keys -n TwitterAPI -v 1.0.0 -e dev --provider admin
+NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory.
+You can override the default token endpoint using --token (-t) optional flag providing a new token endpoint
+```
+
+### Options
+
+```
+  -e, --environment string   Key generation environment
+  -h, --help                 help for keys
+  -n, --name string          API or API Product to generate keys
+  -r, --provider string      Provider of the API or API Product
+  -t, --token string         Token endpoint URL of Environment
+  -v, --version string       Version of the API
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_import.md
+++ b/import-export-cli/docs/apictl_import.md
@@ -1,10 +1,12 @@
 ## apictl import
 
-Import an API Product to an environment
+Import an API/API Product/Application to an environment
 
 ### Synopsis
 
+Import an API to the environment specified by flag (--environment, -e)
 Import an API Product to the environment specified by flag (--environment, -e)
+Import an Application to the environment specified by flag (--environment, -e)
 
 ```
 apictl import [flags]
@@ -13,7 +15,9 @@ apictl import [flags]
 ### Examples
 
 ```
+apictl import api -f qa/TwitterAPI.zip -e dev
 apictl import api-product -f qa/LeasingAPIProduct.zip -e dev
+apictl import app -f qa/apps/sampleApp.zip -e dev
 ```
 
 ### Options
@@ -32,5 +36,7 @@ apictl import api-product -f qa/LeasingAPIProduct.zip -e dev
 ### SEE ALSO
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl import api](apictl_import_api.md)	 - Import API
 * [apictl import api-product](apictl_import_api-product.md)	 - Import API Product
+* [apictl import app](apictl_import_app.md)	 - Import App
 

--- a/import-export-cli/docs/apictl_import_api-product.md
+++ b/import-export-cli/docs/apictl_import_api-product.md
@@ -42,5 +42,5 @@ NOTE: Both the flags (--file (-f) and --environment (-e)) are mandatory
 
 ### SEE ALSO
 
-* [apictl import](apictl_import.md)	 - Import an API Product to an environment
+* [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
 

--- a/import-export-cli/docs/apictl_import_api.md
+++ b/import-export-cli/docs/apictl_import_api.md
@@ -1,0 +1,45 @@
+## apictl import api
+
+Import API
+
+### Synopsis
+
+Import an API to an environment
+
+```
+apictl import api --file <path-to-api> --environment <environment> [flags]
+```
+
+### Examples
+
+```
+apictl import api -f qa/TwitterAPI.zip -e dev
+apictl import api -f staging/FacebookAPI.zip -e production
+apictl import api -f ~/myapi -e production --update
+apictl import api -f ~/myapi -e production --update
+NOTE: Both the flags (--file (-f) and --environment (-e)) are mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from the which the API should be imported
+  -f, --file string          Name of the API to be imported
+  -h, --help                 help for api
+      --params string        Provide a API Manager params file (default "api_params.yaml")
+      --preserve-provider    Preserve existing provider of API after importing (default true)
+      --skipCleanup          Leave all temporary files created during import process
+      --update               Update an existing API or create a new API
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
+

--- a/import-export-cli/docs/apictl_import_app.md
+++ b/import-export-cli/docs/apictl_import_app.md
@@ -1,0 +1,46 @@
+## apictl import app
+
+Import App
+
+### Synopsis
+
+Import an Application to an environment
+
+```
+apictl import app (--file <app-zip-file> --environment <environment-to-which-the-app-should-be-imported>) [flags]
+```
+
+### Examples
+
+```
+apictl import app -f qa/apps/sampleApp.zip -e dev
+apictl import app -f staging/apps/sampleApp.zip -e prod -o testUser
+apictl import app -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e prod
+NOTE: Both the flags (--file (-f) and --environment (-e)) are mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from the which the Application should be imported
+  -f, --file string          Name of the ZIP file of the Application to be imported
+  -h, --help                 help for app
+  -o, --owner string         Name of the target owner of the Application as desired by the Importer
+      --preserveOwner        Preserves app owner
+      --skipCleanup          Leave all temporary files created during import process
+      --skipKeys             Skip importing keys of the Application
+  -s, --skipSubscriptions    Skip subscriptions of the Application
+      --update               Update the Application if it is already imported
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
+

--- a/import-export-cli/docs/apictl_k8s.md
+++ b/import-export-cli/docs/apictl_k8s.md
@@ -1,0 +1,45 @@
+## apictl k8s
+
+Kubernetes mode based commands
+
+### Synopsis
+
+Kubernetes mode based commands such as install, uninstall, add/update api, change registry.
+
+```
+apictl k8s [flags]
+```
+
+### Examples
+
+```
+apictl k8s install api-operator
+apictl k8s uninstall api-operator
+apictl k8s add api -n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+apictl k8s update api -n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+apictl k8s change registry
+```
+
+### Options
+
+```
+  -h, --help   help for k8s
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl k8s add](apictl_k8s_add.md)	 - Add an API to the kubernetes cluster
+* [apictl k8s change](apictl_k8s_change.md)	 - Change a configuration in K8s cluster resource
+* [apictl k8s delete](apictl_k8s_delete.md)	 - Delete resources related to kubernetes
+* [apictl k8s install](apictl_k8s_install.md)	 - Install an operator in the configured K8s cluster
+* [apictl k8s uninstall](apictl_k8s_uninstall.md)	 - Uninstall an operator in the configured K8s cluster
+* [apictl k8s update](apictl_k8s_update.md)	 - Update an API to the kubernetes cluster
+

--- a/import-export-cli/docs/apictl_k8s_add.md
+++ b/import-export-cli/docs/apictl_k8s_add.md
@@ -1,0 +1,35 @@
+## apictl k8s add
+
+Add an API to the kubernetes cluster
+
+### Synopsis
+
+Add an API from a Swagger file to the kubernetes cluster. JSON and YAML formats are accepted.
+To execute kubernetes commands set mode to Kubernetes
+
+### Examples
+
+```
+apictl k8s add api -n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+
+apictl k8s add api -n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2 --override=true
+```
+
+### Options
+
+```
+  -h, --help   help for add
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s add api](apictl_k8s_add_api.md)	 - Handle APIs in kubernetes cluster 
+

--- a/import-export-cli/docs/apictl_k8s_add_api.md
+++ b/import-export-cli/docs/apictl_k8s_add_api.md
@@ -1,0 +1,48 @@
+## apictl k8s add api
+
+Handle APIs in kubernetes cluster 
+
+### Synopsis
+
+Add, Update and Delete APIs in kubernetes cluster. JSON and YAML formats are accepted.
+available modes are as follows
+* kubernetes
+
+```
+apictl k8s add api [flags]
+```
+
+### Examples
+
+```
+apictl k8s add/update api -n petstore --from-file=./Swagger.json --replicas=3 --namespace=wso2
+```
+
+### Options
+
+```
+  -a, --apiEndPoint string      
+  -e, --env stringArray         Environment variables to be passed to deployment
+  -f, --from-file stringArray   Path to swagger file
+  -h, --help                    help for api
+      --hostname string         Ingress hostname that the API is being exposed
+  -i, --image string            Image of the API. If specified, ignores the value of --override
+  -m, --mode string             Property to override the deploying mode. Available modes: privateJet, sidecar
+  -n, --name string             Name of the API
+      --namespace string        namespace of API
+      --override                Property to override the existing docker image with the given name and version
+      --replicas int            replica set (default 1)
+  -v, --version string          Property to override the API version
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s add](apictl_k8s_add.md)	 - Add an API to the kubernetes cluster
+

--- a/import-export-cli/docs/apictl_k8s_change.md
+++ b/import-export-cli/docs/apictl_k8s_change.md
@@ -1,0 +1,32 @@
+## apictl k8s change
+
+Change a configuration in K8s cluster resource
+
+### Synopsis
+
+Change a configuration in K8s cluster resource
+
+### Examples
+
+```
+apictl k8s change registry
+```
+
+### Options
+
+```
+  -h, --help   help for change
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s change registry](apictl_k8s_change_registry.md)	 - Change the registry
+

--- a/import-export-cli/docs/apictl_k8s_change_registry.md
+++ b/import-export-cli/docs/apictl_k8s_change_registry.md
@@ -1,0 +1,41 @@
+## apictl k8s change registry
+
+Change the registry
+
+### Synopsis
+
+Change the registry to be pushed the built micro-gateway image
+
+```
+apictl k8s change registry [flags]
+```
+
+### Examples
+
+```
+apictl k8s change registry
+```
+
+### Options
+
+```
+  -h, --help                   help for registry
+  -c, --key-file string        Credentials file
+  -p, --password string        Password of the given user
+      --password-stdin         Prompt for password of the given user in the stdin
+  -R, --registry-type string   Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP
+  -r, --repository string      Repository name or URI
+  -u, --username string        Username of the repository
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s change](apictl_k8s_change.md)	 - Change a configuration in K8s cluster resource
+

--- a/import-export-cli/docs/apictl_k8s_delete.md
+++ b/import-export-cli/docs/apictl_k8s_delete.md
@@ -1,0 +1,37 @@
+## apictl k8s delete
+
+Delete resources related to kubernetes
+
+### Synopsis
+
+Delete resources by filenames, stdin, resources and names, or by resources and label selector in kubernetes mode
+
+```
+apictl k8s delete [flags]
+```
+
+### Examples
+
+```
+apictl delete api petstore
+apictl delete api -l name=myLabel
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s delete apictl](apictl_k8s_delete_apictl.md)	 - Delete API resources
+

--- a/import-export-cli/docs/apictl_k8s_delete_apictl.md
+++ b/import-export-cli/docs/apictl_k8s_delete_apictl.md
@@ -1,0 +1,36 @@
+## apictl k8s delete apictl
+
+Delete API resources
+
+### Synopsis
+
+Delete API resources by API name or label selector in kubernetes mode
+
+```
+apictl k8s delete apictl delete api (<name-of-the-api> or -l name=<name-of-the-label>) [flags]
+```
+
+### Examples
+
+```
+apictl delete api petstore
+  apictl delete api -l name=myLabel
+```
+
+### Options
+
+```
+  -h, --help   help for apictl
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s delete](apictl_k8s_delete.md)	 - Delete resources related to kubernetes
+

--- a/import-export-cli/docs/apictl_k8s_install.md
+++ b/import-export-cli/docs/apictl_k8s_install.md
@@ -1,0 +1,33 @@
+## apictl k8s install
+
+Install an operator in the configured K8s cluster
+
+### Synopsis
+
+Install an operator in the configured K8s cluster
+
+### Examples
+
+```
+apictl k8s install api-operator
+```
+
+### Options
+
+```
+  -h, --help   help for install
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s install api-operator](apictl_k8s_install_api-operator.md)	 - Install API Operator
+* [apictl k8s install wso2am-operator](apictl_k8s_install_wso2am-operator.md)	 - Install WSO2AM Operator
+

--- a/import-export-cli/docs/apictl_k8s_install_api-operator.md
+++ b/import-export-cli/docs/apictl_k8s_install_api-operator.md
@@ -1,0 +1,44 @@
+## apictl k8s install api-operator
+
+Install API Operator
+
+### Synopsis
+
+Install API Operator in the configured K8s cluster
+
+```
+apictl k8s install api-operator [flags]
+```
+
+### Examples
+
+```
+apictl k8s install api-operator
+apictl k8s install api-operator -f path/to/operator/configs
+apictl k8s install api-operator -f path/to/operator/config/file.yaml
+```
+
+### Options
+
+```
+  -f, --from-file string       Path to API Operator directory
+  -h, --help                   help for api-operator
+  -c, --key-file string        Credentials file
+  -p, --password string        Password of the given user
+      --password-stdin         Prompt for password of the given user in the stdin
+  -R, --registry-type string   Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP
+  -r, --repository string      Repository name or URI
+  -u, --username string        Username of the repository
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s install](apictl_k8s_install.md)	 - Install an operator in the configured K8s cluster
+

--- a/import-export-cli/docs/apictl_k8s_install_wso2am-operator.md
+++ b/import-export-cli/docs/apictl_k8s_install_wso2am-operator.md
@@ -1,0 +1,38 @@
+## apictl k8s install wso2am-operator
+
+Install WSO2AM Operator
+
+### Synopsis
+
+Install WSO2AM Operator in the configured K8s cluster
+
+```
+apictl k8s install wso2am-operator [flags]
+```
+
+### Examples
+
+```
+apictl k8s install wso2am-operator
+apictl k8s install wso2am-operator -f path/to/operator/configs
+apictl k8s install wso2am-operator -f path/to/operator/config/file.yaml
+```
+
+### Options
+
+```
+  -f, --from-file string   Path to wso2am-operator directory
+  -h, --help               help for wso2am-operator
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s install](apictl_k8s_install.md)	 - Install an operator in the configured K8s cluster
+

--- a/import-export-cli/docs/apictl_k8s_uninstall.md
+++ b/import-export-cli/docs/apictl_k8s_uninstall.md
@@ -1,0 +1,33 @@
+## apictl k8s uninstall
+
+Uninstall an operator in the configured K8s cluster
+
+### Synopsis
+
+Uninstall an operator in the configured K8s cluster
+
+### Examples
+
+```
+apictl k8s uninstall api-operator
+```
+
+### Options
+
+```
+  -h, --help   help for uninstall
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s uninstall api-operator](apictl_k8s_uninstall_api-operator.md)	 - Uninstall API Operator
+* [apictl k8s uninstall wso2am-operator](apictl_k8s_uninstall_wso2am-operator.md)	 - Uninstall WSO2AM Operator
+

--- a/import-export-cli/docs/apictl_k8s_uninstall_api-operator.md
+++ b/import-export-cli/docs/apictl_k8s_uninstall_api-operator.md
@@ -1,0 +1,37 @@
+## apictl k8s uninstall api-operator
+
+Uninstall API Operator
+
+### Synopsis
+
+Uninstall API Operator in the configured K8s cluster
+
+```
+apictl k8s uninstall api-operator [flags]
+```
+
+### Examples
+
+```
+apictl k8s uninstall api-operator
+apictl k8s uninstall api-operator --force
+```
+
+### Options
+
+```
+      --force   Force uninstall API Operator
+  -h, --help    help for api-operator
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s uninstall](apictl_k8s_uninstall.md)	 - Uninstall an operator in the configured K8s cluster
+

--- a/import-export-cli/docs/apictl_k8s_uninstall_wso2am-operator.md
+++ b/import-export-cli/docs/apictl_k8s_uninstall_wso2am-operator.md
@@ -1,0 +1,37 @@
+## apictl k8s uninstall wso2am-operator
+
+Uninstall WSO2AM Operator
+
+### Synopsis
+
+Uninstall WSO2AM Operator in the configured K8s cluster
+
+```
+apictl k8s uninstall wso2am-operator [flags]
+```
+
+### Examples
+
+```
+apictl k8s uninstall wso2am-operator
+apictl k8s uninstall wso2am-operator --force
+```
+
+### Options
+
+```
+      --force   Force uninstall WSO2AM Operator
+  -h, --help    help for wso2am-operator
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s uninstall](apictl_k8s_uninstall.md)	 - Uninstall an operator in the configured K8s cluster
+

--- a/import-export-cli/docs/apictl_k8s_update.md
+++ b/import-export-cli/docs/apictl_k8s_update.md
@@ -1,0 +1,34 @@
+## apictl k8s update
+
+Update an API to the kubernetes cluster
+
+### Synopsis
+
+Update an existing API with Swagger file in the kubernetes cluster. JSON and YAML formats are accepted.
+
+### Examples
+
+```
+apictl k8s update api -n petstore --from-file=./Swagger.json --replicas=1 --namespace=wso2
+
+apictl k8s update api -n petstore --from-file=./product-apim-tooling/import-export-cli/build/target/apictl/myapi --replicas=1 --namespace=wso2
+```
+
+### Options
+
+```
+  -h, --help   help for update
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
+* [apictl k8s update api](apictl_k8s_update_api.md)	 - Handle APIs in kubernetes cluster 
+

--- a/import-export-cli/docs/apictl_k8s_update_api.md
+++ b/import-export-cli/docs/apictl_k8s_update_api.md
@@ -1,0 +1,43 @@
+## apictl k8s update api
+
+Handle APIs in kubernetes cluster 
+
+### Synopsis
+
+Add, Update and Delete APIs in kubernetes cluster. JSON and YAML formats are accepted.
+available modes are as follows
+* kubernetes
+
+```
+apictl k8s update api [flags]
+```
+
+### Examples
+
+```
+apictl k8s add/update api -n petstore --from-file=./Swagger.json --replicas=3 --namespace=wso2
+```
+
+### Options
+
+```
+  -f, --from-file stringArray   Path to swagger file
+  -h, --help                    help for api
+  -m, --mode string             Property to override the deploying mode. Available modes: privateJet, sidecar
+  -n, --name string             Name of the API
+      --namespace string        namespace of API
+      --replicas int            replica set (default 1)
+  -v, --version string          Property to override the existing docker image with same name and version
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl k8s update](apictl_k8s_update.md)	 - Update an API to the kubernetes cluster
+

--- a/import-export-cli/docs/apictl_remove.md
+++ b/import-export-cli/docs/apictl_remove.md
@@ -13,7 +13,7 @@ apictl remove [flags]
 ### Examples
 
 ```
-apictl remove env  production
+apictl remove env [environment]  production
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_remove_env.md
+++ b/import-export-cli/docs/apictl_remove_env.md
@@ -7,13 +7,13 @@ Remove Environment from Config file
 Remove Environment and its related endpoints from the config file
 
 ```
-apictl remove env [flags]
+apictl remove env [environment] [flags]
 ```
 
 ### Examples
 
 ```
-apictl remove env  production
+apictl remove env production
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -27,7 +27,7 @@ apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/wasura/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/wso2user/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
       --vcs-config-path string     Path to the VCS Configuration yaml file which keeps the VCS meta data

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -7,7 +7,6 @@ Set configuration parameters
 Set configuration parameters. Use at least one of the following flags
 * --http-request-timeout <time-in-milli-seconds>
 * --export-directory <path-to-directory-where-apis-should-be-saved>
-* --mode <mode-of-apictl>
 * --vcs-deletion-enabled <enable-or-disable-project-deletion-via-vcs>
 * --vcs-config-path <path-to-custom-vcs-config-file>
 
@@ -21,8 +20,6 @@ apictl set [flags]
 apictl set --http-request-timeout 3600 --export-directory /home/user/exported-apis
 apictl set --http-request-timeout 5000 --export-directory C:\Documents\exported
 apictl set --http-request-timeout 5000
-apictl set --mode kubernetes
-apictl set --mode default
 apictl set --vcs-deletion-enabled=true
 apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 ```
@@ -30,10 +27,9 @@ apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 ### Options
 
 ```
-      --export-directory string    Path to directory where APIs should be saved (default "/home/wso2user/.wso2apictl/exported")
+      --export-directory string    Path to directory where APIs should be saved (default "/home/wasura/.wso2apictl/exported")
   -h, --help                       help for set
       --http-request-timeout int   Timeout for HTTP Client (default 10000)
-  -m, --mode string                If mode is set to "k8s", apictl is capable of executing Kubectl commands. For example "apictl get pods" -> "kubectl get pods". To go back to the default mode, set the mode to "default" (default "default")
       --vcs-config-path string     Path to the VCS Configuration yaml file which keeps the VCS meta data
       --vcs-deletion-enabled       Specifies whether project deletion is allowed during deployment.
 ```

--- a/import-export-cli/go.sum
+++ b/import-export-cli/go.sum
@@ -183,6 +183,7 @@ github.com/coreos/prometheus-operator v0.38.0/go.mod h1:xZC7/TgeC0/mBaJk+1H9dbHa
 github.com/coreos/prometheus-operator v0.38.1-0.20200424145508-7e176fda06cc/go.mod h1:erio69w1R/aC14D5nfvAXSlE8FT8jt2Hnavc50Dp33A=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
@@ -918,6 +919,7 @@ github.com/rubenv/sql-migrate v0.0.0-20191025130928-9355dd04f4b3/go.mod h1:WS0rl
 github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3/go.mod h1:rtQlpHw+eR6UrqaS3kX1VYeaCxzCVdimDS7g5Ln4pPc=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -937,6 +939,7 @@ github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxr
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=

--- a/import-export-cli/impl/addEnv.go
+++ b/import-export-cli/impl/addEnv.go
@@ -1,0 +1,101 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// AddEnv adds a new environment and its endpoints and writes to config file
+// @param envName : Name of the Environment
+// @param publisherEndpoint : API Manager Endpoint for the environment
+// @param regEndpoint : Registration Endpoint for the environment
+// @param tokenEndpoint : Token Endpoint for the environment
+// @param mainConfigFilePath : Path to file where env endpoints are stored
+// @return error
+func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath, addEnvCmdLiteral string) error {
+	var isDefaultTokenEndpointSet bool = false
+
+	if envName == "" {
+		// name of the environment is blank
+		return errors.New("Name of the environment cannot be blank")
+	}
+
+	if envEndpoints.TokenEndpoint == "" {
+		// If token endpoint string is empty,then assign the default value
+		if envEndpoints.ApiManagerEndpoint != "" && !isDefaultTokenEndpointSet {
+			isDefaultTokenEndpointSet = true
+			envEndpoints.TokenEndpoint = utils.GetTokenEndPointFromAPIMEndpoint(envEndpoints.ApiManagerEndpoint)
+		}
+		if envEndpoints.PublisherEndpoint != "" && !isDefaultTokenEndpointSet {
+			envEndpoints.TokenEndpoint = utils.GetTokenEndPointFromPublisherEndpoint(envEndpoints.PublisherEndpoint)
+		}
+		fmt.Printf("Default token endpoint '%s' is added as the token endpoint \n", envEndpoints.TokenEndpoint)
+	}
+
+	if envEndpoints.ApiManagerEndpoint == "" {
+		if envEndpoints.AdminEndpoint == "" || envEndpoints.DevPortalEndpoint == "" ||
+			envEndpoints.PublisherEndpoint == "" || envEndpoints.RegistrationEndpoint == "" ||
+			envEndpoints.TokenEndpoint == "" {
+			utils.ShowHelpCommandTip(addEnvCmdLiteral)
+			return errors.New("Endpoint(s) cannot be blank")
+		}
+	}
+
+	if utils.EnvExistsInMainConfigFile(envName, mainConfigFilePath) {
+		// environment already exists
+		return errors.New("Environment '" + envName + "' already exists in " + mainConfigFilePath)
+	}
+
+	mainConfig := utils.GetMainConfigFromFile(mainConfigFilePath)
+
+	var validatedEnvEndpoints = utils.EnvEndpoints{
+		TokenEndpoint: envEndpoints.TokenEndpoint,
+	}
+
+	if envEndpoints.ApiManagerEndpoint != "" {
+		validatedEnvEndpoints.ApiManagerEndpoint = envEndpoints.ApiManagerEndpoint
+	}
+
+	if envEndpoints.RegistrationEndpoint != "" {
+		validatedEnvEndpoints.RegistrationEndpoint = envEndpoints.RegistrationEndpoint
+	}
+
+	if envEndpoints.PublisherEndpoint != "" {
+		validatedEnvEndpoints.PublisherEndpoint = envEndpoints.PublisherEndpoint
+	}
+
+	if envEndpoints.DevPortalEndpoint != "" {
+		validatedEnvEndpoints.DevPortalEndpoint = envEndpoints.DevPortalEndpoint
+	}
+
+	if envEndpoints.AdminEndpoint != "" {
+		validatedEnvEndpoints.AdminEndpoint = envEndpoints.AdminEndpoint
+	}
+
+	mainConfig.Environments[envName] = validatedEnvEndpoints
+	utils.WriteConfigFile(mainConfig, mainConfigFilePath)
+
+	fmt.Printf("Successfully added environment '%s'\n", envName)
+
+	return nil
+}

--- a/import-export-cli/impl/apiProducts.go
+++ b/import-export-cli/impl/apiProducts.go
@@ -1,0 +1,148 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+
+	v2 "github.com/wso2/product-apim-tooling/import-export-cli/specs/v2"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Get the ID of an API Product if available
+// @param accessToken : Access token to call the Publisher Rest API
+// @param environment : Environment where API Product needs to be located
+// @param apiProductName : Name of the API Product
+// @param apiProductProvider : Provider of the API Product
+// @return apiId, error
+func GetAPIProductId(accessToken, environment, apiProductName, apiProductProvider string) (string, error) {
+	// Unified Search endpoint from the config file to search API Products
+	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
+
+	// Prepping headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	var queryVal string
+	// TODO Search by version as well when the versioning support has been implemented for API Products
+	queryVal = "type:\"" + utils.DefaultApiProductType + "\" name:\"" + apiProductName + "\""
+	if apiProductProvider != "" {
+		queryVal = queryVal + " provider:\"" + apiProductProvider + "\""
+	}
+	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+		// 200 OK or 201 Created
+		apiData := &utils.ApiSearch{}
+		data := []byte(resp.Body())
+		err = json.Unmarshal(data, &apiData)
+		if apiData.Count != 0 {
+			apiProductId := apiData.List[0].ID
+			return apiProductId, err
+		}
+		// TODO Print the version as well when the versioning support has been implemented for API Products
+		if apiProductProvider != "" {
+			return "", errors.New("Requested API Product is not available in the Publisher. API Product: " + apiProductName +
+				" Provider: " + apiProductProvider)
+		}
+		return "", errors.New("Requested API Product is not available in the Publisher. API Product: " + apiProductName)
+	} else {
+		utils.Logf("Error: %s\n", resp.Error())
+		utils.Logf("Body: %s\n", resp.Body())
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthorized
+			return "", fmt.Errorf("Authorization failed while searching API Product: " + apiProductName)
+		}
+		return "", errors.New("Request didn't respond 200 OK for searching API Products. Status: " + resp.Status())
+	}
+}
+
+// GetAPIProductDefinition scans filePath and returns APIProductDefinition or an error
+func GetAPIProductDefinition(filePath string) (*v2.APIProductDefinition, []byte, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buffer []byte
+	if info.IsDir() {
+		_, content, err := resolveYamlOrJSON(path.Join(filePath, "Meta-information", "api"))
+		if err != nil {
+			return nil, nil, err
+		}
+		buffer = content
+	} else {
+		return nil, nil, fmt.Errorf("looking for directory, found %s", info.Name())
+	}
+	apiProduct, err := extractAPIProductDefinition(buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+	return apiProduct, buffer, nil
+}
+
+// GetAPIProductList
+// @param accessToken : Access Token for the environment
+// @param unifiedSearchEndpoint : Unified Search Endpoint for the environment to retreive API Product list
+// @param query : String to be matched against the API Product names
+// @return count (no. of API Products)
+// @return array of API Product objects
+// @return error
+func GetAPIProductList(accessToken, unifiedSearchEndpoint, query, limit string) (count int32, apiProducts []utils.APIProduct, err error) {
+	// Unified Search endpoint from the config file to search API Products
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	// To filter API Products from unified search
+	unifiedSearchEndpoint += "?query=type:\"" + utils.DefaultApiProductType + "\""
+
+	// Setting up the query parameter and limit parameter
+	if query != "" {
+		unifiedSearchEndpoint += " " + query
+	}
+	if limit != "" {
+		unifiedSearchEndpoint += "&limit=" + limit
+	}
+	utils.Logln(utils.LogPrefixInfo+"URL:", unifiedSearchEndpoint)
+	resp, err := utils.InvokeGETRequest(unifiedSearchEndpoint, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+unifiedSearchEndpoint, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		apiProductListResponse := &utils.APIProductListResponse{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &apiProductListResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+		}
+		return apiProductListResponse.Count, apiProductListResponse.List, nil
+	} else {
+		return 0, nil, errors.New(string(resp.Body()))
+	}
+}

--- a/import-export-cli/impl/apiProducts.go
+++ b/import-export-cli/impl/apiProducts.go
@@ -30,7 +30,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-// Get the ID of an API Product if available
+// GetAPIProductId Get the ID of an API Product if available
 // @param accessToken : Access token to call the Publisher Rest API
 // @param environment : Environment where API Product needs to be located
 // @param apiProductName : Name of the API Product
@@ -103,7 +103,7 @@ func GetAPIProductDefinition(filePath string) (*v2.APIProductDefinition, []byte,
 	return apiProduct, buffer, nil
 }
 
-// GetAPIProductList
+// GetAPIProductList Get the list of API Products available in a particular environment
 // @param accessToken : Access Token for the environment
 // @param unifiedSearchEndpoint : Unified Search Endpoint for the environment to retreive API Product list
 // @param query : String to be matched against the API Product names

--- a/import-export-cli/impl/apis.go
+++ b/import-export-cli/impl/apis.go
@@ -30,7 +30,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-// Get the ID of an API if available
+// GetAPIId Get the ID of an API if available
 // @param accessToken : Token to call the Publisher Rest API
 // @param environment : Environment where API needs to be located
 // @param apiName : Name of the API
@@ -103,7 +103,7 @@ func GetAPIDefinition(filePath string) (*v2.APIDefinition, []byte, error) {
 	return api, buffer, nil
 }
 
-// GetAPIList
+// GetAPIList Get the list of APIs available in a particular environment
 // @param accessToken : Access Token for the environment
 // @param apiListEndpoint : API List endpoint
 // @param query : string to be matched against the API names

--- a/import-export-cli/impl/apis.go
+++ b/import-export-cli/impl/apis.go
@@ -1,0 +1,164 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+
+	v2 "github.com/wso2/product-apim-tooling/import-export-cli/specs/v2"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Get the ID of an API if available
+// @param accessToken : Token to call the Publisher Rest API
+// @param environment : Environment where API needs to be located
+// @param apiName : Name of the API
+// @param apiVersion : Version of the API
+// @param apiProvider : Provider of API
+// @return apiId, error
+func GetAPIId(accessToken, environment, apiName, apiVersion, apiProvider string) (string, error) {
+	// Unified Search endpoint from the config file to search APIs
+	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
+
+	// Prepping headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	var queryVal string
+	queryVal = "name:\"" + apiName + "\" version:\"" + apiVersion + "\""
+	if apiProvider != "" {
+		queryVal = queryVal + " provider:\"" + apiProvider + "\""
+	}
+	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+		// 200 OK or 201 Created
+		apiData := &utils.ApiSearch{}
+		data := []byte(resp.Body())
+		err = json.Unmarshal(data, &apiData)
+		if apiData.Count != 0 {
+			apiId := apiData.List[0].ID
+			return apiId, err
+		}
+		if apiProvider != "" {
+			return "", errors.New("Requested API is not available in the Publisher. API: " + apiName +
+				" Version: " + apiVersion + " Provider: " + apiProvider)
+		}
+		return "", errors.New("Requested API is not available in the Publisher. API: " + apiName +
+			" Version: " + apiVersion)
+	} else {
+		utils.Logf("Error: %s\n", resp.Error())
+		utils.Logf("Body: %s\n", resp.Body())
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthorized
+			return "", fmt.Errorf("Authorization failed while searching API: " + apiName)
+		}
+		return "", errors.New("Request didn't respond 200 OK for searching APIs. Status: " + resp.Status())
+	}
+}
+
+// GetAPIDefinition scans filePath and returns APIDefinition or an error
+func GetAPIDefinition(filePath string) (*v2.APIDefinition, []byte, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buffer []byte
+	if info.IsDir() {
+		_, content, err := resolveYamlOrJSON(path.Join(filePath, "Meta-information", "api"))
+		if err != nil {
+			return nil, nil, err
+		}
+		buffer = content
+	} else {
+		return nil, nil, fmt.Errorf("looking for directory, found %s", info.Name())
+	}
+	api, err := extractAPIDefinition(buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+	return api, buffer, nil
+}
+
+// GetAPIList
+// @param accessToken : Access Token for the environment
+// @param apiListEndpoint : API List endpoint
+// @param query : string to be matched against the API names
+// @param limit : total # of results to return
+// @return count (no. of APIs)
+// @return array of API objects
+// @return error
+func GetAPIList(accessToken, apiListEndpoint, query, limit string) (count int32, apis []utils.API, err error) {
+	queryParamAdded := false
+	getQueryParamConnector := func() (connector string) {
+		if queryParamAdded {
+			return "&"
+		} else {
+			queryParamAdded = true
+			return "?"
+		}
+	}
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	if query != "" {
+		apiListEndpoint += getQueryParamConnector() + "query=" + query
+	}
+	if limit != "" {
+		apiListEndpoint += getQueryParamConnector() + "limit=" + limit
+	}
+	utils.Logln(utils.LogPrefixInfo+"URL:", apiListEndpoint)
+	resp, err := utils.InvokeGETRequest(apiListEndpoint, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+apiListEndpoint, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		apiListResponse := &utils.APIListResponse{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &apiListResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+		}
+
+		return apiListResponse.Count, apiListResponse.List, nil
+	} else {
+		return 0, nil, errors.New(string(resp.Body()))
+	}
+}
+
+func getQueryParamConnector() (connector string) {
+	if queryParamAdded {
+		return "&"
+	} else {
+		queryParamAdded = true
+		return "?"
+	}
+}

--- a/import-export-cli/impl/apps.go
+++ b/import-export-cli/impl/apps.go
@@ -1,0 +1,142 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/go-resty/resty"
+	v2 "github.com/wso2/product-apim-tooling/import-export-cli/specs/v2"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// GetAppId Get the ID of an Application if available
+// @param accessToken : Token to call the Developer Portal Rest API
+// @return appId, error
+func GetAppId(accessToken, environment, appName, appOwner string) (string, error) {
+	// Application REST API endpoint of the environment from the config file
+	applicationEndpoint := utils.GetAdminApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath) +
+		"?user=" + appOwner + "&name=" + appName
+
+	// Prepping headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	resp, err := utils.InvokeGETRequest(applicationEndpoint, headers)
+
+	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+		// 200 OK or 201 Created
+		appData := &utils.AppList{}
+		data := []byte(resp.Body())
+		err = json.Unmarshal(data, &appData)
+		appId := ""
+		if appData.Count != 0 {
+			for _, app := range appData.List {
+				if app.Name == appName {
+					appId = app.ApplicationID
+				}
+			}
+			return appId, err
+		}
+		return "", errors.New("Cannot find the application: " + appName + " for owner: " + appOwner)
+
+	} else {
+		utils.Logf("Error: %s\n", resp.Error())
+		utils.Logf("Body: %s\n", resp.Body())
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthorized
+			return "", fmt.Errorf("Authorization failed while searching CLI application: " + appName)
+		}
+		return "", errors.New("Request didn't respond 200 OK for searching existing applications. " +
+			"Status: " + resp.Status())
+	}
+}
+
+// GetApplicationDefinition scans filePath and returns ApplicationDefinition or an error
+func GetApplicationDefinition(filePath string) (*v2.ApplicationDefinition, []byte, error) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var buffer []byte
+	if info.IsDir() {
+		_, content, err := resolveYamlOrJSON(path.Join(filePath, filepath.Base(filePath)))
+		if err != nil {
+			return nil, nil, err
+		}
+		buffer = content
+	} else {
+		return nil, nil, fmt.Errorf("looking for directory, found %s", info.Name())
+	}
+	api, err := extractAppDefinition(buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+	return api, buffer, nil
+}
+
+//Get Application List
+// @param accessToken : Access Token for the environment
+// @param applicationListEndpoint : Endpoint to use for listing applications
+// @param appOwner : Owner of the applications
+// @param limit : Max number of results to return
+// @return count (no. of Applications)
+// @return array of Application objects
+// @return error
+func GetApplicationList(accessToken, applicationListEndpoint, appOwner, limit string) (count int32, apps []utils.Application,
+	err error) {
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	if limit != "" {
+		applicationListEndpoint += "?limit=" + limit
+	}
+
+	var resp *resty.Response
+	if appOwner == "" {
+		resp, err = utils.InvokeGETRequest(applicationListEndpoint, headers)
+	} else {
+		resp, err = utils.InvokeGETRequestWithQueryParam("user", appOwner, applicationListEndpoint, headers)
+	}
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+applicationListEndpoint, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		appListResponse := &utils.ApplicationListResponse{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &appListResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+		}
+
+		return appListResponse.Count, appListResponse.List, nil
+
+	} else {
+		return 0, nil, errors.New(resp.Status())
+	}
+}

--- a/import-export-cli/impl/changeAPIStatus.go
+++ b/import-export-cli/impl/changeAPIStatus.go
@@ -1,0 +1,112 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-resty/resty"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// ChangeAPIStatusInEnv function is used with change-status api command
+func ChangeAPIStatusInEnv(credential credentials.Credential, accessToken, environment, stateChangeAction, name, version, provider string) (*resty.Response, error) {
+	changeAPIStatusEndpoint := utils.GetApiListEndpointOfEnv(environment, utils.MainConfigFilePath)
+	return changeAPIStatus(changeAPIStatusEndpoint, stateChangeAction, name, version, provider, environment, accessToken, credential)
+}
+
+// changeAPIStatus
+// @param changeAPIStatusEndpoint : API Manager Publisher REST API Endpoint for the environment
+// @param stateChangeAction : Action to be performed to change the state of the API
+// @param name : Name of the API
+// @param version : Version of the API
+// @param provider : Provider of the API
+// @param environment : Environment where the API resides
+// @param accessToken : Access Token for the resource
+// @param credential : Credentials of the logged-in user
+// @return response Response in the form of *resty.Response
+func changeAPIStatus(changeAPIStatusEndpoint, stateChangeAction, name, version, provider, environment, accessToken string, credential credentials.Credential) (*resty.Response, error) {
+	changeAPIStatusEndpoint = utils.AppendSlashToString(changeAPIStatusEndpoint)
+	apiId, err := getAPIIdForStateChange(accessToken, name, version, provider, environment, credential)
+	if err != nil {
+		utils.HandleErrorAndExit("Error while getting API Id for state change ", err)
+	}
+	url := changeAPIStatusEndpoint + "change-lifecycle?action=" + stateChangeAction + "&apiId=" + apiId
+	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	resp, err := utils.InvokePOSTRequest(url, headers, "")
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Get the ID of an API if available
+// @param accessToken : Token to call the Publisher Rest API
+// @param name : Name of the API
+// @param version : Version of the API
+// @param provider : Provider of the API
+// @param environment : Environment where the API resides
+// @return apiId, error
+func getAPIIdForStateChange(accessToken, name, version, provider, environment string, credential credentials.Credential) (string, error) {
+	// Unified Search endpoint from the config file to search APIs
+	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
+
+	// Prepping headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	var queryVal string
+	queryVal = "name:\"" + name + "\" version:\"" + version + "\""
+	if provider != "" {
+		queryVal = queryVal + " provider:\"" + provider + "\""
+	}
+	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
+	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+		// 200 OK or 201 Created
+		apiData := &utils.ApiSearch{}
+		data := []byte(resp.Body())
+		err = json.Unmarshal(data, &apiData)
+		if apiData.Count != 0 {
+			apiId := apiData.List[0].ID
+			return apiId, err
+		}
+		if provider != "" {
+			return "", errors.New("Requested API is not available in the Publisher. API: " + name +
+				" Version: " + version + " Provider: " + provider)
+		}
+		return "", errors.New("Requested API is not available in the Publisher. API: " + name +
+			" Version: " + version)
+	} else {
+		utils.Logf("Error: %s\n", resp.Error())
+		utils.Logf("Body: %s\n", resp.Body())
+		if resp.StatusCode() == http.StatusUnauthorized {
+			// 401 Unauthorized
+			return "", fmt.Errorf("Authorization failed while searching API: " + name)
+		}
+		return "", errors.New("Request didn't respond 200 OK for searching APIs. Status: " + resp.Status())
+	}
+}

--- a/import-export-cli/impl/deleteAPI.go
+++ b/import-export-cli/impl/deleteAPI.go
@@ -14,18 +14,18 @@
 * KIND, either express or implied.  See the License for the
 * specific language governing permissions and limitations
 * under the License.
-*/
+ */
 
 package impl
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/go-resty/resty"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"net/http"
 	"strconv"
+
+	"github.com/go-resty/resty"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 // DeleteAPI
@@ -38,7 +38,7 @@ import (
 func DeleteAPI(accessToken, environment, deleteAPIName, deleteAPIVersion, deleteAPIProvider string) (*resty.Response, error) {
 	deleteEndpoint := utils.GetApiListEndpointOfEnv(environment, utils.MainConfigFilePath)
 	deleteEndpoint = utils.AppendSlashToString(deleteEndpoint)
-	apiId, err := getAPIId(accessToken, environment, deleteAPIName, deleteAPIVersion, deleteAPIProvider)
+	apiId, err := GetAPIId(accessToken, environment, deleteAPIName, deleteAPIVersion, deleteAPIProvider)
 	if err != nil {
 		utils.HandleErrorAndExit("Error while getting API Id for deletion ", err)
 	}
@@ -63,54 +63,5 @@ func PrintDeleteAPIResponse(resp *resty.Response, err error) {
 		fmt.Println("Error deleting API:", err)
 	} else {
 		fmt.Println("API deleted successfully!. Status: " + strconv.Itoa(resp.StatusCode()))
-	}
-}
-
-// Get the ID of an API if available
-// @param accessToken : Token to call the Publisher Rest API
-// @param environment : Environment where API needs to be located
-// @param apiName : Name of the API
-// @param apiVersion : Version of the API
-// @param apiProvider : Provider of API
-// @return apiId, error
-func getAPIId(accessToken, environment, apiName, apiVersion, apiProvider string) (string, error) {
-	// Unified Search endpoint from the config file to search APIs
-	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
-
-	// Prepping headers
-	headers := make(map[string]string)
-	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
-	var queryVal string
-	queryVal = "name:\"" + apiName + "\" version:\"" + apiVersion + "\""
-	if apiProvider != "" {
-		queryVal = queryVal + " provider:\"" + apiProvider + "\""
-	}
-	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
-		// 200 OK or 201 Created
-		apiData := &utils.ApiSearch{}
-		data := []byte(resp.Body())
-		err = json.Unmarshal(data, &apiData)
-		if apiData.Count != 0 {
-			apiId := apiData.List[0].ID
-			return apiId, err
-		}
-		if apiProvider != "" {
-			return "", errors.New("Requested API is not available in the Publisher. API: " + apiName +
-				" Version: " + apiVersion + " Provider: " + apiProvider)
-		}
-		return "", errors.New("Requested API is not available in the Publisher. API: " + apiName +
-			" Version: " + apiVersion)
-	} else {
-		utils.Logf("Error: %s\n", resp.Error())
-		utils.Logf("Body: %s\n", resp.Body())
-		if resp.StatusCode() == http.StatusUnauthorized {
-			// 401 Unauthorized
-			return "", fmt.Errorf("Authorization failed while searching API: " + apiName)
-		}
-		return "", errors.New("Request didn't respond 200 OK for searching APIs. Status: " + resp.Status())
 	}
 }

--- a/import-export-cli/impl/deleteAPIProduct.go
+++ b/import-export-cli/impl/deleteAPIProduct.go
@@ -19,7 +19,6 @@
 package impl
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -39,7 +38,7 @@ import (
 func DeleteAPIProduct(accessToken, environment, apiProductName, apiProductProvider string) (*resty.Response, error) {
 	deleteEndpoint := utils.GetApiProductListEndpointOfEnv(environment, utils.MainConfigFilePath)
 	deleteEndpoint = utils.AppendSlashToString(deleteEndpoint)
-	apiProductId, err := getAPIProductId(accessToken, environment, apiProductName, apiProductProvider)
+	apiProductId, err := GetAPIProductId(accessToken, environment, apiProductName, apiProductProvider)
 	if err != nil {
 		utils.HandleErrorAndExit("Error while getting API Product Id for deletion ", err)
 	}
@@ -64,55 +63,5 @@ func PrintDeleteAPIProductResponse(resp *resty.Response, err error) {
 		fmt.Println("Error deleting API Product:", err)
 	} else {
 		fmt.Println("API Product deleted successfully!. Status: " + strconv.Itoa(resp.StatusCode()))
-	}
-}
-
-
-// Get the ID of an API Product if available
-// @param accessToken : Access token to call the Publisher Rest API
-// @param environment : Environment where API Product needs to be located
-// @param apiProductName : Name of the API Product
-// @param apiProductProvider : Provider of the API Product
-// @return apiId, error
-func getAPIProductId(accessToken, environment, apiProductName, apiProductProvider string) (string, error) {
-	// Unified Search endpoint from the config file to search API Products
-	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
-
-	// Prepping headers
-	headers := make(map[string]string)
-	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
-	var queryVal string
-	// TODO Search by version as well when the versioning support has been implemented for API Products
-	queryVal = "type:\"" + utils.DefaultApiProductType + "\" name:\"" + apiProductName + "\""
-	if apiProductProvider != "" {
-		queryVal = queryVal + " provider:\"" + apiProductProvider + "\""
-	}
-	resp, err := utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
-		// 200 OK or 201 Created
-		apiData := &utils.ApiSearch{}
-		data := []byte(resp.Body())
-		err = json.Unmarshal(data, &apiData)
-		if apiData.Count != 0 {
-			apiProductId := apiData.List[0].ID
-			return apiProductId, err
-		}
-		// TODO Print the version as well when the versioning support has been implemented for API Products
-		if apiProductProvider != "" {
-			return "", errors.New("Requested API Product is not available in the Publisher. API Product: " + apiProductName +
-				" Provider: " + apiProductProvider)
-		}
-		return "", errors.New("Requested API Product is not available in the Publisher. API Product: " + apiProductName)
-	} else {
-		utils.Logf("Error: %s\n", resp.Error())
-		utils.Logf("Body: %s\n", resp.Body())
-		if resp.StatusCode() == http.StatusUnauthorized {
-			// 401 Unauthorized
-			return "", fmt.Errorf("Authorization failed while searching API Product: " + apiProductName)
-		}
-		return "", errors.New("Request didn't respond 200 OK for searching API Products. Status: " + resp.Status())
 	}
 }

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -30,17 +30,17 @@ import (
 // ExportAPIFromEnv function is used with export api command
 func ExportAPIFromEnv(accessToken, name, version, provider, format, exportEnvironment string, preserveStatus bool) (*resty.Response, error) {
 	adminEndpoint := utils.GetAdminEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
-	return ExportAPI(name, version, provider, format, adminEndpoint, accessToken, preserveStatus)
+	return exportAPI(name, version, provider, format, adminEndpoint, accessToken, preserveStatus)
 }
 
-// ExportAPI function is used with export api command
+// exportAPI function is used with export api command
 // @param name : Name of the API to be exported
 // @param version : Version of the API to be exported
 // @param provider : Provider of the API
 // @param adminEndpoint : API Manager Admin Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
-func ExportAPI(name, version, provider, format, adminEndpoint, accessToken string, preserveStatus bool) (*resty.Response, error) {
+func exportAPI(name, version, provider, format, adminEndpoint, accessToken string, preserveStatus bool) (*resty.Response, error) {
 	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
 	query := "export/api?name=" + name + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(preserveStatus)

--- a/import-export-cli/impl/exportAPIProduct.go
+++ b/import-export-cli/impl/exportAPIProduct.go
@@ -1,0 +1,91 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/go-resty/resty"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// ExportAPIProductFromEnv function is used with export api command
+func ExportAPIProductFromEnv(accessToken, name, version, provider, format, exportEnvironment string) (*resty.Response, error) {
+	adminEndpoint := utils.GetAdminEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
+	return exportAPIProduct(name, version, provider, format, adminEndpoint, accessToken)
+}
+
+// exportAPIProduct
+// @param name : Name of the API Product to be exported
+// @param version : Version of the API Product to be exported
+// @param provider : Provider of the API Product
+// @param adminEndpoint : API Manager Admin Endpoint for the environment
+// @param accessToken : Access Token for the resource
+// @return response Response in the form of *resty.Response
+func exportAPIProduct(name, version, provider, format, adminEndpoint, accessToken string) (*resty.Response, error) {
+	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
+	query := "export/api-product?name=" + name + "&version=" + version + "&providerName=" + provider
+	if format != "" {
+		query += "&format=" + format
+	}
+
+	url := adminEndpoint + query
+	utils.Logln(utils.LogPrefixInfo+"ExportAPIProduct: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
+
+	resp, err := utils.InvokeGETRequest(url, headers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// WriteAPIProductToZip
+// @param exportAPIProductName : Name of the API Product to be exported
+// @param resp : Response returned from making the HTTP request (only pass a 200 OK)
+// Exported API Product will be written to a zip file
+func WriteAPIProductToZip(exportAPIProductName, exportAPIProductVersion, zipLocationPath string, runningExportAPIProductCommand bool, resp *resty.Response) {
+	zipFilename := exportAPIProductName + "_" + exportAPIProductVersion + ".zip" // MyAPIProduct_1.0.0.zip
+	// Writes the REST API response to a temporary zip file
+	tempZipFile, err := utils.WriteResponseToTempZip(zipFilename, resp)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating the temporary zip file to store the exported API Product", err)
+	}
+
+	err = utils.CreateDirIfNotExist(zipLocationPath)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating dir to store zip archive: "+zipLocationPath, err)
+	}
+	exportedFinalZip := filepath.Join(zipLocationPath, zipFilename)
+	// Add api_product_params.yaml file inside the zip and create a new zip file in exportedFinalZip location
+	err = IncludeParamsFileToZip(tempZipFile, exportedFinalZip, utils.ParamFileAPIProduct)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating the final zip archive", err)
+	}
+
+	if runningExportAPIProductCommand {
+		fmt.Println("Successfully exported API Product!")
+		fmt.Println("Find the exported API Product at " + exportedFinalZip)
+	}
+}

--- a/import-export-cli/impl/getApiProducts.go
+++ b/import-export-cli/impl/getApiProducts.go
@@ -19,11 +19,8 @@
 package impl
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"text/template"
 
@@ -91,50 +88,6 @@ func (a *apiProduct) MarshalJSON() ([]byte, error) {
 func GetAPIProductListFromEnv(accessToken, environment, query, limit string) (count int32, apiProducts []utils.APIProduct, err error) {
 	unifiedSearchEndpoint := utils.GetUnifiedSearchEndpointOfEnv(environment, utils.MainConfigFilePath)
 	return GetAPIProductList(accessToken, unifiedSearchEndpoint, query, limit)
-}
-
-// GetAPIProductList
-// @param accessToken : Access Token for the environment
-// @param unifiedSearchEndpoint : Unified Search Endpoint for the environment to retreive API Product list
-// @param query : String to be matched against the API Product names
-// @return count (no. of API Products)
-// @return array of API Product objects
-// @return error
-func GetAPIProductList(accessToken, unifiedSearchEndpoint, query, limit string) (count int32, apiProducts []utils.APIProduct, err error) {
-	// Unified Search endpoint from the config file to search API Products
-	headers := make(map[string]string)
-	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
-
-	// To filter API Products from unified search
-	unifiedSearchEndpoint += "?query=type:\"" + utils.DefaultApiProductType + "\""
-
-	// Setting up the query parameter and limit parameter
-	if query != "" {
-		unifiedSearchEndpoint += " " + query
-	}
-	if limit != "" {
-		unifiedSearchEndpoint += "&limit=" + limit
-	}
-	utils.Logln(utils.LogPrefixInfo+"URL:", unifiedSearchEndpoint)
-	resp, err := utils.InvokeGETRequest(unifiedSearchEndpoint, headers)
-
-	if err != nil {
-		utils.HandleErrorAndExit("Unable to connect to "+unifiedSearchEndpoint, err)
-	}
-
-	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
-
-	if resp.StatusCode() == http.StatusOK {
-		apiProductListResponse := &utils.APIProductListResponse{}
-		unmarshalError := json.Unmarshal([]byte(resp.Body()), &apiProductListResponse)
-
-		if unmarshalError != nil {
-			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
-		}
-		return apiProductListResponse.Count, apiProductListResponse.List, nil
-	} else {
-		return 0, nil, errors.New(string(resp.Body()))
-	}
 }
 
 // PrintAPIProducts

--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -56,30 +55,6 @@ func extractAPIDefinition(jsonContent []byte) (*v2.APIDefinition, error) {
 	}
 
 	return api, nil
-}
-
-// GetAPIDefinition scans filePath and returns APIDefinition or an error
-func GetAPIDefinition(filePath string) (*v2.APIDefinition, []byte, error) {
-	info, err := os.Stat(filePath)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var buffer []byte
-	if info.IsDir() {
-		_, content, err := resolveYamlOrJSON(path.Join(filePath, "Meta-information", "api"))
-		if err != nil {
-			return nil, nil, err
-		}
-		buffer = content
-	} else {
-		return nil, nil, fmt.Errorf("looking for directory, found %s", info.Name())
-	}
-	api, err := extractAPIDefinition(buffer)
-	if err != nil {
-		return nil, nil, err
-	}
-	return api, buffer, nil
 }
 
 // mergeAPI merges environmentParams to the API given in apiDirectory
@@ -648,19 +623,6 @@ func injectParamsToAPI(importPath, paramsPath, importEnvironment string, preserv
 	return nil
 }
 
-// getAPIID returns id of the API by using apiInfo which contains name and version as info
-func getAPIID(accessOAuthToken, environment, name, version string) (string, error) {
-	apiQuery := fmt.Sprintf("name:\"%s\" version:\"%s\"", name, version)
-	count, apis, err := GetAPIListFromEnv(accessOAuthToken, environment, url.QueryEscape(apiQuery), "")
-	if err != nil {
-		return "", err
-	}
-	if count == 0 {
-		return "", nil
-	}
-	return apis[0].ID, nil
-}
-
 // isEmpty returns true when a given string is empty
 func isEmpty(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
@@ -959,7 +921,8 @@ func ImportAPI(accessOAuthToken, adminEndpoint, importEnvironment, importPath, a
 	updateAPI := false
 	if importAPIUpdate {
 		// check for API existence
-		id, err := getAPIID(accessOAuthToken, importEnvironment, apiInfo.ID.APIName, apiInfo.ID.Version)
+		id, err := GetAPIId(accessOAuthToken, importEnvironment, apiInfo.ID.APIName, apiInfo.ID.Version,
+			apiInfo.ID.ProviderName)
 		if err != nil {
 			return err
 		}

--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -798,6 +798,7 @@ func importAPI(endpoint, filePath, accessToken string, extraParams map[string]st
 		// We have an HTTP error
 		fmt.Println("Error importing API.")
 		fmt.Println("Status: " + resp.Status())
+		fmt.Println("Response:", resp)
 		return errors.New(resp.Status())
 	}
 }

--- a/import-export-cli/impl/importAPIProduct.go
+++ b/import-export-cli/impl/importAPIProduct.go
@@ -137,6 +137,7 @@ func importAPIProduct(endpoint, filePath, accessToken string, extraParams map[st
 		// We have an HTTP error
 		fmt.Println("Error importing API Product.")
 		fmt.Println("Status: " + resp.Status())
+		fmt.Println("Response:", resp)
 		return errors.New(resp.Status())
 	}
 }

--- a/import-export-cli/impl/importApp.go
+++ b/import-export-cli/impl/importApp.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/go-resty/resty"
 	"io"
 	"log"
 	"mime/multipart"
@@ -31,6 +30,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+
+	"github.com/go-resty/resty"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
@@ -112,6 +113,7 @@ func ImportApplication(accessToken, adminEndpoint, filename, appOwner string, up
 		// We have an HTTP error
 		fmt.Println("Error importing Application.")
 		fmt.Println("Status: " + resp.Status())
+		fmt.Println("Response:", resp)
 		return nil, errors.New(resp.Status())
 	}
 }
@@ -190,7 +192,7 @@ func NewAppFileUploadRequest(uri string, params map[string]string, paramName, pa
 	// set headers
 	headers := make(map[string]string)
 	headers[utils.HeaderContentType] = writer.FormDataContentType()
-	headers[utils.HeaderAuthorization] =  utils.HeaderValueAuthBearerPrefix+" "+accessToken
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = "*/*"
 	headers[utils.HeaderConnection] = utils.HeaderValueKeepAlive
 

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -1,9 +1,11 @@
-<h1 id="cli-for-importing-and-exporting-apis-and-applications">CLI for Importing and Exporting APIs and Applications</h1>
+<h1 id="cli-for-importing-and-exporting-apis-and-applications">CLI for Importing and Exporting APIs and Applications
+</h1>
 <h2 id="for-wso2-api-manager-3-2.0">For WSO2 API Manager 3.2.0</h2>
 <p>Command Line tool for importing and exporting APIs and Applications between different API Environments</p>
 <h2 id="getting-started">Getting Started</h2>
 <ul>
-    <li><h3 id="running">Running</h3>
+    <li>
+        <h3 id="running">Running</h3>
         <p> Select a generated archive suitable for your platform (Mac, Windows, Linux) and extract it to a desired
             location and <code>cd</code> into it.<br> Then execute <code>apictl</code> to start the application.</p>
         <blockquote>
@@ -14,21 +16,25 @@
         </blockquote>
         <p> Execute <code>apictl --help</code> for further instructions.</p>
     </li>
-    <li><h3 id="adding-environments">Adding Environments</h3>
+    <li>
+        <h3 id="adding-environments">Adding Environments</h3>
         <p> Add environments by either manually editing <code>$HOME/.wso2apictl/main_config.yaml</code> or using the
-            command<br> <code>apictl add-env</code>.</p>
+            command<br> <code>apictl add env</code>.</p>
         <blockquote>
             <p>NOTE: Directory structure for configuration files (<code>$HOME/.wso2apictl</code>) will be created upon
                 execution of <code>apictl</code></p>
         </blockquote>
-        <p> Execute <code>apictl add-env --help</code> for detailed instructions</p>
+        <p> Execute <code>apictl add env --help</code> for detailed instructions</p>
         <blockquote>
-            <p>The flags <code>--environment (-e)</code> and <code>--token</code> are mandatory.
-                You can either provide only the 2 flags <code>--apim</code> and <code>--token</code>, or all the other 5 flags (<code>--registration</code>, <code>--publisher</code>, <code>--devportal</code>, <code>--admin</code>, <code>--token</code>) without providing <code>--apim</code> flag.
-                If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint.</p>
+            <p>You can either provide only the 2 flags <code>--apim</code> and <code>--token</code>, or all the other 5
+                flags (<code>--registration</code>, <code>--publisher</code>, <code>--devportal</code>,
+                <code>--admin</code>, <code>--token</code>) without providing <code>--apim</code> flag.
+                If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify
+                --apim flag with the API Manager endpoint.</p>
         </blockquote>
     </li>
-    <li><h3 id="command-autocompletion-for-bash-only-">Command Autocompletion (For Bash Only)</h3>
+    <li>
+        <h3 id="command-autocompletion-for-bash-only-">Command Autocompletion (For Bash Only)</h3>
         <p> Copy the file <code>apictl_bash_completion.sh</code> to <code>/etc/bash_completion.d/</code> and source it
             with<br> <code>source /etc/bash_completion.d/apictl_bash_completion.sh</code> to enable bash
             auto-completion.</p>
@@ -48,7 +54,8 @@
 </code></pre>
 <h3 id="commands">Commands</h3>
 <ul>
-    <li><h4 id="login">login [environment]</h4>
+    <li>
+        <h4 id="login">login [environment]</h4>
         <pre><code class="lang-bash">   Flags:
        Optional:
            --username, -u
@@ -63,34 +70,34 @@
     </li>
 </ul>
 <ul>
-    <li><h4 id="logout">logout [environment]</h4>
+    <li>
+        <h4 id="logout">logout [environment]</h4>
         <pre><code class="lang-bash">   Examples:
        apictl logout dev
 </code></pre>
     </li>
 </ul>
 <ul>
-    <li><h4 id="export-api">export-api</h4>
+    <li>
+        <h4 id="export-api">export api</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
            --name, -n
            --version, -v
-           --provider, -r
            --environment, -e
        Optional:
-           --username, -u
-           --password, -p
-           NOTE: user will be prompted to enter credentials if they are not provided with these flags
+           --preserveStatus
+           --format
+           --provider, -r
    Examples:
-       apictl export-api -n TestAPI -v 1.0.1 -r admin -e staging
-       apictl export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin -p 123456
-       apictl export-api -n TestAPI -v 1.0.1 -r admin -e staging -u admin
-       apictl export-api -n TestAPI -v 1.0.1 -r admin -e staging -p 123456
+       apictl export api -n TestAPI -v 1.0.1 -e staging
+       apictl export api -n TestAPI -v 1.0.1 -r admin -e staging
 </code></pre>
     </li>
 </ul>
 <ul>
-    <li><h4 id="import-api">import-api</h4>
+    <li>
+        <h4 id="import-api">import api</h4>
     </li>
 </ul>
 <pre><code class="lang-bash">        Flags:
@@ -98,35 +105,72 @@
                 --file, -f
                 --environment, -e
             Optional:
-                --username, -u 
-                --password, -p 
-                NOTE: user will be prompted to enter credentials if they are not provided with these flags
+                --params
+                --preserve-provider
+                --update
+                --skipCleanup
         Examples:
-            apictl import-api -f dev/TestAPI_1.0.0.zip -e dev
-            apictl import-api -f qa/TestAPI_2.0.0.zip -e dev -u admin -p 123456
-            apictl import-api -f staging/TestAPI_1.1.zip -e dev -u admin
-            apictl import-api -f production/TestAPI_3.0.1.zip -e dev -p 123456
-            apictl import-api -f TestAPI -e dev
+                apictl import api -f qa/TwitterAPI.zip -e dev
+                apictl import api -f staging/FacebookAPI.zip -e production
+                apictl import api -f ~/myapi -e production --update
+                apictl import api -f ~/myapi -e production --update
 </code></pre>
 <ul>
-    <li><h4 id="export-app">export-app</h4>
+    <li>
+        <h4 id="export-api-product">export api-product</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --name, -n
+           --environment, -e
+       Optional:
+            --provider, -r
+            --format
+   Examples:
+       apictl export api-product -n LeasingAPIProduct -e dev
+       apictl export api-product -n CreditAPIProduct -v 1.0.0 -r admin -e production
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="import-api-product">import api-product</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --file, -f
+           --environment, -e
+       Optional:
+           --import-apis
+           --preserve-provider
+           --skipCleanup
+           --update-api-product
+           --update-apis          
+   Examples:
+       apictl import api-product -f qa/LeasingAPIProduct.zip -e dev
+       apictl import api-product -f staging/CreditAPIProduct.zip -e production --update-api-product
+       apictl import api-product -f ~/myapiproduct -e production
+       apictl import api-product -f ~/myapiproduct -e production --update-api-product --update-apis
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="export-app">export app</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
             --name, -n
             --owner, -o
             --environment, -e
        Optional:
-            --username, -u
-            --password, -p
-            NOTE: user will be prompted to enter credentials if they are not provided with these flags
+            --withKeys
    Examples:
-            apictl export-app -n SampleApp -o admin -e dev
-            apictl export-app -n SampleApp -o admin -e prod
+            apictl export app -n SampleApp -o admin -e dev
+            apictl export app -n SampleApp -o admin -e prod
 </code></pre>
     </li>
 </ul>
 <ul>
-    <li><h4 id="import-app">import-app</h4>
+    <li>
+        <h4 id="import-app">import app</h4>
     </li>
 </ul>
 <pre><code class="lang-bash">        Flags:
@@ -139,53 +183,80 @@
                   --preserveOwner, -r
                   --file, -f
                   --environment, -e
+                  --skipCleanup
+                  --skipKeys
+                  --update
         Examples:
-            apictl import-app -f qa/apps/sampleApp.zip -e dev
-            apictl Import App -f staging/apps/sampleApp.zip -e prod -o testUser -u admin -p admin
-            apictl import-app -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e staging
+            apictl import app -f qa/apps/sampleApp.zip -e dev
+            apictl import app -f staging/apps/sampleApp.zip -e prod -o testUser -u admin -p admin
+            apictl import app -f qa/apps/sampleApp.zip --preserveOwner --skipSubscriptions -e staging
 </code></pre>
 <ul>
-    <li><h4 id="list-apis">list apis</h4>
+    <li>
+        <h4 id="get-apis">get apis</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
           Optional:
-              --username, -u 
-              --password, -p 
-              NOTE: user will be prompted to enter credentials if they are not provided with these flags
+              --format
+              --limit, -l
               --query, -q
       Examples:
-          apictl list apis -e dev
-          apictl list apis -e prod -q version:1.0.0
-          apictl list apis -e prod -q provider:admin
-          apictl list apis -e staging
+          apictl get apis -e dev
+          apictl get apis -e dev -q version:1.0.0
+          apictl get apis -e prod -q provider:admin
+          apictl get apis -e prod -l 100
+          apictl get apis -e staging
 </code></pre>
     </li>
-    <li><h4 id="list-apps">list apps</h4>
+    <li>
+        <h4 id="get-api-products">get api-products</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+              --limit, -l
+              --query, -q
+      Examples:
+          apictl get api-products -e dev
+          apictl get api-products -e dev -q provider:devops
+          apictl get api-products -e prod -q provider:admin context:/myproduct
+          apictl get api-products -e prod -l 25
+          apictl get api-products -e staging
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-apps">get apps</h4>
         <pre><code class="lang-bash">      Flags:
           Required
                   --environment, -e
                   --owner, -o
             Optional
-                  --username, -u
-                  --password, -p
+                  --format
+                  --limit, -l
+                  --owner, -o
         Examples:
-            apictl list apps -e dev -o admin
-            apictl list apps -e staging -o sampleUser
+            apictl get apps -e dev 
+            apictl get apps -e dev -o sampleUser
+            apictl get apps -e prod -o sampleUser
+            apictl get apps -e staging -o sampleUser
+            apictl get apps -e dev -l 40        
 </code></pre>
     </li>
-    <li><h4 id="list-envs">list envs</h4>
+    <li>
+        <h4 id="get-envs">get envs</h4>
         <pre><code class="lang-bash">     Flags:
          None
      Example:
-         apictl list envs
+         apictl get envs
 </code></pre>
     </li>
-    <li><h4 id="add-env">add-env</h4>
+    <li>
+        <h4 id="add-env">add env [environment]</h4>
         <pre><code class="lang-bash">      Flags:
         Required:
-            --environment, -e (Name of the environment)
-            AND
+            (either)
             --apim (API Manager endpoint)
             OR (the following 4)
             --registration https://localhost:9443 \
@@ -196,33 +267,33 @@
             --token (Token Endpoint)
 
         Examples:
-        apictl add-env -e dev \
+        apictl add env dev \
             --apim https://localhost:9443
 
-        apictl add-env -e staging \
+        apictl add env staging \
             --registration https://idp.com:9443 \
             --publisher https://apim.com:9443 \
             --devportal https://apps.com:9443 \
             --admin https://apim.com:9443 \
             --token https://gw.com:8243/token
             
-        apictl add-env -e prod \
+        apictl add env prod \
             --apim https://apim.com:9443 \
             --registration https://idp.com:9443 \
             --token https://gw.com:8243/token
 </code></pre>
     </li>
-    <li><h4 id="remove-env">remove env</h4>
+    <li>
+        <h4 id="remove-env">remove env [environment]</h4>
     </li>
 </ul>
-<pre><code class="lang-bash">        Flags:
-            Required:
-                --environment, -e (Name of the environment)
+<pre><code class="lang-bash">      
             Examples:
-                apictl remove-env -e dev
+                apictl remove env dev
 </code></pre>
 <ul>
-    <li><h4 id="reset-user">reset-user</h4>
+    <li>
+        <h4 id="reset-user">reset-user</h4>
     </li>
 </ul>
 <pre><code class="lang-bash">        Flags
@@ -231,38 +302,46 @@
             apictl reset-user -e dev
 </code></pre>
 <ul>
-    <li><h4 id="version">version</h4>
+    <li>
+        <h4 id="version">version</h4>
         <pre><code class="lang-bash">      apictl version
 </code></pre>
     </li>
-    <li><h4 id="set">set</h4>
+    <li>
+        <h4 id="set">set</h4>
         <pre><code class="lang-bash">      Flags
           --http-request-timeout
           --export-directory
+          --vcs-config-path string
+          --vcs-deletion-enabled
       Examples:
-          apictl set --http-request-timeout 10000
-          apictl set --export-directory /home/user/exported
+          apictl set --http-request-timeout 3600 --export-directory /home/user/exported-apis
+          apictl set --http-request-timeout 5000 --export-directory C:\Documents\exported
+          apictl set --http-request-timeout 5000
+          apictl set --vcs-deletion-enabled=true
+          apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 </code></pre>
     </li>
 </ul>
 <ul>
-    <li><h4 id="get-keys">get-keys</h4>
+    <li>
+        <h4 id="get-keys">get keys</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
             --name, -n
-            --version, -v
             --environment, -e
        Optional:
-            --username, -u
-            --password, -p
-            NOTE: user will be prompted to enter credentials if they are not provided with these flags
+            --version, -v
+            --provider, -r
+            --token, -t
    Examples:
-            apictl get-keys -n PizzaShackAPI --version 1.0.0 -e dev --provider admin
+            apictl get keys -n PizzaShackAPI --version 1.0.0 -e dev --provider admin
 </code></pre>
     </li>
 </ul>
 <ul>
-    <li><h4 id="delete-api">delete api</h4>
+    <li>
+        <h4 id="delete-api">delete api</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
            --name, -n
@@ -278,7 +357,8 @@
     </li>
 </ul>
 <ul>
-    <li><h4 id="delete-api-product">delete api-product</h4>
+    <li>
+        <h4 id="delete-api-product">delete api-product</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
            --name, -n
@@ -294,7 +374,8 @@
     </li>
 </ul>
 <ul>
-    <li><h4 id="delete-app">delete app</h4>
+    <li>
+        <h4 id="delete-app">delete app</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
            --name, -n
@@ -309,7 +390,8 @@
     </li>
 </ul>
 <ul>
-    <li><h4 id="change-status-api">change-status api</h4>
+    <li>
+        <h4 id="change-status-api">change-status api</h4>
         <pre><code class="lang-bash">   Flags:
        Required:
            --action, -a

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -36,9 +36,103 @@ __apictl_contains_word()
     return 1
 }
 
+__apictl_handle_go_custom_completion()
+{
+    __apictl_debug "${FUNCNAME[0]}: cur is ${cur}, words[*] is ${words[*]}, #words[@] is ${#words[@]}"
+
+    local shellCompDirectiveError=1
+    local shellCompDirectiveNoSpace=2
+    local shellCompDirectiveNoFileComp=4
+    local shellCompDirectiveFilterFileExt=8
+    local shellCompDirectiveFilterDirs=16
+
+    local out requestComp lastParam lastChar comp directive args
+
+    # Prepare the command to request completions for the program.
+    # Calling ${words[0]} instead of directly apictl allows to handle aliases
+    args=("${words[@]:1}")
+    requestComp="${words[0]} __completeNoDesc ${args[*]}"
+
+    lastParam=${words[$((${#words[@]}-1))]}
+    lastChar=${lastParam:$((${#lastParam}-1)):1}
+    __apictl_debug "${FUNCNAME[0]}: lastParam ${lastParam}, lastChar ${lastChar}"
+
+    if [ -z "${cur}" ] && [ "${lastChar}" != "=" ]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go method.
+        __apictl_debug "${FUNCNAME[0]}: Adding extra empty parameter"
+        requestComp="${requestComp} \"\""
+    fi
+
+    __apictl_debug "${FUNCNAME[0]}: calling ${requestComp}"
+    # Use eval to handle any environment variables and such
+    out=$(eval "${requestComp}" 2>/dev/null)
+
+    # Extract the directive integer at the very end of the output following a colon (:)
+    directive=${out##*:}
+    # Remove the directive
+    out=${out%:*}
+    if [ "${directive}" = "${out}" ]; then
+        # There is not directive specified
+        directive=0
+    fi
+    __apictl_debug "${FUNCNAME[0]}: the completion directive is: ${directive}"
+    __apictl_debug "${FUNCNAME[0]}: the completions are: ${out[*]}"
+
+    if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
+        # Error code.  No completion.
+        __apictl_debug "${FUNCNAME[0]}: received error from custom completion go code"
+        return
+    else
+        if [ $((directive & shellCompDirectiveNoSpace)) -ne 0 ]; then
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                __apictl_debug "${FUNCNAME[0]}: activating no space"
+                compopt -o nospace
+            fi
+        fi
+        if [ $((directive & shellCompDirectiveNoFileComp)) -ne 0 ]; then
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                __apictl_debug "${FUNCNAME[0]}: activating no file completion"
+                compopt +o default
+            fi
+        fi
+    fi
+
+    if [ $((directive & shellCompDirectiveFilterFileExt)) -ne 0 ]; then
+        # File extension filtering
+        local fullFilter filter filteringCmd
+        # Do not use quotes around the $out variable or else newline
+        # characters will be kept.
+        for filter in ${out[*]}; do
+            fullFilter+="$filter|"
+        done
+
+        filteringCmd="_filedir $fullFilter"
+        __apictl_debug "File filtering command: $filteringCmd"
+        $filteringCmd
+    elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
+        # File completion for directories only
+        local subDir
+        # Use printf to strip any trailing newline
+        subdir=$(printf "%s" "${out[0]}")
+        if [ -n "$subdir" ]; then
+            __apictl_debug "Listing directories in $subdir"
+            __apictl_handle_subdirs_in_dir_flag "$subdir"
+        else
+            __apictl_debug "Listing directories in ."
+            _filedir -d
+        fi
+    else
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
+        done < <(compgen -W "${out[*]}" -- "$cur")
+    fi
+}
+
 __apictl_handle_reply()
 {
     __apictl_debug "${FUNCNAME[0]}"
+    local comp
     case $cur in
         -*)
             if [[ $(type -t compopt) = "builtin" ]]; then
@@ -50,7 +144,9 @@ __apictl_handle_reply()
             else
                 allflags=("${flags[*]} ${two_word_flags[*]}")
             fi
-            COMPREPLY=( $(compgen -W "${allflags[*]}" -- "$cur") )
+            while IFS='' read -r comp; do
+                COMPREPLY+=("$comp")
+            done < <(compgen -W "${allflags[*]}" -- "$cur")
             if [[ $(type -t compopt) = "builtin" ]]; then
                 [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
             fi
@@ -95,15 +191,22 @@ __apictl_handle_reply()
     local completions
     completions=("${commands[@]}")
     if [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
-        completions=("${must_have_one_noun[@]}")
+        completions+=("${must_have_one_noun[@]}")
+    elif [[ -n "${has_completion_function}" ]]; then
+        # if a go completion function is provided, defer to that function
+        __apictl_handle_go_custom_completion
     fi
     if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
         completions+=("${must_have_one_flag[@]}")
     fi
-    COMPREPLY=( $(compgen -W "${completions[*]}" -- "$cur") )
+    while IFS='' read -r comp; do
+        COMPREPLY+=("$comp")
+    done < <(compgen -W "${completions[*]}" -- "$cur")
 
     if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
-        COMPREPLY=( $(compgen -W "${noun_aliases[*]}" -- "$cur") )
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
+        done < <(compgen -W "${noun_aliases[*]}" -- "$cur")
     fi
 
     if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
@@ -138,7 +241,7 @@ __apictl_handle_filename_extension_flag()
 __apictl_handle_subdirs_in_dir_flag()
 {
     local dir="$1"
-    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1 || return
 }
 
 __apictl_handle_flag()
@@ -250,105 +353,9 @@ __apictl_handle_word()
     __apictl_handle_word
 }
 
-_apictl_add_api()
+_apictl_add_env()
 {
-    last_command="apictl_add_api"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--apiEndPoint=")
-    two_word_flags+=("--apiEndPoint")
-    two_word_flags+=("-a")
-    local_nonpersistent_flags+=("--apiEndPoint=")
-    flags+=("--env=")
-    two_word_flags+=("--env")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--env=")
-    flags+=("--from-file=")
-    two_word_flags+=("--from-file")
-    two_word_flags+=("-f")
-    local_nonpersistent_flags+=("--from-file=")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--hostname=")
-    two_word_flags+=("--hostname")
-    local_nonpersistent_flags+=("--hostname=")
-    flags+=("--image=")
-    two_word_flags+=("--image")
-    two_word_flags+=("-i")
-    local_nonpersistent_flags+=("--image=")
-    flags+=("--mode=")
-    two_word_flags+=("--mode")
-    two_word_flags+=("-m")
-    local_nonpersistent_flags+=("--mode=")
-    flags+=("--name=")
-    two_word_flags+=("--name")
-    two_word_flags+=("-n")
-    local_nonpersistent_flags+=("--name=")
-    flags+=("--namespace=")
-    two_word_flags+=("--namespace")
-    local_nonpersistent_flags+=("--namespace=")
-    flags+=("--override")
-    local_nonpersistent_flags+=("--override")
-    flags+=("--replicas=")
-    two_word_flags+=("--replicas")
-    local_nonpersistent_flags+=("--replicas=")
-    flags+=("--version=")
-    two_word_flags+=("--version")
-    two_word_flags+=("-v")
-    local_nonpersistent_flags+=("--version=")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_flag+=("--from-file=")
-    must_have_one_flag+=("-f")
-    must_have_one_flag+=("--name=")
-    must_have_one_flag+=("-n")
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_add()
-{
-    last_command="apictl_add"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("api")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_add-env()
-{
-    last_command="apictl_add-env"
+    last_command="apictl_add_env"
 
     command_aliases=()
 
@@ -362,43 +369,44 @@ _apictl_add-env()
 
     flags+=("--admin=")
     two_word_flags+=("--admin")
+    local_nonpersistent_flags+=("--admin")
     local_nonpersistent_flags+=("--admin=")
     flags+=("--apim=")
     two_word_flags+=("--apim")
+    local_nonpersistent_flags+=("--apim")
     local_nonpersistent_flags+=("--apim=")
     flags+=("--devportal=")
     two_word_flags+=("--devportal")
+    local_nonpersistent_flags+=("--devportal")
     local_nonpersistent_flags+=("--devportal=")
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--publisher=")
     two_word_flags+=("--publisher")
+    local_nonpersistent_flags+=("--publisher")
     local_nonpersistent_flags+=("--publisher=")
     flags+=("--registration=")
     two_word_flags+=("--registration")
+    local_nonpersistent_flags+=("--registration")
     local_nonpersistent_flags+=("--registration=")
     flags+=("--token=")
     two_word_flags+=("--token")
+    local_nonpersistent_flags+=("--token")
     local_nonpersistent_flags+=("--token=")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
     must_have_one_noun=()
     noun_aliases=()
 }
 
-_apictl_change_registry()
+_apictl_add_help()
 {
-    last_command="apictl_change_registry"
+    last_command="apictl_add_help"
 
     command_aliases=()
 
@@ -410,48 +418,25 @@ _apictl_change_registry()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--key-file=")
-    two_word_flags+=("--key-file")
-    two_word_flags+=("-c")
-    local_nonpersistent_flags+=("--key-file=")
-    flags+=("--password=")
-    two_word_flags+=("--password")
-    two_word_flags+=("-p")
-    local_nonpersistent_flags+=("--password=")
-    flags+=("--password-stdin")
-    local_nonpersistent_flags+=("--password-stdin")
-    flags+=("--registry-type=")
-    two_word_flags+=("--registry-type")
-    two_word_flags+=("-R")
-    local_nonpersistent_flags+=("--registry-type=")
-    flags+=("--repository=")
-    two_word_flags+=("--repository")
-    two_word_flags+=("-r")
-    local_nonpersistent_flags+=("--repository=")
-    flags+=("--username=")
-    two_word_flags+=("--username")
-    two_word_flags+=("-u")
-    local_nonpersistent_flags+=("--username=")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
     must_have_one_noun=()
+    has_completion_function=1
     noun_aliases=()
 }
 
-_apictl_change()
+_apictl_add()
 {
-    last_command="apictl_change"
+    last_command="apictl_add"
 
     command_aliases=()
 
     commands=()
-    commands+=("registry")
+    commands+=("env")
+    commands+=("help")
 
     flags=()
     two_word_flags=()
@@ -462,6 +447,7 @@ _apictl_change()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -488,26 +474,37 @@ _apictl_change-status_api()
     flags+=("--action=")
     two_word_flags+=("--action")
     two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--action")
     local_nonpersistent_flags+=("--action=")
+    local_nonpersistent_flags+=("-a")
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--provider=")
     two_word_flags+=("--provider")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
     local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--version=")
     two_word_flags+=("--version")
     two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
     local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -525,6 +522,30 @@ _apictl_change-status_api()
     noun_aliases=()
 }
 
+_apictl_change-status_help()
+{
+    last_command="apictl_change-status_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
 _apictl_change-status()
 {
     last_command="apictl_change-status"
@@ -533,6 +554,7 @@ _apictl_change-status()
 
     commands=()
     commands+=("api")
+    commands+=("help")
 
     flags=()
     two_word_flags=()
@@ -543,6 +565,7 @@ _apictl_change-status()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -569,22 +592,31 @@ _apictl_delete_api()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--provider=")
     two_word_flags+=("--provider")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
     local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--version=")
     two_word_flags+=("--version")
     two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
     local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -617,18 +649,25 @@ _apictl_delete_api-product()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--provider=")
     two_word_flags+=("--provider")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
     local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -659,18 +698,25 @@ _apictl_delete_app()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--owner=")
     two_word_flags+=("--owner")
     two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--owner")
     local_nonpersistent_flags+=("--owner=")
+    local_nonpersistent_flags+=("-o")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -684,6 +730,30 @@ _apictl_delete_app()
     noun_aliases=()
 }
 
+_apictl_delete_help()
+{
+    last_command="apictl_delete_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
 _apictl_delete()
 {
     last_command="apictl_delete"
@@ -694,6 +764,7 @@ _apictl_delete()
     commands+=("api")
     commands+=("api-product")
     commands+=("app")
+    commands+=("help")
 
     flags=()
     two_word_flags=()
@@ -704,11 +775,75 @@ _apictl_delete()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_export_api()
+{
+    last_command="apictl_export_api"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--preserveStatus")
+    local_nonpersistent_flags+=("--preserveStatus")
+    flags+=("--provider=")
+    two_word_flags+=("--provider")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
+    local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
+    flags+=("--version=")
+    two_word_flags+=("--version")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+    local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--version=")
+    must_have_one_flag+=("-v")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -730,21 +865,29 @@ _apictl_export_api-product()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--format=")
     two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
     local_nonpersistent_flags+=("--format=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--provider=")
     two_word_flags+=("--provider")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
     local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -758,36 +901,9 @@ _apictl_export_api-product()
     noun_aliases=()
 }
 
-_apictl_export()
+_apictl_export_apis()
 {
-    last_command="apictl_export"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("api-product")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_export-api()
-{
-    last_command="apictl_export-api"
+    last_command="apictl_export_apis"
 
     command_aliases=()
 
@@ -802,67 +918,18 @@ _apictl_export-api()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
-    flags+=("--format=")
-    two_word_flags+=("--format")
-    local_nonpersistent_flags+=("--format=")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--name=")
-    two_word_flags+=("--name")
-    two_word_flags+=("-n")
-    local_nonpersistent_flags+=("--name=")
-    flags+=("--preserveStatus")
-    local_nonpersistent_flags+=("--preserveStatus")
-    flags+=("--provider=")
-    two_word_flags+=("--provider")
-    two_word_flags+=("-r")
-    local_nonpersistent_flags+=("--provider=")
-    flags+=("--version=")
-    two_word_flags+=("--version")
-    two_word_flags+=("-v")
-    local_nonpersistent_flags+=("--version=")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
-    must_have_one_flag+=("--name=")
-    must_have_one_flag+=("-n")
-    must_have_one_flag+=("--version=")
-    must_have_one_flag+=("-v")
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_export-apis()
-{
-    last_command="apictl_export-apis"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--force")
     flags+=("--format=")
     two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
     local_nonpersistent_flags+=("--format=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--preserveStatus")
     local_nonpersistent_flags+=("--preserveStatus")
     flags+=("--insecure")
@@ -876,9 +943,9 @@ _apictl_export-apis()
     noun_aliases=()
 }
 
-_apictl_export-app()
+_apictl_export_app()
 {
-    last_command="apictl_export-app"
+    last_command="apictl_export_app"
 
     command_aliases=()
 
@@ -893,18 +960,25 @@ _apictl_export-app()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--owner=")
     two_word_flags+=("--owner")
     two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--owner")
     local_nonpersistent_flags+=("--owner=")
+    local_nonpersistent_flags+=("-o")
     flags+=("--withKeys")
     local_nonpersistent_flags+=("--withKeys")
     flags+=("--insecure")
@@ -922,9 +996,65 @@ _apictl_export-app()
     noun_aliases=()
 }
 
-_apictl_get-keys()
+_apictl_export_help()
 {
-    last_command="apictl_get-keys"
+    last_command="apictl_export_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_export()
+{
+    last_command="apictl_export"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("api-product")
+    commands+=("apis")
+    commands+=("app")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get_api-products()
+{
+    last_command="apictl_get_api-products"
 
     command_aliases=()
 
@@ -939,26 +1069,245 @@ _apictl_get-keys()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--limit=")
+    two_word_flags+=("--limit")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--limit")
+    local_nonpersistent_flags+=("--limit=")
+    local_nonpersistent_flags+=("-l")
+    flags+=("--query=")
+    two_word_flags+=("--query")
+    two_word_flags+=("-q")
+    local_nonpersistent_flags+=("--query")
+    local_nonpersistent_flags+=("--query=")
+    local_nonpersistent_flags+=("-q")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get_apis()
+{
+    last_command="apictl_get_apis"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--limit=")
+    two_word_flags+=("--limit")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--limit")
+    local_nonpersistent_flags+=("--limit=")
+    local_nonpersistent_flags+=("-l")
+    flags+=("--query=")
+    two_word_flags+=("--query")
+    two_word_flags+=("-q")
+    local_nonpersistent_flags+=("--query")
+    local_nonpersistent_flags+=("--query=")
+    local_nonpersistent_flags+=("-q")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get_apps()
+{
+    last_command="apictl_get_apps"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--limit=")
+    two_word_flags+=("--limit")
+    two_word_flags+=("-l")
+    local_nonpersistent_flags+=("--limit")
+    local_nonpersistent_flags+=("--limit=")
+    local_nonpersistent_flags+=("-l")
+    flags+=("--owner=")
+    two_word_flags+=("--owner")
+    two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--owner")
+    local_nonpersistent_flags+=("--owner=")
+    local_nonpersistent_flags+=("-o")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get_envs()
+{
+    last_command="apictl_get_envs"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get_help()
+{
+    last_command="apictl_get_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_get_keys()
+{
+    last_command="apictl_get_keys"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--name=")
     two_word_flags+=("--name")
     two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
     local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
     flags+=("--provider=")
     two_word_flags+=("--provider")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
     local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--token=")
     two_word_flags+=("--token")
     two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--token")
     local_nonpersistent_flags+=("--token=")
+    local_nonpersistent_flags+=("-t")
     flags+=("--version=")
     two_word_flags+=("--version")
     two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
     local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -968,6 +1317,116 @@ _apictl_get-keys()
     must_have_one_flag+=("-e")
     must_have_one_flag+=("--name=")
     must_have_one_flag+=("-n")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_get()
+{
+    last_command="apictl_get"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api-products")
+    commands+=("apis")
+    commands+=("apps")
+    commands+=("envs")
+    commands+=("help")
+    commands+=("keys")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_help()
+{
+    last_command="apictl_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_import_api()
+{
+    last_command="apictl_import_api"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--file=")
+    two_word_flags+=("--file")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--file")
+    local_nonpersistent_flags+=("--file=")
+    local_nonpersistent_flags+=("-f")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--params=")
+    two_word_flags+=("--params")
+    local_nonpersistent_flags+=("--params")
+    local_nonpersistent_flags+=("--params=")
+    flags+=("--preserve-provider")
+    local_nonpersistent_flags+=("--preserve-provider")
+    flags+=("--skipCleanup")
+    local_nonpersistent_flags+=("--skipCleanup")
+    flags+=("--update")
+    local_nonpersistent_flags+=("--update")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--file=")
+    must_have_one_flag+=("-f")
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -989,14 +1448,19 @@ _apictl_import_api-product()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--file=")
     two_word_flags+=("--file")
     two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--file")
     local_nonpersistent_flags+=("--file=")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--import-apis")
     local_nonpersistent_flags+=("--import-apis")
     flags+=("--preserve-provider")
@@ -1020,36 +1484,9 @@ _apictl_import_api-product()
     noun_aliases=()
 }
 
-_apictl_import()
+_apictl_import_app()
 {
-    last_command="apictl_import"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("api-product")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_import-api()
-{
-    last_command="apictl_import-api"
+    last_command="apictl_import_app"
 
     command_aliases=()
 
@@ -1064,65 +1501,25 @@ _apictl_import-api()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--file=")
     two_word_flags+=("--file")
     two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--file")
     local_nonpersistent_flags+=("--file=")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
-    flags+=("--params=")
-    two_word_flags+=("--params")
-    local_nonpersistent_flags+=("--params=")
-    flags+=("--preserve-provider")
-    local_nonpersistent_flags+=("--preserve-provider")
-    flags+=("--skipCleanup")
-    local_nonpersistent_flags+=("--skipCleanup")
-    flags+=("--update")
-    local_nonpersistent_flags+=("--update")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
-    must_have_one_flag+=("--file=")
-    must_have_one_flag+=("-f")
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_import-app()
-{
-    last_command="apictl_import-app"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
-    flags+=("--file=")
-    two_word_flags+=("--file")
-    two_word_flags+=("-f")
-    local_nonpersistent_flags+=("--file=")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--owner=")
     two_word_flags+=("--owner")
     two_word_flags+=("-o")
+    local_nonpersistent_flags+=("--owner")
     local_nonpersistent_flags+=("--owner=")
+    local_nonpersistent_flags+=("-o")
     flags+=("--preserveOwner")
     local_nonpersistent_flags+=("--preserveOwner")
     flags+=("--skipCleanup")
@@ -1132,6 +1529,7 @@ _apictl_import-app()
     flags+=("--skipSubscriptions")
     flags+=("-s")
     local_nonpersistent_flags+=("--skipSubscriptions")
+    local_nonpersistent_flags+=("-s")
     flags+=("--update")
     local_nonpersistent_flags+=("--update")
     flags+=("--insecure")
@@ -1143,6 +1541,61 @@ _apictl_import-app()
     must_have_one_flag+=("-e")
     must_have_one_flag+=("--file=")
     must_have_one_flag+=("-f")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_import_help()
+{
+    last_command="apictl_import_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_import()
+{
+    last_command="apictl_import"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("api-product")
+    commands+=("app")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
     must_have_one_noun=()
     noun_aliases=()
 }
@@ -1164,18 +1617,24 @@ _apictl_init()
     flags+=("--definition=")
     two_word_flags+=("--definition")
     two_word_flags+=("-d")
+    local_nonpersistent_flags+=("--definition")
     local_nonpersistent_flags+=("--definition=")
+    local_nonpersistent_flags+=("-d")
     flags+=("--force")
     flags+=("-f")
     local_nonpersistent_flags+=("--force")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--initial-state=")
     two_word_flags+=("--initial-state")
+    local_nonpersistent_flags+=("--initial-state")
     local_nonpersistent_flags+=("--initial-state=")
     flags+=("--oas=")
     two_word_flags+=("--oas")
+    local_nonpersistent_flags+=("--oas")
     local_nonpersistent_flags+=("--oas=")
     flags+=("--insecure")
     flags+=("-k")
@@ -1186,9 +1645,9 @@ _apictl_init()
     noun_aliases=()
 }
 
-_apictl_install_api-operator()
+_apictl_k8s_add_api()
 {
-    last_command="apictl_install_api-operator"
+    last_command="apictl_k8s_add_api"
 
     command_aliases=()
 
@@ -1200,35 +1659,206 @@ _apictl_install_api-operator()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--apiEndPoint=")
+    two_word_flags+=("--apiEndPoint")
+    two_word_flags+=("-a")
+    local_nonpersistent_flags+=("--apiEndPoint")
+    local_nonpersistent_flags+=("--apiEndPoint=")
+    local_nonpersistent_flags+=("-a")
+    flags+=("--env=")
+    two_word_flags+=("--env")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--env")
+    local_nonpersistent_flags+=("--env=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--from-file=")
     two_word_flags+=("--from-file")
     two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--from-file")
     local_nonpersistent_flags+=("--from-file=")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--hostname=")
+    two_word_flags+=("--hostname")
+    local_nonpersistent_flags+=("--hostname")
+    local_nonpersistent_flags+=("--hostname=")
+    flags+=("--image=")
+    two_word_flags+=("--image")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--image")
+    local_nonpersistent_flags+=("--image=")
+    local_nonpersistent_flags+=("-i")
+    flags+=("--mode=")
+    two_word_flags+=("--mode")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--mode")
+    local_nonpersistent_flags+=("--mode=")
+    local_nonpersistent_flags+=("-m")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    local_nonpersistent_flags+=("--namespace")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--override")
+    local_nonpersistent_flags+=("--override")
+    flags+=("--replicas=")
+    two_word_flags+=("--replicas")
+    local_nonpersistent_flags+=("--replicas")
+    local_nonpersistent_flags+=("--replicas=")
+    flags+=("--version=")
+    two_word_flags+=("--version")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+    local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--from-file=")
+    must_have_one_flag+=("-f")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_add_help()
+{
+    last_command="apictl_k8s_add_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_add()
+{
+    last_command="apictl_k8s_add"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_change_help()
+{
+    last_command="apictl_k8s_change_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_change_registry()
+{
+    last_command="apictl_k8s_change_registry"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--key-file=")
     two_word_flags+=("--key-file")
     two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--key-file")
     local_nonpersistent_flags+=("--key-file=")
+    local_nonpersistent_flags+=("-c")
     flags+=("--password=")
     two_word_flags+=("--password")
     two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--password")
     local_nonpersistent_flags+=("--password=")
+    local_nonpersistent_flags+=("-p")
     flags+=("--password-stdin")
     local_nonpersistent_flags+=("--password-stdin")
     flags+=("--registry-type=")
     two_word_flags+=("--registry-type")
     two_word_flags+=("-R")
+    local_nonpersistent_flags+=("--registry-type")
     local_nonpersistent_flags+=("--registry-type=")
+    local_nonpersistent_flags+=("-R")
     flags+=("--repository=")
     two_word_flags+=("--repository")
     two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--repository")
     local_nonpersistent_flags+=("--repository=")
+    local_nonpersistent_flags+=("-r")
     flags+=("--username=")
     two_word_flags+=("--username")
     two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--username")
     local_nonpersistent_flags+=("--username=")
+    local_nonpersistent_flags+=("-u")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1238,9 +1868,142 @@ _apictl_install_api-operator()
     noun_aliases=()
 }
 
-_apictl_install_wso2am-operator()
+_apictl_k8s_change()
 {
-    last_command="apictl_install_wso2am-operator"
+    last_command="apictl_k8s_change"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("registry")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_delete_apictl()
+{
+    last_command="apictl_k8s_delete_apictl"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_delete_help()
+{
+    last_command="apictl_k8s_delete_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_delete()
+{
+    last_command="apictl_k8s_delete"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("apictl")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_help()
+{
+    last_command="apictl_k8s_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_install_api-operator()
+{
+    last_command="apictl_k8s_install_api-operator"
 
     command_aliases=()
 
@@ -1255,10 +2018,45 @@ _apictl_install_wso2am-operator()
     flags+=("--from-file=")
     two_word_flags+=("--from-file")
     two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--from-file")
     local_nonpersistent_flags+=("--from-file=")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--key-file=")
+    two_word_flags+=("--key-file")
+    two_word_flags+=("-c")
+    local_nonpersistent_flags+=("--key-file")
+    local_nonpersistent_flags+=("--key-file=")
+    local_nonpersistent_flags+=("-c")
+    flags+=("--password=")
+    two_word_flags+=("--password")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--password")
+    local_nonpersistent_flags+=("--password=")
+    local_nonpersistent_flags+=("-p")
+    flags+=("--password-stdin")
+    local_nonpersistent_flags+=("--password-stdin")
+    flags+=("--registry-type=")
+    two_word_flags+=("--registry-type")
+    two_word_flags+=("-R")
+    local_nonpersistent_flags+=("--registry-type")
+    local_nonpersistent_flags+=("--registry-type=")
+    local_nonpersistent_flags+=("-R")
+    flags+=("--repository=")
+    two_word_flags+=("--repository")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--repository")
+    local_nonpersistent_flags+=("--repository=")
+    local_nonpersistent_flags+=("-r")
+    flags+=("--username=")
+    two_word_flags+=("--username")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--username")
+    local_nonpersistent_flags+=("--username=")
+    local_nonpersistent_flags+=("-u")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1268,14 +2066,72 @@ _apictl_install_wso2am-operator()
     noun_aliases=()
 }
 
-_apictl_install()
+_apictl_k8s_install_help()
 {
-    last_command="apictl_install"
+    last_command="apictl_k8s_install_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_install_wso2am-operator()
+{
+    last_command="apictl_k8s_install_wso2am-operator"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--from-file=")
+    two_word_flags+=("--from-file")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--from-file")
+    local_nonpersistent_flags+=("--from-file=")
+    local_nonpersistent_flags+=("-f")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_install()
+{
+    last_command="apictl_k8s_install"
 
     command_aliases=()
 
     commands=()
     commands+=("api-operator")
+    commands+=("help")
     commands+=("wso2am-operator")
 
     flags=()
@@ -1287,6 +2143,7 @@ _apictl_install()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1296,9 +2153,9 @@ _apictl_install()
     noun_aliases=()
 }
 
-_apictl_list_api-products()
+_apictl_k8s_uninstall_api-operator()
 {
-    last_command="apictl_list_api-products"
+    last_command="apictl_k8s_uninstall_api-operator"
 
     command_aliases=()
 
@@ -1310,38 +2167,24 @@ _apictl_list_api-products()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
-    flags+=("--format=")
-    two_word_flags+=("--format")
-    local_nonpersistent_flags+=("--format=")
+    flags+=("--force")
+    local_nonpersistent_flags+=("--force")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
-    flags+=("--limit=")
-    two_word_flags+=("--limit")
-    two_word_flags+=("-l")
-    local_nonpersistent_flags+=("--limit=")
-    flags+=("--query=")
-    two_word_flags+=("--query")
-    two_word_flags+=("-q")
-    local_nonpersistent_flags+=("--query=")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
     must_have_one_noun=()
     noun_aliases=()
 }
 
-_apictl_list_apis()
+_apictl_k8s_uninstall_help()
 {
-    last_command="apictl_list_apis"
+    last_command="apictl_k8s_uninstall_help"
 
     command_aliases=()
 
@@ -1353,38 +2196,19 @@ _apictl_list_apis()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
-    flags+=("--format=")
-    two_word_flags+=("--format")
-    local_nonpersistent_flags+=("--format=")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--limit=")
-    two_word_flags+=("--limit")
-    two_word_flags+=("-l")
-    local_nonpersistent_flags+=("--limit=")
-    flags+=("--query=")
-    two_word_flags+=("--query")
-    two_word_flags+=("-q")
-    local_nonpersistent_flags+=("--query=")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
     must_have_one_noun=()
+    has_completion_function=1
     noun_aliases=()
 }
 
-_apictl_list_apps()
+_apictl_k8s_uninstall_wso2am-operator()
 {
-    last_command="apictl_list_apps"
+    last_command="apictl_k8s_uninstall_wso2am-operator"
 
     command_aliases=()
 
@@ -1396,38 +2220,54 @@ _apictl_list_apps()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--environment=")
-    two_word_flags+=("--environment")
-    two_word_flags+=("-e")
-    local_nonpersistent_flags+=("--environment=")
-    flags+=("--format=")
-    two_word_flags+=("--format")
-    local_nonpersistent_flags+=("--format=")
+    flags+=("--force")
+    local_nonpersistent_flags+=("--force")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
-    flags+=("--limit=")
-    two_word_flags+=("--limit")
-    two_word_flags+=("-l")
-    local_nonpersistent_flags+=("--limit=")
-    flags+=("--owner=")
-    two_word_flags+=("--owner")
-    two_word_flags+=("-o")
-    local_nonpersistent_flags+=("--owner=")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--environment=")
-    must_have_one_flag+=("-e")
     must_have_one_noun=()
     noun_aliases=()
 }
 
-_apictl_list_envs()
+_apictl_k8s_uninstall()
 {
-    last_command="apictl_list_envs"
+    last_command="apictl_k8s_uninstall"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api-operator")
+    commands+=("help")
+    commands+=("wso2am-operator")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s_update_api()
+{
+    last_command="apictl_k8s_update_api"
 
     command_aliases=()
 
@@ -1439,12 +2279,42 @@ _apictl_list_envs()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--format=")
-    two_word_flags+=("--format")
-    local_nonpersistent_flags+=("--format=")
+    flags+=("--from-file=")
+    two_word_flags+=("--from-file")
+    two_word_flags+=("-f")
+    local_nonpersistent_flags+=("--from-file")
+    local_nonpersistent_flags+=("--from-file=")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--mode=")
+    two_word_flags+=("--mode")
+    two_word_flags+=("-m")
+    local_nonpersistent_flags+=("--mode")
+    local_nonpersistent_flags+=("--mode=")
+    local_nonpersistent_flags+=("-m")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--namespace=")
+    two_word_flags+=("--namespace")
+    local_nonpersistent_flags+=("--namespace")
+    local_nonpersistent_flags+=("--namespace=")
+    flags+=("--replicas=")
+    two_word_flags+=("--replicas")
+    local_nonpersistent_flags+=("--replicas")
+    local_nonpersistent_flags+=("--replicas=")
+    flags+=("--version=")
+    two_word_flags+=("--version")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+    local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1454,17 +2324,39 @@ _apictl_list_envs()
     noun_aliases=()
 }
 
-_apictl_list()
+_apictl_k8s_update_help()
 {
-    last_command="apictl_list"
+    last_command="apictl_k8s_update_help"
 
     command_aliases=()
 
     commands=()
-    commands+=("api-products")
-    commands+=("apis")
-    commands+=("apps")
-    commands+=("envs")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_k8s_update()
+{
+    last_command="apictl_k8s_update"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("help")
 
     flags=()
     two_word_flags=()
@@ -1475,6 +2367,41 @@ _apictl_list()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_k8s()
+{
+    last_command="apictl_k8s"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("add")
+    commands+=("change")
+    commands+=("delete")
+    commands+=("help")
+    commands+=("install")
+    commands+=("uninstall")
+    commands+=("update")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1501,16 +2428,21 @@ _apictl_login()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--password=")
     two_word_flags+=("--password")
     two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--password")
     local_nonpersistent_flags+=("--password=")
+    local_nonpersistent_flags+=("-p")
     flags+=("--password-stdin")
     local_nonpersistent_flags+=("--password-stdin")
     flags+=("--username=")
     two_word_flags+=("--username")
     two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--username")
     local_nonpersistent_flags+=("--username=")
+    local_nonpersistent_flags+=("-u")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1537,6 +2469,7 @@ _apictl_logout()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1563,12 +2496,37 @@ _apictl_remove_env()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
 
     must_have_one_flag=()
     must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_remove_help()
+{
+    last_command="apictl_remove_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
     noun_aliases=()
 }
 
@@ -1580,6 +2538,7 @@ _apictl_remove()
 
     commands=()
     commands+=("env")
+    commands+=("help")
 
     flags=()
     two_word_flags=()
@@ -1590,6 +2549,7 @@ _apictl_remove()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1615,181 +2575,22 @@ _apictl_set()
 
     flags+=("--export-directory=")
     two_word_flags+=("--export-directory")
+    local_nonpersistent_flags+=("--export-directory")
     local_nonpersistent_flags+=("--export-directory=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--http-request-timeout=")
     two_word_flags+=("--http-request-timeout")
+    local_nonpersistent_flags+=("--http-request-timeout")
     local_nonpersistent_flags+=("--http-request-timeout=")
-    flags+=("--mode=")
-    two_word_flags+=("--mode")
-    two_word_flags+=("-m")
-    local_nonpersistent_flags+=("--mode=")
     flags+=("--vcs-config-path=")
     two_word_flags+=("--vcs-config-path")
+    local_nonpersistent_flags+=("--vcs-config-path")
     local_nonpersistent_flags+=("--vcs-config-path=")
     flags+=("--vcs-deletion-enabled")
     local_nonpersistent_flags+=("--vcs-deletion-enabled")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_uninstall_api-operator()
-{
-    last_command="apictl_uninstall_api-operator"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--force")
-    local_nonpersistent_flags+=("--force")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_uninstall_wso2am-operator()
-{
-    last_command="apictl_uninstall_wso2am-operator"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--force")
-    local_nonpersistent_flags+=("--force")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_uninstall()
-{
-    last_command="apictl_uninstall"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("api-operator")
-    commands+=("wso2am-operator")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_update_api()
-{
-    last_command="apictl_update_api"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--from-file=")
-    two_word_flags+=("--from-file")
-    two_word_flags+=("-f")
-    local_nonpersistent_flags+=("--from-file=")
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
-    flags+=("--mode=")
-    two_word_flags+=("--mode")
-    two_word_flags+=("-m")
-    local_nonpersistent_flags+=("--mode=")
-    flags+=("--name=")
-    two_word_flags+=("--name")
-    two_word_flags+=("-n")
-    local_nonpersistent_flags+=("--name=")
-    flags+=("--namespace=")
-    two_word_flags+=("--namespace")
-    local_nonpersistent_flags+=("--namespace=")
-    flags+=("--replicas=")
-    two_word_flags+=("--replicas")
-    local_nonpersistent_flags+=("--replicas=")
-    flags+=("--version=")
-    two_word_flags+=("--version")
-    two_word_flags+=("-v")
-    local_nonpersistent_flags+=("--version=")
-    flags+=("--insecure")
-    flags+=("-k")
-    flags+=("--verbose")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_apictl_update()
-{
-    last_command="apictl_update"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("api")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    local_nonpersistent_flags+=("--help")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1816,10 +2617,13 @@ _apictl_vcs_deploy()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--skipRollback")
     local_nonpersistent_flags+=("--skipRollback")
     flags+=("--insecure")
@@ -1830,6 +2634,30 @@ _apictl_vcs_deploy()
     must_have_one_flag+=("--environment=")
     must_have_one_flag+=("-e")
     must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_vcs_help()
+{
+    last_command="apictl_vcs_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
     noun_aliases=()
 }
 
@@ -1850,9 +2678,11 @@ _apictl_vcs_init()
     flags+=("--force")
     flags+=("-f")
     local_nonpersistent_flags+=("--force")
+    local_nonpersistent_flags+=("-f")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1879,10 +2709,13 @@ _apictl_vcs_status()
     flags+=("--environment=")
     two_word_flags+=("--environment")
     two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
     local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1902,6 +2735,7 @@ _apictl_vcs()
 
     commands=()
     commands+=("deploy")
+    commands+=("help")
     commands+=("init")
     commands+=("status")
 
@@ -1914,6 +2748,7 @@ _apictl_vcs()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1940,6 +2775,7 @@ _apictl_version()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -1957,27 +2793,18 @@ _apictl_root_command()
 
     commands=()
     commands+=("add")
-    commands+=("add-env")
-    commands+=("change")
     commands+=("change-status")
     commands+=("delete")
     commands+=("export")
-    commands+=("export-api")
-    commands+=("export-apis")
-    commands+=("export-app")
-    commands+=("get-keys")
+    commands+=("get")
+    commands+=("help")
     commands+=("import")
-    commands+=("import-api")
-    commands+=("import-app")
     commands+=("init")
-    commands+=("install")
-    commands+=("list")
+    commands+=("k8s")
     commands+=("login")
     commands+=("logout")
     commands+=("remove")
     commands+=("set")
-    commands+=("uninstall")
-    commands+=("update")
     commands+=("vcs")
     commands+=("version")
 
@@ -1990,6 +2817,7 @@ _apictl_root_command()
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
     flags+=("--insecure")
     flags+=("-k")
     flags+=("--verbose")
@@ -2019,6 +2847,7 @@ __start_apictl()
     local commands=("apictl")
     local must_have_one_flag=()
     local must_have_one_noun=()
+    local has_completion_function
     local last_command
     local nouns=()
 

--- a/import-export-cli/shell-completions/apictl_zsh_completions.sh
+++ b/import-export-cli/shell-completions/apictl_zsh_completions.sh
@@ -1,970 +1,159 @@
 #compdef _apictl apictl
 
+# zsh completion for apictl                               -*- shell-script -*-
 
-function _apictl {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for apictl]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "add:Add an API to the kubernetes cluster"
-      "add-env:Add Environment to Config file"
-      "change:Change a configuration in K8s cluster resource"
-      "change-status:Change Status of an API"
-      "delete:Delete an API/APIProduct/Application in an environment"
-      "export:Export an API Product in an environment"
-      "export-api:Export API"
-      "export-apis:Export APIs for migration"
-      "export-app:Export App"
-      "get-keys:Generate access token to invoke the API or API Product"
-      "help:Help about any command"
-      "import:Import an API Product to an environment"
-      "import-api:Import API"
-      "import-app:Import App"
-      "init:Initialize a new project in given path"
-      "install:Install an operator in the configured K8s cluster"
-      "list:List APIs/APIProducts/Applications in an environment or List the environments"
-      "login:Login to an API Manager"
-      "logout:Logout to from an API Manager"
-      "remove:Remove an environment"
-      "set:Set configuration parameters"
-      "uninstall:Uninstall an operator in the configured K8s cluster"
-      "update:Update an API to the kubernetes cluster"
-      "vcs:Checks status and deploys projects"
-      "version:Display Version on current apictl"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  add)
-    _apictl_add
-    ;;
-  add-env)
-    _apictl_add-env
-    ;;
-  change)
-    _apictl_change
-    ;;
-  change-status)
-    _apictl_change-status
-    ;;
-  delete)
-    _apictl_delete
-    ;;
-  export)
-    _apictl_export
-    ;;
-  export-api)
-    _apictl_export-api
-    ;;
-  export-apis)
-    _apictl_export-apis
-    ;;
-  export-app)
-    _apictl_export-app
-    ;;
-  get-keys)
-    _apictl_get-keys
-    ;;
-  help)
-    _apictl_help
-    ;;
-  import)
-    _apictl_import
-    ;;
-  import-api)
-    _apictl_import-api
-    ;;
-  import-app)
-    _apictl_import-app
-    ;;
-  init)
-    _apictl_init
-    ;;
-  install)
-    _apictl_install
-    ;;
-  list)
-    _apictl_list
-    ;;
-  login)
-    _apictl_login
-    ;;
-  logout)
-    _apictl_logout
-    ;;
-  remove)
-    _apictl_remove
-    ;;
-  set)
-    _apictl_set
-    ;;
-  uninstall)
-    _apictl_uninstall
-    ;;
-  update)
-    _apictl_update
-    ;;
-  vcs)
-    _apictl_vcs
-    ;;
-  version)
-    _apictl_version
-    ;;
-  esac
+__apictl_debug()
+{
+    local file="$BASH_COMP_DEBUG_FILE"
+    if [[ -n ${file} ]]; then
+        echo "$*" >> "${file}"
+    fi
 }
 
+_apictl()
+{
+    local shellCompDirectiveError=1
+    local shellCompDirectiveNoSpace=2
+    local shellCompDirectiveNoFileComp=4
+    local shellCompDirectiveFilterFileExt=8
+    local shellCompDirectiveFilterDirs=16
 
-function _apictl_add {
-  local -a commands
+    local lastParam lastChar flagPrefix requestComp out directive compCount comp lastComp
+    local -a completions
 
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for add]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
+    __apictl_debug "\n========= starting completion logic =========="
+    __apictl_debug "CURRENT: ${CURRENT}, words[*]: ${words[*]}"
 
-  case $state in
-  cmnds)
-    commands=(
-      "api:handle APIs in kubernetes cluster "
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CURRENT location, so we need
+    # to truncate the command-line ($words) up to the $CURRENT location.
+    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+    words=("${=words[1,CURRENT]}")
+    __apictl_debug "Truncated words[*]: ${words[*]},"
 
-  case "$words[1]" in
-  api)
-    _apictl_add_api
-    ;;
-  help)
-    _apictl_add_help
-    ;;
-  esac
+    lastParam=${words[-1]}
+    lastChar=${lastParam[-1]}
+    __apictl_debug "lastParam: ${lastParam}, lastChar: ${lastChar}"
+
+    # For zsh, when completing a flag with an = (e.g., apictl -n=<TAB>)
+    # completions must be prefixed with the flag
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        # We are dealing with a flag with an =
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    # Prepare the command to obtain completions
+    requestComp="${words[1]} __complete ${words[2,-1]}"
+    if [ "${lastChar}" = "" ]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go completion code.
+        __apictl_debug "Adding extra empty parameter"
+        requestComp="${requestComp} \"\""
+    fi
+
+    __apictl_debug "About to call: eval ${requestComp}"
+
+    # Use eval to handle any environment variables and such
+    out=$(eval ${requestComp} 2>/dev/null)
+    __apictl_debug "completion output: ${out}"
+
+    # Extract the directive integer following a : from the last line
+    local lastLine
+    while IFS='\n' read -r line; do
+        lastLine=${line}
+    done < <(printf "%s\n" "${out[@]}")
+    __apictl_debug "last line: ${lastLine}"
+
+    if [ "${lastLine[1]}" = : ]; then
+        directive=${lastLine[2,-1]}
+        # Remove the directive including the : and the newline
+        local suffix
+        (( suffix=${#lastLine}+2))
+        out=${out[1,-$suffix]}
+    else
+        # There is no directive specified.  Leave $out as is.
+        __apictl_debug "No directive found.  Setting do default"
+        directive=0
+    fi
+
+    __apictl_debug "directive: ${directive}"
+    __apictl_debug "completions: ${out}"
+    __apictl_debug "flagPrefix: ${flagPrefix}"
+
+    if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
+        __apictl_debug "Completion received error. Ignoring completions."
+        return
+    fi
+
+    compCount=0
+    while IFS='\n' read -r comp; do
+        if [ -n "$comp" ]; then
+            # If requested, completions are returned with a description.
+            # The description is preceded by a TAB character.
+            # For zsh's _describe, we need to use a : instead of a TAB.
+            # We first need to escape any : as part of the completion itself.
+            comp=${comp//:/\\:}
+
+            local tab=$(printf '\t')
+            comp=${comp//$tab/:}
+
+            ((compCount++))
+            __apictl_debug "Adding completion: ${comp}"
+            completions+=${comp}
+            lastComp=$comp
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    if [ $((directive & shellCompDirectiveFilterFileExt)) -ne 0 ]; then
+        # File extension filtering
+        local filteringCmd
+        filteringCmd='_files'
+        for filter in ${completions[@]}; do
+            if [ ${filter[1]} != '*' ]; then
+                # zsh requires a glob pattern to do file filtering
+                filter="\*.$filter"
+            fi
+            filteringCmd+=" -g $filter"
+        done
+        filteringCmd+=" ${flagPrefix}"
+
+        __apictl_debug "File filtering command: $filteringCmd"
+        _arguments '*:filename:'"$filteringCmd"
+    elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
+        # File completion for directories only
+        local subDir
+        subdir="${completions[1]}"
+        if [ -n "$subdir" ]; then
+            __apictl_debug "Listing directories in $subdir"
+            pushd "${subdir}" >/dev/null 2>&1
+        else
+            __apictl_debug "Listing directories in ."
+        fi
+
+        _arguments '*:dirname:_files -/'" ${flagPrefix}"
+        if [ -n "$subdir" ]; then
+            popd >/dev/null 2>&1
+        fi
+    elif [ $((directive & shellCompDirectiveNoSpace)) -ne 0 ] && [ ${compCount} -eq 1 ]; then
+        __apictl_debug "Activating nospace."
+        # We can use compadd here as there is no description when
+        # there is only one completion.
+        compadd -S '' "${lastComp}"
+    elif [ ${compCount} -eq 0 ]; then
+        if [ $((directive & shellCompDirectiveNoFileComp)) -ne 0 ]; then
+            __apictl_debug "deactivating file completion"
+        else
+            # Perform file completion
+            __apictl_debug "activating file completion"
+            _arguments '*:filename:_files'" ${flagPrefix}"
+        fi
+    else
+        _describe "completions" completions $(echo $flagPrefix)
+    fi
 }
 
-function _apictl_add_api {
-  _arguments \
-    '(-a --apiEndPoint)'{-a,--apiEndPoint}'[]:' \
-    '(*-e *--env)'{\*-e,\*--env}'[Environment variables to be passed to deployment]:' \
-    '(*-f *--from-file)'{\*-f,\*--from-file}'[Path to swagger file]:' \
-    '(-h --help)'{-h,--help}'[help for api]' \
-    '--hostname[Ingress hostname that the API is being exposed]:' \
-    '(-i --image)'{-i,--image}'[Image of the API. If specified, ignores the value of --override]:' \
-    '(-m --mode)'{-m,--mode}'[Property to override the deploying mode. Available modes: privateJet, sidecar]:' \
-    '(-n --name)'{-n,--name}'[Name of the API]:' \
-    '--namespace[namespace of API]:' \
-    '--override[Property to override the existing docker image with the given name and version]' \
-    '--replicas[replica set]:' \
-    '(-v --version)'{-v,--version}'[Property to override the API version]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_add_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_add-env {
-  _arguments \
-    '--admin[Admin endpoint for the environment]:' \
-    '--apim[API Manager endpoint for the environment]:' \
-    '--devportal[DevPortal endpoint for the environment]:' \
-    '(-e --environment)'{-e,--environment}'[Name of the environment to be added]:' \
-    '(-h --help)'{-h,--help}'[help for add-env]' \
-    '--publisher[Publisher endpoint for the environment]:' \
-    '--registration[Registration endpoint for the environment]:' \
-    '--token[Token endpoint for the environment]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_change {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for change]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "help:Help about any command"
-      "registry:Change the registry"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  help)
-    _apictl_change_help
-    ;;
-  registry)
-    _apictl_change_registry
-    ;;
-  esac
-}
-
-function _apictl_change_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_change_registry {
-  _arguments \
-    '(-h --help)'{-h,--help}'[help for registry]' \
-    '(-c --key-file)'{-c,--key-file}'[Credentials file]:' \
-    '(-p --password)'{-p,--password}'[Password of the given user]:' \
-    '--password-stdin[Prompt for password of the given user in the stdin]' \
-    '(-R --registry-type)'{-R,--registry-type}'[Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP]:' \
-    '(-r --repository)'{-r,--repository}'[Repository name or URI]:' \
-    '(-u --username)'{-u,--username}'[Username of the repository]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_change-status {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for change-status]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api:Change Status of an API"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api)
-    _apictl_change-status_api
-    ;;
-  help)
-    _apictl_change-status_help
-    ;;
-  esac
-}
-
-function _apictl_change-status_api {
-  _arguments \
-    '(-a --action)'{-a,--action}'[Action to be taken to change the status of the API]:' \
-    '(-e --environment)'{-e,--environment}'[Environment of which the API state should be changed]:' \
-    '(-h --help)'{-h,--help}'[help for api]' \
-    '(-n --name)'{-n,--name}'[Name of the API to be state changed]:' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API]:' \
-    '(-v --version)'{-v,--version}'[Version of the API to be state changed]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_change-status_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_delete {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for delete]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api:Delete API"
-      "api-product:Delete API Product"
-      "app:Delete App"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api)
-    _apictl_delete_api
-    ;;
-  api-product)
-    _apictl_delete_api-product
-    ;;
-  app)
-    _apictl_delete_app
-    ;;
-  help)
-    _apictl_delete_help
-    ;;
-  esac
-}
-
-function _apictl_delete_api {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from which the API should be deleted]:' \
-    '(-h --help)'{-h,--help}'[help for api]' \
-    '(-n --name)'{-n,--name}'[Name of the API to be deleted]:' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API to be deleted]:' \
-    '(-v --version)'{-v,--version}'[Version of the API to be deleted]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_delete_api-product {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from which the API Product should be deleted]:' \
-    '(-h --help)'{-h,--help}'[help for api-product]' \
-    '(-n --name)'{-n,--name}'[Name of the API Product to be deleted]:' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API Product to be deleted]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_delete_app {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from which the Application should be deleted]:' \
-    '(-h --help)'{-h,--help}'[help for app]' \
-    '(-n --name)'{-n,--name}'[Name of the Application to be deleted]:' \
-    '(-o --owner)'{-o,--owner}'[Owner of the Application to be deleted]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_delete_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_export {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for export]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api-product:Export API Product"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api-product)
-    _apictl_export_api-product
-    ;;
-  help)
-    _apictl_export_help
-    ;;
-  esac
-}
-
-function _apictl_export_api-product {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to which the API Product should be exported]:' \
-    '--format[File format of exported archive (json or yaml)]:' \
-    '(-h --help)'{-h,--help}'[help for api-product]' \
-    '(-n --name)'{-n,--name}'[Name of the API Product to be exported]:' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API Product]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_export_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_export-api {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to which the API should be exported]:' \
-    '--format[File format of exported archive(json or yaml)]:' \
-    '(-h --help)'{-h,--help}'[help for export-api]' \
-    '(-n --name)'{-n,--name}'[Name of the API to be exported]:' \
-    '--preserveStatus[Preserve API status when exporting. Otherwise API will be exported in CREATED status]' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API]:' \
-    '(-v --version)'{-v,--version}'[Version of the API to be exported]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_export-apis {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from which the APIs should be exported]:' \
-    '--force[Clean all the previously exported APIs of the given target tenant, in the given environment if any, and to export APIs from beginning]' \
-    '--format[File format of exported archives(json or yaml)]:' \
-    '(-h --help)'{-h,--help}'[help for export-apis]' \
-    '--preserveStatus[Preserve API status when exporting. Otherwise API will be exported in CREATED status]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_export-app {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to which the Application should be exported]:' \
-    '(-h --help)'{-h,--help}'[help for export-app]' \
-    '(-n --name)'{-n,--name}'[Name of the Application to be exported]:' \
-    '(-o --owner)'{-o,--owner}'[Owner of the Application to be exported]:' \
-    '--withKeys[Export keys for the application ]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_get-keys {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Key generation environment]:' \
-    '(-h --help)'{-h,--help}'[help for get-keys]' \
-    '(-n --name)'{-n,--name}'[API or API Product to generate keys]:' \
-    '(-r --provider)'{-r,--provider}'[Provider of the API or API Product]:' \
-    '(-t --token)'{-t,--token}'[Token endpoint URL of Environment]:' \
-    '(-v --version)'{-v,--version}'[Version of the API]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_import {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for import]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api-product:Import API Product"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api-product)
-    _apictl_import_api-product
-    ;;
-  help)
-    _apictl_import_help
-    ;;
-  esac
-}
-
-function _apictl_import_api-product {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from the which the API Product should be imported]:' \
-    '(-f --file)'{-f,--file}'[Name of the API Product to be imported]:' \
-    '(-h --help)'{-h,--help}'[help for api-product]' \
-    '--import-apis[Import dependent APIs associated with the API Product]' \
-    '--preserve-provider[Preserve existing provider of API Product after importing]' \
-    '--skipCleanup[Leave all temporary files created during import process]' \
-    '--update-api-product[Update an existing API Product or create a new API Product]' \
-    '--update-apis[Update existing dependent APIs associated with the API Product]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_import_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_import-api {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from the which the API should be imported]:' \
-    '(-f --file)'{-f,--file}'[Name of the API to be imported]:' \
-    '(-h --help)'{-h,--help}'[help for import-api]' \
-    '--params[Provide a API Manager params file]:' \
-    '--preserve-provider[Preserve existing provider of API after importing]' \
-    '--skipCleanup[Leave all temporary files created during import process]' \
-    '--update[Update an existing API or create a new API]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_import-app {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment from the which the Application should be imported]:' \
-    '(-f --file)'{-f,--file}'[Name of the ZIP file of the Application to be imported]:' \
-    '(-h --help)'{-h,--help}'[help for import-app]' \
-    '(-o --owner)'{-o,--owner}'[Name of the target owner of the Application as desired by the Importer]:' \
-    '--preserveOwner[Preserves app owner]' \
-    '--skipCleanup[Leave all temporary files created during import process]' \
-    '--skipKeys[Skip importing keys of the Application]' \
-    '(-s --skipSubscriptions)'{-s,--skipSubscriptions}'[Skip subscriptions of the Application]' \
-    '--update[Update the Application if it is already imported]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_init {
-  _arguments \
-    '(-d --definition)'{-d,--definition}'[Provide a YAML definition of API]:' \
-    '(-f --force)'{-f,--force}'[Force create project]' \
-    '(-h --help)'{-h,--help}'[help for init]' \
-    '--initial-state[Provide the initial state of the API; Valid states: [CREATED PUBLISHED]]:' \
-    '--oas[Provide an OpenAPI specification file for the API]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_install {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for install]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api-operator:Install API Operator"
-      "help:Help about any command"
-      "wso2am-operator:Install WSO2AM Operator"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api-operator)
-    _apictl_install_api-operator
-    ;;
-  help)
-    _apictl_install_help
-    ;;
-  wso2am-operator)
-    _apictl_install_wso2am-operator
-    ;;
-  esac
-}
-
-function _apictl_install_api-operator {
-  _arguments \
-    '(-f --from-file)'{-f,--from-file}'[Path to API Operator directory]:' \
-    '(-h --help)'{-h,--help}'[help for api-operator]' \
-    '(-c --key-file)'{-c,--key-file}'[Credentials file]:' \
-    '(-p --password)'{-p,--password}'[Password of the given user]:' \
-    '--password-stdin[Prompt for password of the given user in the stdin]' \
-    '(-R --registry-type)'{-R,--registry-type}'[Registry type: DOCKER_HUB | AMAZON_ECR |GCR | HTTP]:' \
-    '(-r --repository)'{-r,--repository}'[Repository name or URI]:' \
-    '(-u --username)'{-u,--username}'[Username of the repository]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_install_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_install_wso2am-operator {
-  _arguments \
-    '(-f --from-file)'{-f,--from-file}'[Path to wso2am-operator directory]:' \
-    '(-h --help)'{-h,--help}'[help for wso2am-operator]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_list {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for list]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api-products:Display a list of API Products in an environment"
-      "apis:Display a list of APIs in an environment"
-      "apps:Display a list of Applications in an environment specific to an owner"
-      "envs:Display the list of environments"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api-products)
-    _apictl_list_api-products
-    ;;
-  apis)
-    _apictl_list_apis
-    ;;
-  apps)
-    _apictl_list_apps
-    ;;
-  envs)
-    _apictl_list_envs
-    ;;
-  help)
-    _apictl_list_help
-    ;;
-  esac
-}
-
-function _apictl_list_api-products {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to be searched]:' \
-    '--format[Pretty-print API Products using Go Templates. Use "{{ jsonPretty . }}" to list all fields]:' \
-    '(-h --help)'{-h,--help}'[help for api-products]' \
-    '(-l --limit)'{-l,--limit}'[Maximum number of API Products to return]:' \
-    '(-q --query)'{-q,--query}'[Query pattern]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_list_apis {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to be searched]:' \
-    '--format[Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields]:' \
-    '(-h --help)'{-h,--help}'[help for apis]' \
-    '(-l --limit)'{-l,--limit}'[Maximum number of apis to return]:' \
-    '(-q --query)'{-q,--query}'[Query pattern]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_list_apps {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Environment to be searched]:' \
-    '--format[Pretty-print outputusing Go templates. Use "{{jsonPretty .}}" to list all fields]:' \
-    '(-h --help)'{-h,--help}'[help for apps]' \
-    '(-l --limit)'{-l,--limit}'[Maximum number of applications to return]:' \
-    '(-o --owner)'{-o,--owner}'[Owner of the Application]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_list_envs {
-  _arguments \
-    '--format[Pretty-print environments using go templates]:' \
-    '(-h --help)'{-h,--help}'[help for envs]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_list_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_login {
-  _arguments \
-    '(-h --help)'{-h,--help}'[help for login]' \
-    '(-p --password)'{-p,--password}'[Password for login]:' \
-    '--password-stdin[Get password from stdin]' \
-    '(-u --username)'{-u,--username}'[Username for login]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_logout {
-  _arguments \
-    '(-h --help)'{-h,--help}'[help for logout]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_remove {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for remove]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "env:Remove Environment from Config file"
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  env)
-    _apictl_remove_env
-    ;;
-  help)
-    _apictl_remove_help
-    ;;
-  esac
-}
-
-function _apictl_remove_env {
-  _arguments \
-    '(-h --help)'{-h,--help}'[help for env]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_remove_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_set {
-  _arguments \
-    '--export-directory[Path to directory where APIs should be saved]:' \
-    '(-h --help)'{-h,--help}'[help for set]' \
-    '--http-request-timeout[Timeout for HTTP Client]:' \
-    '(-m --mode)'{-m,--mode}'[If mode is set to "k8s", apictl is capable of executing Kubectl commands. For example "apictl get pods" -> "kubectl get pods". To go back to the default mode, set the mode to "default"]:' \
-    '--vcs-config-path[Path to the VCS Configuration yaml file which keeps the VCS meta data]:' \
-    '--vcs-deletion-enabled[Specifies whether project deletion is allowed during deployment.]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_uninstall {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for uninstall]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api-operator:Uninstall API Operator"
-      "help:Help about any command"
-      "wso2am-operator:Uninstall WSO2AM Operator"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api-operator)
-    _apictl_uninstall_api-operator
-    ;;
-  help)
-    _apictl_uninstall_help
-    ;;
-  wso2am-operator)
-    _apictl_uninstall_wso2am-operator
-    ;;
-  esac
-}
-
-function _apictl_uninstall_api-operator {
-  _arguments \
-    '--force[Force uninstall API Operator]' \
-    '(-h --help)'{-h,--help}'[help for api-operator]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_uninstall_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_uninstall_wso2am-operator {
-  _arguments \
-    '--force[Force uninstall WSO2AM Operator]' \
-    '(-h --help)'{-h,--help}'[help for wso2am-operator]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_update {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for update]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "api:handle APIs in kubernetes cluster "
-      "help:Help about any command"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  api)
-    _apictl_update_api
-    ;;
-  help)
-    _apictl_update_help
-    ;;
-  esac
-}
-
-function _apictl_update_api {
-  _arguments \
-    '(*-f *--from-file)'{\*-f,\*--from-file}'[Path to swagger file]:' \
-    '(-h --help)'{-h,--help}'[help for api]' \
-    '(-m --mode)'{-m,--mode}'[Property to override the deploying mode. Available modes: privateJet, sidecar]:' \
-    '(-n --name)'{-n,--name}'[Name of the API]:' \
-    '--namespace[namespace of API]:' \
-    '--replicas[replica set]:' \
-    '(-v --version)'{-v,--version}'[Property to override the existing docker image with same name and version]:' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_update_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-
-function _apictl_vcs {
-  local -a commands
-
-  _arguments -C \
-    '(-h --help)'{-h,--help}'[help for vcs]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]' \
-    "1: :->cmnds" \
-    "*::arg:->args"
-
-  case $state in
-  cmnds)
-    commands=(
-      "deploy:Deploys projects to the specified environment"
-      "help:Help about any command"
-      "init:Initializes a GIT repository with API Controller"
-      "status:Shows the list of projects that are ready to deploy"
-    )
-    _describe "command" commands
-    ;;
-  esac
-
-  case "$words[1]" in
-  deploy)
-    _apictl_vcs_deploy
-    ;;
-  help)
-    _apictl_vcs_help
-    ;;
-  init)
-    _apictl_vcs_init
-    ;;
-  status)
-    _apictl_vcs_status
-    ;;
-  esac
-}
-
-function _apictl_vcs_deploy {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Name of the environment to deploy the project(s)]:' \
-    '(-h --help)'{-h,--help}'[help for deploy]' \
-    '--skipRollback[Specifies whether rolling back to the last successful revision during an error situation should be skipped]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_vcs_help {
-  _arguments \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_vcs_init {
-  _arguments \
-    '(-f --force)'{-f,--force}'[Forcefully reinitialize and replace vcs.yaml if already exists in the repository root.]' \
-    '(-h --help)'{-h,--help}'[help for init]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_vcs_status {
-  _arguments \
-    '(-e --environment)'{-e,--environment}'[Name of the environment to check the project(s) status]:' \
-    '(-h --help)'{-h,--help}'[help for status]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
-function _apictl_version {
-  _arguments \
-    '(-h --help)'{-h,--help}'[help for version]' \
-    '(-k --insecure)'{-k,--insecure}'[Allow connections to SSL endpoints without certs]' \
-    '--verbose[Enable verbose mode]'
-}
-
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_apictl" ]; then
+	_apictl
+fi


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/293
Fixes: https://github.com/wso2/product-apim-tooling/issues/340
Fixes: https://github.com/wso2/product-apim-tooling/issues/309

## Goals
Revamp the commands in the format below and deprecate the existing commands.
(A special scope for Kubernetes will be added as "k8s" in the commands related to K8s Operator)
**Format:- _apictl \<scope> \<action> \<resource> \<parameters>_**

## Approach
- Copied the code related to the existing commands (specially related to K8s Operator) inside that directory.
- Modified the code in the **cmd** directory to match with the format _apictl \<scope> \<action> \<resource> \<parameters>_.
- Moved the common code segments to the **impl** and refer those from **deprecated** package and **cmd** package both.
- Refactored the code

## User stories
- Please find the revamped commands addressed by this PR.
<table>
  <tr>
    <th>Old Command</th>
    <th>Revamped Command</th>
  </tr>
  <tr>
    <td>apictl delete api [flags]</td>
    <td>apictl delete api [flags] <br>
           apictl k8s delete api [flags]</td>
  </tr>
  <tr>
    <td>apictl install api-operator [flags]</td>
    <td>apictl k8s install api-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl install wso2am-operator [flags]</td>
    <td>apictl k8s install wso2am-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl uninstall api-operator [flags]</td>
    <td>apictl k8s uninstall api-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl uninstall wso2am-operator [flags]</td>
    <td>apictl k8s uninstall wso2am-operator [flags]</td>
  </tr>
  <tr>
    <td>apictl change registry [flags]</td>
    <td>apictl k8s change registry [flags]</td>
  </tr>
  <tr>
    <td>apictl add api [flags]</td>
    <td>apictl k8s add api [flags]</td>
  </tr>
  <tr>
    <td>apictl update api [flags]</td>
    <td>apictl k8s update api [flags]</td>
  </tr>
  <tr>
    <td>apictl add-env [flags]</td>
    <td>apictl add env [flags]</td>
  </tr>
</table>

- Deprecated the flag "mode" in "apictl set [flags]"

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/515