### PR TITLE
Changing the type of the "availableTiers" array in default_api.yaml

### DIFF
--- a/import-export-cli/box/resources/init/default_api.yaml
+++ b/import-export-cli/box/resources/init/default_api.yaml
@@ -5,7 +5,7 @@ id:
 context:
 type: HTTP
 availableTiers:
-  - name: Unlimited
+  - Unlimited
 status: CREATED
 visibility: public
 transports: http,https


### PR DESCRIPTION
## Purpose
Fixes the below "apictl init" error which arises because of the type mismatch of the **APIDefinition.availableTiers** field and the **availableTiers** field in the default_api.yaml.

```
wasura@wasura:~/Desktop$ apictl init Petstore --oas https://petstore.swagger.io/v2/swagger.json
Initializing a new WSO2 API Manager project in /home/wasura/Desktop/Petstore
apictl: Error initializing project Reason: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go struct field APIDefinition.availableTiers of type string
Removing the project directory /home/wasura/Desktop/Petstore with its content
```

## Goals
Add the changes which were missed in https://github.com/wso2/product-apim-tooling/pull/525

## Approach
Change the **availableTiers** field to a string array which was earlier an object array.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/525

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64