### PR TITLE
Modifying integration tests for revamped commands

### DIFF
--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -19,8 +19,9 @@
 package integration
 
 import (
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -19,8 +19,9 @@
 package integration
 
 import (
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -79,7 +79,7 @@ func GetValueOfUniformResponse(response string) string {
 // SetupEnv : Adds a new environment and automatically removes it when the calling test function execution ends
 //
 func SetupEnv(t *testing.T, env string, apim string, tokenEp string) {
-	Execute(t, "add-env", "-e", env, "--apim", apim, "--token", tokenEp)
+	Execute(t, "add", "env", env, "--apim", apim, "--token", tokenEp)
 
 	t.Cleanup(func() {
 		Execute(t, "remove", "env", env)
@@ -89,7 +89,7 @@ func SetupEnv(t *testing.T, env string, apim string, tokenEp string) {
 // SetupEnv : Adds a new environment just with apim endpoint and automatically removes it when the
 // calling test function execution ends
 func SetupEnvWithoutTokenFlag(t *testing.T, env string, apim string) {
-	Execute(t, "add-env", "-e", env, "--apim", apim)
+	Execute(t, "add", "env", env, "--apim", apim)
 
 	t.Cleanup(func() {
 		Execute(t, "remove", "env", env)
@@ -310,7 +310,7 @@ func CreateTempDir(t *testing.T, path string) {
 func GetExportedPathFromOutput(output string) string {
 	//Check directory path to omit changes due to OS differences
 	if strings.Contains(output, ":\\") {
-		arrayOutput := []rune (output)
+		arrayOutput := []rune(output)
 		extractedPath := string(arrayOutput[strings.Index(output, ":\\")-1:])
 		return strings.ReplaceAll(strings.ReplaceAll(extractedPath, "\n", ""), " ", "")
 	} else {

--- a/import-export-cli/integration/deprecatedCommands_TestUtils.go
+++ b/import-export-cli/integration/deprecatedCommands_TestUtils.go
@@ -1,0 +1,171 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+func exportAPI(t *testing.T, name string, version string, provider string, env string) (string, error) {
+	var output string
+	var err error
+
+	if provider == "" {
+		output, err = base.Execute(t, "export-api", "-n", name, "-v", version, "-e", env, "-k", "--verbose")
+	} else {
+		output, err = base.Execute(t, "export-api", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
+	}
+
+	t.Cleanup(func() {
+		base.RemoveAPIArchive(t, testutils.GetEnvAPIExportPath(env), name, version)
+	})
+
+	return output, err
+}
+
+func importAPI(t *testing.T, args *testutils.ApiImportExportTestArgs) (string, error) {
+	fileName := base.GetAPIArchiveFilePath(t, args.SrcAPIM.GetEnvName(), args.Api.Name, args.Api.Version)
+
+	params := []string{"import-api", "-f", fileName, "-e", args.DestAPIM.EnvName, "-k", "--verbose"}
+
+	if args.OverrideProvider {
+		params = append(params, "--preserve-provider=false")
+	}
+
+	if args.ParamsFile != "" {
+		params = append(params, "--params", args.ParamsFile)
+	}
+
+	output, err := base.Execute(t, params...)
+
+	t.Cleanup(func() {
+		err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		base.WaitForIndexing()
+	})
+
+	return output, err
+}
+
+func listAPIs(t *testing.T, args *testutils.ApiImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "list", "apis", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
+	return output, err
+}
+
+func exportAllApisOfATenant(t *testing.T, args *testutils.ApiImportExportTestArgs) (string, error) {
+	//Setup environment
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+	//Login to the environmeTestImportAndExportAPIWithJpegImagent
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	output, error := base.Execute(t, "export-apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force")
+	return output, error
+}
+
+func validateAPIExportFailureDeprecated(t *testing.T, args *testutils.ApiImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl env
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// Attempt exporting api from env
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	exportAPI(t, args.Api.Name, args.Api.Version, args.ApiProvider.Username, args.SrcAPIM.GetEnvName())
+
+	// Validate that export failed
+	assert.False(t, base.IsAPIArchiveExists(t, testutils.GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+		args.Api.Name, args.Api.Version))
+}
+
+func validateAPIExportImportDeprecated(t *testing.T, args *testutils.ApiImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+	base.SetupEnv(t, args.DestAPIM.GetEnvName(), args.DestAPIM.GetApimURL(), args.DestAPIM.GetTokenURL())
+
+	// Export api from env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	exportAPI(t, args.Api.Name, args.Api.Version, args.Api.Provider, args.SrcAPIM.GetEnvName())
+
+	assert.True(t, base.IsAPIArchiveExists(t, testutils.GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+		args.Api.Name, args.Api.Version))
+
+	// Import api to env 2
+	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	importAPI(t, args)
+
+	// Give time for newly imported API to get indexed, or else getAPI by name will fail
+	base.WaitForIndexing()
+
+	// Get App from env 2
+	importedAPI := testutils.GetAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
+
+	// Validate env 1 and env 2 API is equal
+	testutils.ValidateAPIsEqual(t, args.Api, importedAPI)
+}
+
+func validateAPIsList(t *testing.T, args *testutils.ApiImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// List APIs of env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	output, _ := listAPIs(t, args)
+
+	apisList := args.SrcAPIM.GetAPIs()
+
+	testutils.ValidateListAPIsEqual(t, output, apisList)
+}
+
+func validateAllApisOfATenantIsExported(t *testing.T, args *testutils.ApiImportExportTestArgs, apisAdded int) {
+	output, error := exportAllApisOfATenant(t, args)
+	assert.Nil(t, error, "Error while exporting APIs")
+	assert.Contains(t, output, "export-apis execution completed", "Error while exporting APIs")
+
+	//Derive exported path from output
+	exportedPath := base.GetExportedPathFromOutput(strings.ReplaceAll(output, "Command: export-apis execution completed !", ""))
+	count, _ := base.CountFiles(exportedPath)
+	assert.GreaterOrEqual(t, count, apisAdded, "Error while exporting APIs")
+
+	t.Cleanup(func() {
+		//Remove Exported apis and logout
+		pathToCleanUp := utils.DefaultExportDirPath + testutils.TestMigrationDirectorySuffix
+		base.RemoveDir(pathToCleanUp)
+	})
+}

--- a/import-export-cli/integration/deprecatedCommands_TestUtils.go
+++ b/import-export-cli/integration/deprecatedCommands_TestUtils.go
@@ -77,6 +77,11 @@ func listAPIs(t *testing.T, args *testutils.ApiImportExportTestArgs) (string, er
 	return output, err
 }
 
+func listAPIProducts(t *testing.T, args *testutils.ApiProductImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "list", "api-products", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
+	return output, err
+}
+
 func exportAllApisOfATenant(t *testing.T, args *testutils.ApiImportExportTestArgs) (string, error) {
 	//Setup environment
 	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
@@ -168,4 +173,22 @@ func validateAllApisOfATenantIsExported(t *testing.T, args *testutils.ApiImportE
 		pathToCleanUp := utils.DefaultExportDirPath + testutils.TestMigrationDirectorySuffix
 		base.RemoveDir(pathToCleanUp)
 	})
+}
+
+func validateAPIProductsList(t *testing.T, args *testutils.ApiProductImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// List API Products of env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	output, _ := listAPIProducts(t, args)
+
+	apiProductsList := args.SrcAPIM.GetAPIProducts()
+
+	testutils.ValidateListAPIProductsEqual(t, output, apiProductsList)
 }

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -169,3 +169,63 @@ func TestListApiProductsDevopsTenantUserDeprecated(t *testing.T) {
 
 	validateAPIProductsList(t, args)
 }
+
+func TestExportAppNonAdminSuperTenantDeprecated(t *testing.T) {
+	subscriberUserName := subscriber.UserName
+	subscriberPassword := subscriber.Password
+
+	dev := apimClients[0]
+
+	app := testutils.AddApp(t, dev, subscriberUserName, subscriberPassword)
+
+	args := &testutils.AppImportExportTestArgs{
+		AppOwner:    testutils.Credentials{Username: subscriberUserName, Password: subscriberPassword},
+		CtlUser:     testutils.Credentials{Username: subscriberUserName, Password: subscriberPassword},
+		Application: app,
+		SrcAPIM:     dev,
+	}
+
+	validateAppExportFailure(t, args)
+}
+
+func TestExportImportAppDevopsTenantDeprecated(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	app := testutils.AddApp(t, dev, tenantAdminUsername, tenantAdminPassword)
+
+	args := &testutils.AppImportExportTestArgs{
+		AppOwner:    testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Application: app,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	validateAppExportImportWithPreserveOwner(t, args)
+}
+
+func TestListAppsDevopsTenantUserDeprecated(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	otherUsername := subscriber.UserName + "@" + TENANT1
+	otherPassword := subscriber.Password
+
+	apim := apimClients[0]
+	testutils.AddApp(t, apim, tenantAdminUsername, tenantAdminPassword)
+	testutils.AddApp(t, apim, otherUsername, otherPassword)
+
+	base.SetupEnv(t, apim.GetEnvName(), apim.GetApimURL(), apim.GetTokenURL())
+	base.Login(t, apim.GetEnvName(), tenantDevopsUsername, tenantDevopsPassword)
+	listApps(t, apim.GetEnvName())
+}

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -1,0 +1,132 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
+)
+
+//List Environments using apictl
+func TestListEnvironmentsDeprecated(t *testing.T) {
+	apim := apimClients[0]
+	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+	response, _ := base.Execute(t, "list", "envs")
+	base.GetRowsFromTableResponse(response)
+	base.Log(response)
+	assert.Contains(t, response, apim.GetEnvName(), "TestListEnvironmentsDeprecated Failed")
+}
+
+// Export an API from one environment as a super tenant non admin user (who has API Create and API Publish permissions)
+// by specifying the provider name
+func TestExportApiNonAdminSuperTenantUserDeprecated(t *testing.T) {
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: apiCreator, Password: apiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: apiPublisher, Password: apiPublisherPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+	}
+
+	validateAPIExportFailureDeprecated(t, args)
+}
+
+// Export an API from one environment and import to another environment as tenant user with
+// Internal/devops role by specifying the provider name
+func TestExportImportApiDevopsTenantUserDeprecated(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	validateAPIExportImportDeprecated(t, args)
+}
+
+func TestListApisDevopsTenantUserDeprecated(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		SrcAPIM: dev,
+	}
+
+	validateAPIsList(t, args)
+}
+
+func TestExportApisWithExportApisCommandDeprecated(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	var api *apim.API
+	var apisAdded = 0
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		api = testutils.AddAPI(t, dev, tenantAdminUsername, tenantAdminPassword)
+		apisAdded++
+	}
+
+	// This will be the API that will be deleted by apictl, so no need to do cleaning
+	api = testutils.AddAPIWithoutCleaning(t, dev, tenantAdminUsername, tenantAdminPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		Api:     api,
+		SrcAPIM: dev,
+	}
+
+	validateAllApisOfATenantIsExported(t, args, apisAdded)
+}

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -229,3 +229,49 @@ func TestListAppsDevopsTenantUserDeprecated(t *testing.T) {
 	base.Login(t, apim.GetEnvName(), tenantDevopsUsername, tenantDevopsPassword)
 	listApps(t, apim.GetEnvName())
 }
+
+func TestGetKeysNonAdminSuperTenantUserDeprecated(t *testing.T) {
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
+
+	args := &testutils.ApiGetKeyTestArgs{
+		CtlUser: testutils.Credentials{Username: apiPublisher, Password: apiPublisherPassword},
+		Api:     api,
+		Apim:    dev,
+	}
+
+	validateGetKeysFailure(t, args)
+}
+
+func TestGetKeysAdminSuperTenantUserDeprecated(t *testing.T) {
+	adminUser := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
+
+	args := &testutils.ApiGetKeyTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
+		Api:     api,
+		Apim:    dev,
+	}
+
+	validateGetKeys(t, args)
+}

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -31,14 +31,14 @@ import (
 
 const defaultExportPath = utils.DefaultExportDirName
 
-//List Environments using apictl
-func TestListEnvironments(t *testing.T) {
+//Get Environments using apictl
+func TestGetEnvironments(t *testing.T) {
 	apim := apimClients[0]
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	response, _ := base.Execute(t, "list", "envs")
+	response, _ := base.Execute(t, "get", "envs")
 	base.GetRowsFromTableResponse(response)
 	base.Log(response)
-	assert.Contains(t, response, apim.GetEnvName(), "TestListEnvironments Failed")
+	assert.Contains(t, response, apim.GetEnvName(), "TestGetEnvironments Failed")
 }
 
 //Change Export directory using apictl and assert the change

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -179,7 +179,7 @@ func importUpdateAPIProduct(t *testing.T, args *ApiProductImportExportTestArgs) 
 }
 
 func listAPIProducts(t *testing.T, args *ApiProductImportExportTestArgs) (string, error) {
-	output, err := base.Execute(t, "list", "api-products", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "get", "api-products", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
 	return output, err
 }
 
@@ -507,10 +507,10 @@ func ValidateAPIProductsList(t *testing.T, args *ApiProductImportExportTestArgs)
 
 	apiProductsList := args.SrcAPIM.GetAPIProducts()
 
-	validateListAPIProductsEqual(t, output, apiProductsList)
+	ValidateListAPIProductsEqual(t, output, apiProductsList)
 }
 
-func validateListAPIProductsEqual(t *testing.T, apiProductsListFromCtl string, apiProductsList *apim.APIProductList) {
+func ValidateListAPIProductsEqual(t *testing.T, apiProductsListFromCtl string, apiProductsList *apim.APIProductList) {
 	unmatchedCount := apiProductsList.Count
 	for _, apiProduct := range apiProductsList.List {
 		// If the output string contains the same API Product ID, then decrement the count

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -100,7 +100,7 @@ func AddAPIProductFromJSON(t *testing.T, client *apim.Client, username string, p
 	return apiProduct
 }
 
-func getAPI(t *testing.T, client *apim.Client, name string, username string, password string) *apim.API {
+func GetAPI(t *testing.T, client *apim.Client, name string, username string, password string) *apim.API {
 	if username == adminservices.DevopsUsername {
 		client.Login(adminservices.AdminUsername, adminservices.AdminPassword)
 	} else if username == adminservices.DevopsUsername+"@"+adminservices.Tenant1 {
@@ -143,7 +143,7 @@ func getResourceURL(apim *apim.Client, api *apim.API) string {
 	return "http://" + apim.GetHost() + ":" + strconv.Itoa(port) + api.Context + "/" + api.Version + "/menu"
 }
 
-func getEnvAPIExportPath(envName string) string {
+func GetEnvAPIExportPath(envName string) string {
 	return filepath.Join(utils.DefaultExportDirPath, utils.ExportedApisDirName, envName)
 }
 
@@ -152,20 +152,20 @@ func exportAPI(t *testing.T, name string, version string, provider string, env s
 	var err error
 
 	if provider == "" {
-		output, err = base.Execute(t, "export-api", "-n", name, "-v", version, "-e", env, "-k", "--verbose")
+		output, err = base.Execute(t, "export", "api", "-n", name, "-v", version, "-e", env, "-k", "--verbose")
 	} else {
-		output, err = base.Execute(t, "export-api", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
+		output, err = base.Execute(t, "export", "api", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
 	}
 
 	t.Cleanup(func() {
-		base.RemoveAPIArchive(t, getEnvAPIExportPath(env), name, version)
+		base.RemoveAPIArchive(t, GetEnvAPIExportPath(env), name, version)
 	})
 
 	return output, err
 }
 
 func ValidateAllApisOfATenantIsExported(t *testing.T, args *ApiImportExportTestArgs, apisAdded int) {
-	output, error := ExportAllApisOfATenant(t, args)
+	output, error := exportAllApisOfATenant(t, args)
 	assert.Nil(t, error, "Error while exporting APIs")
 	assert.Contains(t, output, "export-apis execution completed", "Error while exporting APIs")
 
@@ -184,7 +184,7 @@ func ValidateAllApisOfATenantIsExported(t *testing.T, args *ApiImportExportTestA
 func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 	fileName := base.GetAPIArchiveFilePath(t, args.SrcAPIM.GetEnvName(), args.Api.Name, args.Api.Version)
 
-	params := []string{"import-api", "-f", fileName, "-e", args.DestAPIM.EnvName, "-k", "--verbose"}
+	params := []string{"import", "api", "-f", fileName, "-e", args.DestAPIM.EnvName, "-k", "--verbose"}
 
 	if args.OverrideProvider {
 		params = append(params, "--preserve-provider=false")
@@ -210,12 +210,12 @@ func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 
 func importAPIPreserveProviderFailure(t *testing.T, sourceEnv string, api *apim.API, client *apim.Client) (string, error) {
 	fileName := base.GetAPIArchiveFilePath(t, sourceEnv, api.Name, api.Version)
-	output, err := base.Execute(t, "import-api", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "import", "api", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
 	return output, err
 }
 
 func listAPIs(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
-	output, err := base.Execute(t, "list", "apis", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "get", "apis", "-e", args.SrcAPIM.EnvName, "-k", "--verbose")
 	return output, err
 }
 
@@ -237,7 +237,7 @@ func ValidateAPIExportFailure(t *testing.T, args *ApiImportExportTestArgs) {
 	exportAPI(t, args.Api.Name, args.Api.Version, args.ApiProvider.Username, args.SrcAPIM.GetEnvName())
 
 	// Validate that export failed
-	assert.False(t, base.IsAPIArchiveExists(t, getEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+	assert.False(t, base.IsAPIArchiveExists(t, GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
 		args.Api.Name, args.Api.Version))
 }
 
@@ -253,7 +253,7 @@ func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	exportAPI(t, args.Api.Name, args.Api.Version, args.Api.Provider, args.SrcAPIM.GetEnvName())
 
-	assert.True(t, base.IsAPIArchiveExists(t, getEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+	assert.True(t, base.IsAPIArchiveExists(t, GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
 		args.Api.Name, args.Api.Version))
 
 	// Import api to env 2
@@ -261,11 +261,11 @@ func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	importAPI(t, args)
 
-	// Give time for newly imported API to get indexed, or else getAPI by name will fail
+	// Give time for newly imported API to get indexed, or else GetAPI by name will fail
 	base.WaitForIndexing()
 
 	// Get App from env 2
-	importedAPI := getAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
+	importedAPI := GetAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
 
 	// Validate env 1 and env 2 API is equal
 	ValidateAPIsEqual(t, args.Api, importedAPI)
@@ -283,7 +283,7 @@ func ValidateAPIExport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	exportAPI(t, args.Api.Name, args.Api.Version, args.ApiProvider.Username, args.SrcAPIM.GetEnvName())
 
-	assert.True(t, base.IsAPIArchiveExists(t, getEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+	assert.True(t, base.IsAPIArchiveExists(t, GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
 		args.Api.Name, args.Api.Version))
 }
 
@@ -299,11 +299,11 @@ func GetImportedAPI(t *testing.T, args *ApiImportExportTestArgs) *apim.API {
 		t.Fatal(err)
 	}
 
-	// Give time for newly imported API to get indexed, or else getAPI by name will fail
+	// Give time for newly imported API to get indexed, or else GetAPI by name will fail
 	base.WaitForIndexing()
 
 	// Get App from env 2
-	importedAPI := getAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
+	importedAPI := GetAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
 
 	return importedAPI
 }
@@ -330,11 +330,11 @@ func ValidateAPIImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	importAPI(t, args)
 
-	// Give time for newly imported API to get indexed, or else getAPI by name will fail
+	// Give time for newly imported API to get indexed, or else GetAPI by name will fail
 	base.WaitForIndexing()
 
 	// Get App from env 2
-	importedAPI := getAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
+	importedAPI := GetAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
 
 	// Validate env 1 and env 2 API is equal
 	validateAPIsEqualCrossTenant(t, args.Api, importedAPI)
@@ -394,10 +394,10 @@ func ValidateAPIsList(t *testing.T, args *ApiImportExportTestArgs) {
 
 	apisList := args.SrcAPIM.GetAPIs()
 
-	validateListAPIsEqual(t, output, apisList)
+	ValidateListAPIsEqual(t, output, apisList)
 }
 
-func validateListAPIsEqual(t *testing.T, apisListFromCtl string, apisList *apim.APIList) {
+func ValidateListAPIsEqual(t *testing.T, apisListFromCtl string, apisList *apim.APIList) {
 	unmatchedCount := apisList.Count
 	for _, api := range apisList.List {
 		// If the output string contains the same API ID, then decrement the count
@@ -487,10 +487,10 @@ func ValidateAPIDeleteFailure(t *testing.T, args *ApiImportExportTestArgs) {
 }
 
 func exportApiImportedFromProject(t *testing.T, APIName string, APIVersion string, EnvName string) (string, error) {
-	return base.Execute(t, "export-api", "-n", APIName, "-v", APIVersion, "-e", EnvName)
+	return base.Execute(t, "export", "apis", "-n", APIName, "-v", APIVersion, "-e", EnvName)
 }
 
-func ExportAllApisOfATenant(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
+func exportAllApisOfATenant(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 	//Setup environment
 	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
 	//Login to the environmeTestImportAndExportAPIWithJpegImagent
@@ -498,7 +498,7 @@ func ExportAllApisOfATenant(t *testing.T, args *ApiImportExportTestArgs) (string
 
 	base.WaitForIndexing()
 
-	output, error := base.Execute(t, "export-apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force")
+	output, error := base.Execute(t, "export", "apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force")
 	return output, error
 }
 
@@ -510,7 +510,7 @@ func validateAPIIsDeleted(t *testing.T, api *apim.API, apisListAfterDelete *apim
 
 func ImportApiFromProject(t *testing.T, projectName string, client *apim.Client, apiName string, credentials *Credentials, isCleanup bool) (string, error) {
 	projectPath, _ := filepath.Abs(projectName)
-	output, err := base.Execute(t, "import-api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--verbose")
+	output, err := base.Execute(t, "import", "api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--verbose")
 
 	base.WaitForIndexing()
 
@@ -531,7 +531,7 @@ func ImportApiFromProject(t *testing.T, projectName string, client *apim.Client,
 
 func ImportApiFromProjectWithUpdate(t *testing.T, projectName string, client *apim.Client, apiName string, credentials *Credentials, isCleanup bool) (string, error) {
 	projectPath, _ := filepath.Abs(projectName)
-	output, err := base.Execute(t, "import-api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--update", "--verbose")
+	output, err := base.Execute(t, "import", "api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--update", "--verbose")
 
 	base.WaitForIndexing()
 
@@ -551,7 +551,7 @@ func ImportApiFromProjectWithUpdate(t *testing.T, projectName string, client *ap
 }
 
 func ExportApisWithOneCommand(t *testing.T, args *InitTestArgs) (string, error) {
-	output, error := base.Execute(t, "export-apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force", "--verbose")
+	output, error := base.Execute(t, "export", "apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force", "--verbose")
 	return output, error
 }
 
@@ -573,7 +573,7 @@ func ValidateChangeLifeCycleStatusOfAPI(t *testing.T, args *ApiChangeLifeCycleSt
 
 	base.WaitForIndexing()
 	//Assert life cycle state after change
-	api := getAPI(t, args.APIM, args.Api.Name, args.CtlUser.Username, args.CtlUser.Password)
+	api := GetAPI(t, args.APIM, args.Api.Name, args.CtlUser.Username, args.CtlUser.Password)
 	assert.Equal(t, args.ExpectedState, api.LifeCycleStatus, "Expected Life cycle state change is not equals to actual status")
 }
 

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -138,7 +138,7 @@ func UnsubscribeAPI(client *apim.Client, username string, password string, apiID
 	client.DeleteSubscriptions(apiID)
 }
 
-func getResourceURL(apim *apim.Client, api *apim.API) string {
+func GetResourceURL(apim *apim.Client, api *apim.API) string {
 	port := 8280 + apim.GetPortOffset()
 	return "http://" + apim.GetHost() + ":" + strconv.Itoa(port) + api.Context + "/" + api.Version + "/menu"
 }

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -44,20 +44,20 @@ func AddApplicationWithoutCleaning(t *testing.T, client *apim.Client, username s
 	return application
 }
 
-func getApp(t *testing.T, client *apim.Client, name string, username string, password string) *apim.Application {
+func GetApp(t *testing.T, client *apim.Client, name string, username string, password string) *apim.Application {
 	client.Login(username, password)
 	appInfo := client.GetApplicationByName(name)
 	return client.GetApplication(appInfo.ApplicationID)
 }
 
 func ListApps(t *testing.T, env string) []string {
-	response, _ := base.Execute(t, "list", "apps", "-e", env, "-k")
+	response, _ := base.Execute(t, "get", "apps", "-e", env, "-k")
 
 	return base.GetRowsFromTableResponse(response)
 }
 
 func ListAppsWithOwner(t *testing.T, env string, owner string) []string {
-	response, _ := base.Execute(t, "list", "apps", "-e", env, "-k", "--owner", owner)
+	response, _ := base.Execute(t, "gets", "apps", "-e", env, "-k", "--owner", owner)
 
 	return base.GetRowsFromTableResponse(response)
 }
@@ -67,7 +67,7 @@ func getEnvAppExportPath(envName string) string {
 }
 
 func exportApp(t *testing.T, name string, owner string, env string) (string, error) {
-	output, err := base.Execute(t, "export-app", "-n", name, "-o", owner, "-e", env, "-k", "--verbose")
+	output, err := base.Execute(t, "export", "app", "-n", name, "-o", owner, "-e", env, "-k", "--verbose")
 
 	t.Cleanup(func() {
 		base.RemoveApplicationArchive(t, getEnvAppExportPath(env), name, owner)
@@ -78,7 +78,7 @@ func exportApp(t *testing.T, name string, owner string, env string) (string, err
 
 func importAppPreserveOwner(t *testing.T, sourceEnv string, app *apim.Application, client *apim.Client) (string, error) {
 	fileName := base.GetApplicationArchiveFilePath(t, sourceEnv, app.Name, app.Owner)
-	output, err := base.Execute(t, "import-app", "--preserveOwner=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "import", "app", "--preserveOwner=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
 
 	t.Cleanup(func() {
 		client.DeleteApplicationByName(app.Name)
@@ -89,7 +89,7 @@ func importAppPreserveOwner(t *testing.T, sourceEnv string, app *apim.Applicatio
 
 func importAppPreserveOwnerAndUpdate(t *testing.T, sourceEnv string, app *apim.Application, client *apim.Client) (string, error) {
 	fileName := base.GetApplicationArchiveFilePath(t, sourceEnv, app.Name, app.Owner)
-	output, err := base.Execute(t, "import-app", "--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
+	output, err := base.Execute(t, "import", "app", "--preserveOwner=true", "--update=true", "-f", fileName, "-e", client.EnvName, "-k", "--verbose")
 
 	return output, err
 }
@@ -131,10 +131,10 @@ func ValidateAppExportImportWithPreserveOwner(t *testing.T, args *AppImportExpor
 	importAppPreserveOwner(t, args.SrcAPIM.GetEnvName(), args.Application, args.DestAPIM)
 
 	// Get App from env 2
-	importedApp := getApp(t, args.DestAPIM, args.Application.Name, args.AppOwner.Username, args.AppOwner.Password)
+	importedApp := GetApp(t, args.DestAPIM, args.Application.Name, args.AppOwner.Username, args.AppOwner.Password)
 
 	// Validate env 1 and env 2 App is equal
-	validateAppsEqual(t, args.Application, importedApp)
+	ValidateAppsEqual(t, args.Application, importedApp)
 }
 
 func ValidateAppExportImportWithUpdate(t *testing.T, args *AppImportExportTestArgs) {
@@ -158,13 +158,13 @@ func ValidateAppExportImportWithUpdate(t *testing.T, args *AppImportExportTestAr
 	importAppPreserveOwnerAndUpdate(t, args.SrcAPIM.GetEnvName(), args.Application, args.DestAPIM)
 
 	// Get App from env 2
-	importedApp := getApp(t, args.DestAPIM, args.Application.Name, args.AppOwner.Username, args.AppOwner.Password)
+	importedApp := GetApp(t, args.DestAPIM, args.Application.Name, args.AppOwner.Username, args.AppOwner.Password)
 
 	// Validate env 1 and env 2 App is equal
-	validateAppsEqual(t, args.Application, importedApp)
+	ValidateAppsEqual(t, args.Application, importedApp)
 }
 
-func validateAppsEqual(t *testing.T, app1 *apim.Application, app2 *apim.Application) {
+func ValidateAppsEqual(t *testing.T, app1 *apim.Application, app2 *apim.Application) {
 	t.Helper()
 
 	app1Copy := apim.CopyApp(app1)

--- a/import-export-cli/integration/testutils/keys_testUtils.go
+++ b/import-export-cli/integration/testutils/keys_testUtils.go
@@ -30,10 +30,10 @@ import (
 )
 
 func GetKeys(t *testing.T, provider string, name string, version string, env string) (string, error) {
-	return base.Execute(t, "get-keys", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
+	return base.Execute(t, "get", "keys", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
 }
 
-func invokeAPI(t *testing.T, url string, key string, expectedCode int) {
+func InvokeAPI(t *testing.T, url string, key string, expectedCode int) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
@@ -46,7 +46,7 @@ func invokeAPI(t *testing.T, url string, key string, expectedCode int) {
 	authHeader := "Bearer " + key
 	req.Header.Set("Authorization", authHeader)
 
-	t.Log("invokeAPI() url", url)
+	t.Log("InvokeAPI() url", url)
 
 	response, err := client.Do(req)
 
@@ -111,7 +111,7 @@ func ValidateGetKeys(t *testing.T, args *ApiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		invokeAPI(t, getResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
+		InvokeAPI(t, GetResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
 		UnsubscribeAPI(args.Apim, args.CtlUser.Username, args.CtlUser.Password, args.Api.ID)
 	}
 
@@ -144,7 +144,7 @@ func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		invokeAPI(t, getResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
+		InvokeAPI(t, GetResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
 	}
 
 	if args.ApiProduct != nil {


### PR DESCRIPTION
## Purpose
With [1] and [2], some of the existing commands of the API Controller got revamped. The integration tests need to be modified to match with those.

## Goals
Modify integration tests to match with the revamped commands and write test for deprecated commands.

## Approach
Changed the commands to be executed in the integrations tests for the below commands.
- get apis
- get api-products
- get apps
- get envs
- add env
- import api
- import app
- export api
- export app
- get keys

## Related PRs
- [1] https://github.com/wso2/product-apim-tooling/pull/515
- [2] https://github.com/wso2/product-apim-tooling/pull/518

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64