### PR TITLE
[2.x] Supporiting missing parameters for endpoint configs via params file

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -18,6 +18,18 @@ type Configuration struct {
 	RetryDelay *int `yaml:"retryDelay" json:"retryDelay,string"`
 	// Factor used for config
 	Factor *int `yaml:"factor" json:"factor,string"`
+	// RetryErroCode used for config
+	RetryErroCode *int `yaml:"retryErroCode" json:"retryErroCode,string"`
+	// SuspendErrorCode used for config
+	SuspendErrorCode *int `yaml:"suspendErrorCode" json:"suspendErrorCode,string"`
+	// SuspendDuration used for config
+	SuspendDuration *int `yaml:"suspendDuration" json:"suspendDuration,string"`
+	// SuspendMaxDuration used for config
+	SuspendMaxDuration *int `yaml:"suspendMaxDuration" json:"suspendMaxDuration,string"`
+	// ActionSelect used for config
+	ActionSelect *string `yaml:"actionSelect" json:"actionSelect"`
+	// ActionDuration used for config
+	ActionDuration *int `yaml:"actionDuration" json:"actionDuration,string"`
 }
 
 // Endpoint details


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/546

## Goals
Supporting the parameters **retryErroCode**, **suspendErrorCode**, **suspendDuration**, **suspendMaxDuration**, **actionSelect** and **actionDuration** to be configured through the params file.

## Approach
Added the above stated missing parameters to the struct **Configuration**

## User stories
Use case mentioned in https://github.com/wso2/product-apim-tooling/issues/546 is supported now.

## Release note
This will be released with APIMCLI 2.0.11 patch release.

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64