### PR TITLE
Changing "availableTiers" field to a string array

### DIFF
--- a/import-export-cli/specs/v2/apiproductspec.go
+++ b/import-export-cli/specs/v2/apiproductspec.go
@@ -29,7 +29,7 @@ type APIProductDefinition struct {
 	Tags                               []string             `json:"tags" yaml:"tags,omitempty"`
 	Documents                          []interface{}        `json:"documents,omitempty" yaml:"documents,omitempty"`
 	LastUpdated                        string               `json:"lastUpdated,omitempty" yaml:"lastUpdated,omitempty"`
-	AvailableTiers                     []AvailableTiers     `json:"availableTiers,omitempty" yaml:"availableTiers,omitempty"`
+	AvailableTiers                     []string             `json:"availableTiers,omitempty" yaml:"availableTiers,omitempty"`
 	AvailableSubscriptionLevelPolicies []interface{}        `json:"availableSubscriptionLevelPolicies,omitempty" yaml:"availableSubscriptionLevelPolicies,omitempty"`
 	ProductResources                   []APIProductResource `json:"productResources" yaml:"productResources,omitempty"`
 	State                              string               `json:"state,omitempty" yaml:"state,omitempty"`

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -35,7 +35,7 @@ type APIDefinition struct {
 	Tags                               []string           `json:"tags" yaml:"tags,omitempty"`
 	Documents                          []interface{}      `json:"documents,omitempty" yaml:"documents,omitempty"`
 	LastUpdated                        string             `json:"lastUpdated,omitempty" yaml:"lastUpdated,omitempty"`
-	AvailableTiers                     []AvailableTiers   `json:"availableTiers,omitempty" yaml:"availableTiers,omitempty"`
+	AvailableTiers                     []string           `json:"availableTiers,omitempty" yaml:"availableTiers,omitempty"`
 	AvailableSubscriptionLevelPolicies []interface{}      `json:"availableSubscriptionLevelPolicies,omitempty" yaml:"availableSubscriptionLevelPolicies,omitempty"`
 	URITemplates                       []URITemplates     `json:"uriTemplates" yaml:"uriTemplates,omitempty"`
 	APIHeaderChanged                   bool               `json:"apiHeaderChanged,omitempty" yaml:"apiHeaderChanged,omitempty"`
@@ -80,17 +80,6 @@ type ID struct {
 	ProviderName string `json:"providerName" yaml:"providerName"`
 	APIName      string `json:"apiName" yaml:"apiName"`
 	Version      string `json:"version" yaml:"version"`
-}
-type AvailableTiers struct {
-	Name               string `json:"name,omitempty" yaml:"name,omitempty"`
-	DisplayName        string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
-	Description        string `json:"description,omitempty" yaml:"description,omitempty"`
-	RequestsPerMin     int    `json:"requestsPerMin,omitempty" yaml:"requestsPerMin,omitempty"`
-	RequestCount       int    `json:"requestCount,omitempty" yaml:"requestCount,omitempty"`
-	UnitTime           int    `json:"unitTime,omitempty" yaml:"unitTime,omitempty"`
-	TimeUnit           string `json:"timeUnit,omitempty" yaml:"timeUnit,omitempty"`
-	TierPlan           string `json:"tierPlan,omitempty" yaml:"tierPlan,omitempty"`
-	StopOnQuotaReached bool   `json:"stopOnQuotaReached,omitempty" yaml:"stopOnQuotaReached,omitempty"`
 }
 type Scopes struct {
 	Key         string `json:"key,omitempty" yaml:"key,omitempty"`


### PR DESCRIPTION
## Purpose
Remove the **AvailableTiers** struct.

## Goals
Removing the unneccasry structs due to https://github.com/wso2/carbon-apimgt/pull/9366

## Approach
- Made **availableTiers** field a string array, which was earlier an **AvailableTiers** array in APIDefinition and APIProductDefinition structs.
- Removed the **AvailableTiers** struct.

## User stories
Use cases addressed in https://github.com/wso2/carbon-apimgt/pull/9366

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/9366

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64