### PR TITLE
[WIP] Merge mi cli commands with apictl

### DIFF
--- a/import-export-cli/cmd/add.go
+++ b/import-export-cli/cmd/add.go
@@ -28,12 +28,16 @@ const AddCmdLongDesc = `Add new environment and its related endpoints to the con
 const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
 --apim  https://localhost:9443 
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+--mi  https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
 --token https://gw.com:8243/token
+--mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --apim https://apim.com:9443 \
@@ -43,7 +47,8 @@ const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmd
 NOTE: The flag --environment (-e) is mandatory.
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
-cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.`
 
 // AddCmd represents the add command
 var AddCmd = &cobra.Command{

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -32,6 +32,7 @@ var flagDevPortalEndpoint string    // DevPortal endpoint of the environment to 
 var flagRegistrationEndpoint string // registration endpoint of the environment to be added
 var flagApiManagerEndpoint string   // api manager endpoint of the environment to be added
 var flagAdminEndpoint string        // admin endpoint of the environment to be added
+var flagMiManagementEndpoint string // mi management endpoint of the environment to be added
 
 // AddEnv command related Info
 const AddEnvCmdLiteral = "env [environment]"
@@ -41,12 +42,16 @@ const addEnvCmdLongDesc = "Add new environment and its related endpoints to the 
 const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
 --apim  https://localhost:9443 
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+--mi https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
 --token https://gw.com:8243/token
+--mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --apim https://apim.com:9443 \
@@ -55,7 +60,8 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnv
 
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
-cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.`
 
 // addEnvCmd represents the addEnv command
 var addEnvCmd = &cobra.Command{
@@ -81,6 +87,7 @@ func executeAddEnvCmd(mainConfigFilePath string) {
 	envEndpoints.DevPortalEndpoint = flagDevPortalEndpoint
 	envEndpoints.AdminEndpoint = flagAdminEndpoint
 	envEndpoints.TokenEndpoint = flagTokenEndpoint
+	envEndpoints.MiManagementEndpoint = flagMiManagementEndpoint
 	err := impl.AddEnv(envToBeAdded, envEndpoints, mainConfigFilePath, AddEnvCmdLiteral)
 	if err != nil {
 		utils.HandleErrorAndExit("Error adding environment", err)
@@ -98,5 +105,6 @@ func init() {
 	addEnvCmd.Flags().StringVar(&flagRegistrationEndpoint, "registration", "",
 		"Registration endpoint for the environment")
 	addEnvCmd.Flags().StringVar(&flagAdminEndpoint, "admin", "", "Admin endpoint for the environment")
+	addEnvCmd.Flags().StringVar(&flagMiManagementEndpoint, "mi", "", "Micro Integrator Management endpoint for the environment")
 	_ = addEnvCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/deprecated/listEnvs.go
+++ b/import-export-cli/cmd/deprecated/listEnvs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}"
+const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}\t{{.MiManagementEndpoint}}"
 
 var envsCmdFormat string
 

--- a/import-export-cli/cmd/getEnvs.go
+++ b/import-export-cli/cmd/getEnvs.go
@@ -24,7 +24,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}"
+const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}\t{{.MiManagementEndpoint}}"
 
 var envsCmdFormat string
 

--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -83,10 +83,7 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 		// remove keys also if user has already logged into this environment
 		store, err := credentials.GetDefaultCredentialStore()
 		if store.Has(envName) {
-			err = runLogout(envName)
-			if err != nil {
-				utils.Logln("Log out is unsuccessful. ", err)
-			}
+			runLogout(envName)
 		}
 
 		// remove env from mainConfig file (endpoints file)

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -31,7 +31,7 @@ import (
 // DefaultConfigFile name
 var DefaultConfigFile = "keys.json"
 
-// Credential for storing user details
+// Credential for storing apim user details
 type Credential struct {
 	// Username of user
 	Username string `json:"username"`
@@ -46,9 +46,15 @@ type Credential struct {
 // Credentials of cli
 type Credentials struct {
 	// Environments specific credentials
-	Environments map[string]Credential `json:"environments"`
+	Environments map[string]Environment `json:"environments"`
 	// CredStore represent type of store to be used
 	CredStore string `json:"credStore,omitempty"`
+}
+
+// Environment containing credentials of apim and mi
+type Environment struct {
+	APIM Credential   `json:"apim"`
+	MI   MiCredential `json:"mi"`
 }
 
 // GetCredentialStore from file

--- a/import-export-cli/credentials/miCredentials.go
+++ b/import-export-cli/credentials/miCredentials.go
@@ -1,0 +1,174 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package credentials
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"syscall"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// MiCredential for storing mi user details
+type MiCredential struct {
+	// Username of mi user
+	Username string `json:"username"`
+	// Password of mi user
+	Password string `json:"password"`
+	// AccessToken of mi
+	AccessToken string `json:"accessToken"`
+}
+
+// GetMICredentials returns credentials for mi
+func GetMICredentials(env string) (MiCredential, error) {
+
+	store, err := GetDefaultCredentialStore()
+	if err != nil {
+		return MiCredential{}, err
+	}
+
+	if !utils.MIExistsInEnv(env, utils.MainConfigFilePath) {
+		fmt.Println("MI instance does not exists in", env, "Add it using add env")
+		os.Exit(1)
+	}
+
+	if !store.Has(env) {
+
+		fmt.Println("Login to MI in", env)
+		err = RunMILogin(store, env, "", "")
+		if err != nil {
+			return MiCredential{}, err
+		}
+		fmt.Println()
+	}
+	cred, err := store.GetMICredentials(env)
+	if err != nil {
+		return MiCredential{}, err
+	}
+	return cred, nil
+}
+
+// UpdateMIAccessToken updates the access token for mi
+func UpdateMIAccessToken(env, accessToken string) error {
+
+	store, err := GetDefaultCredentialStore()
+	if err != nil {
+		return err
+	}
+	cred, err := store.GetMICredentials(env)
+	if err != nil {
+		return err
+	}
+	return store.SetMICredentials(env, cred.Username, cred.Password, accessToken)
+}
+
+// GetOAuthAccessTokenForMI returns access token for mi
+func GetOAuthAccessTokenForMI(username, password, env string) (string, error) {
+
+	b64encodedCredentials := Base64Encode(username + ":" + password)
+
+	tokenEndpoint := utils.GetMIManagementEndpointOfResource(utils.MiManagementMiLoginResource, env, utils.MainConfigFilePath)
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+
+	resp, err := utils.InvokeGETRequest(tokenEndpoint, headers)
+	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenEndpoint)
+
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return "", errors.New("Unable to connect to MI Token endpoint. Status: " + resp.Status())
+	}
+	responseDataMap := make(map[string]string)
+	data := []byte(resp.Body())
+	unmarshalError := json.Unmarshal(data, &responseDataMap)
+
+	if unmarshalError != nil {
+		return "", unmarshalError
+	}
+	if accessToken, ok := responseDataMap["AccessToken"]; ok {
+		return accessToken, nil
+	}
+	return "", errors.New("AccessToken not found")
+}
+
+// RevokeAccessTokenForMI revokes the mi management token when the user log out from the environment
+func RevokeAccessTokenForMI(env, token string) error {
+
+	tokenRevokeEndpoint := utils.GetMIManagementEndpointOfResource(utils.MiManagementMiLogoutResource, env, utils.MainConfigFilePath)
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + token
+
+	resp, err := utils.InvokeGETRequest(tokenRevokeEndpoint, headers)
+	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenRevokeEndpoint)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return errors.New("Error logging out of the MI in " + env + "Status: " + resp.Status())
+	}
+
+	return nil
+}
+
+// RunMILogin prompt user to input MI management API username and password
+func RunMILogin(store Store, environment, username, password string) error {
+
+	if username == "" {
+		fmt.Print("MI Username:")
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			username = scanner.Text()
+		}
+	}
+
+	if password == "" {
+		fmt.Print("MI Password:")
+		pass, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		password = string(pass)
+		fmt.Println()
+	}
+
+	accessToken, err := GetOAuthAccessTokenForMI(username, password, environment)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Logged into MI in", environment, "environment")
+	err = store.SetMICredentials(environment, username, password, accessToken)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/import-export-cli/credentials/store.go
+++ b/import-export-cli/credentials/store.go
@@ -23,10 +23,16 @@ type Store interface {
 	Has(env string) bool
 	// Get an env from store returns intended Credential or an error
 	Get(env string) (Credential, error)
+	// Get an env from store returns intended Credential or an error
+	GetMICredentials(env string) (MiCredential, error)
 	// Set credentials for env using given username,password,clientId,clientSecret
-	Set(env, username, password, clientId, clientSecret string) error
+	SetMICredentials(env, username, password, accessToken string) error
+	// Set credentials for env using given username,password,clientId,clientSecret
+	Set(env, username, password, clientID, clientSecret string) error
 	// Erase credentials from given env
 	Erase(env string) error
+	// Erase mi credentials from given env
+	EraseMI(env string) error
 	// Load store
 	Load() error
 }

--- a/import-export-cli/impl/addEnv.go
+++ b/import-export-cli/impl/addEnv.go
@@ -53,11 +53,11 @@ func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath
 	}
 
 	if envEndpoints.ApiManagerEndpoint == "" {
-		if envEndpoints.AdminEndpoint == "" || envEndpoints.DevPortalEndpoint == "" ||
-			envEndpoints.PublisherEndpoint == "" || envEndpoints.RegistrationEndpoint == "" ||
-			envEndpoints.TokenEndpoint == "" {
-			utils.ShowHelpCommandTip(addEnvCmdLiteral)
-			return errors.New("Endpoint(s) cannot be blank")
+		if !utils.HasOnlyMIEndpoint(envEndpoints) {
+			if !utils.RequiredAPIMEndpointsExists(envEndpoints) {
+				utils.ShowHelpCommandTip(addEnvCmdLiteral)
+				return errors.New("Endpoint(s) cannot be blank")
+			}
 		}
 	}
 
@@ -90,6 +90,10 @@ func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath
 
 	if envEndpoints.AdminEndpoint != "" {
 		validatedEnvEndpoints.AdminEndpoint = envEndpoints.AdminEndpoint
+	}
+
+	if envEndpoints.MiManagementEndpoint != "" {
+		validatedEnvEndpoints.MiManagementEndpoint = envEndpoints.MiManagementEndpoint
 	}
 
 	mainConfig.Environments[envName] = validatedEnvEndpoints

--- a/import-export-cli/impl/getEnvs.go
+++ b/import-export-cli/impl/getEnvs.go
@@ -36,6 +36,7 @@ const (
 	envsAdminEndpointHeader        = "ADMIN ENDPOINT"
 	envsApiManagerEndpoint         = "API MANAGER ENDPOINT"
 	envsApplicationEndpoint        = "DEVPORTAL ENDPOINT"
+	envsMiManagementEndpoint       = "MI MANAGEMENT ENDPOINT"
 )
 
 // endpoint contains information about endpoint of API Manager
@@ -47,6 +48,7 @@ type endpoints struct {
 	adminEndpoint        string
 	apiManagerEndpoint   string
 	applicationEndpoint  string
+	miManagementEndpoint string
 }
 
 func newEndpointFromEnvEndpoints(name string, e utils.EnvEndpoints) *endpoints {
@@ -58,6 +60,7 @@ func newEndpointFromEnvEndpoints(name string, e utils.EnvEndpoints) *endpoints {
 		publisherEndpoint:    e.PublisherEndpoint,
 		registrationEndpoint: e.RegistrationEndpoint,
 		tokenEndpoint:        e.TokenEndpoint,
+		miManagementEndpoint: e.MiManagementEndpoint,
 	}
 }
 
@@ -96,6 +99,11 @@ func (e endpoints) AdminEndpoint() string {
 	return e.adminEndpoint
 }
 
+// AdminEndpoint
+func (e endpoints) MiManagementEndpoint() string {
+	return e.miManagementEndpoint
+}
+
 // MarshalJSON returns marshaled methods
 func (e *endpoints) MarshalJSON() ([]byte, error) {
 	return formatter.MarshalJSON(e)
@@ -130,6 +138,7 @@ func PrintEnvs(envData map[string]utils.EnvEndpoints, format, defaulEnvsTableFor
 		"AdminEndpoint":        envsAdminEndpointHeader,
 		"ApiManagerEndpoint":   envsApiManagerEndpoint,
 		"ApplicationEndpoint":  envsApplicationEndpoint,
+		"MiManagementEndpoint": envsMiManagementEndpoint,
 	}
 
 	// execute context

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -32,11 +32,12 @@ var CurrentDir, _ = os.Getwd()
 const ConfigDirName = ".wso2apictl"
 
 var HomeDirectory = getConfigHomeDir()
+
 func getConfigHomeDir() string {
 	value := os.Getenv("APICTL_CONFIG_DIR")
 	if len(value) == 0 {
 		value, err := os.UserHomeDir()
-		if len(value) == 0 || err != nil  {
+		if len(value) == 0 || err != nil {
 			current, err := user.Current()
 			if err != nil || current == nil {
 				HandleErrorAndExit("User's HOME folder location couldn't be identified", nil)
@@ -193,3 +194,34 @@ const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"
 const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
 const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
 const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
+
+const MiCmdLiteral = "mi"
+
+// MiManagementAPIContext
+const MiManagementAPIContext = "management"
+
+// Mi Management Resource paths
+const MiManagementCarbonAppResource = "applications"
+const MiManagementServiceResource = "services"
+const MiManagementAPIResource = "apis"
+const MiManagementProxyServiceResource = "proxy-services"
+const MiManagementInboundEndpointResource = "inbound-endpoints"
+const MiManagementEndpointResource = "endpoints"
+const MiManagementMessageProcessorResource = "message-processors"
+const MiManagementTemplateResource = "templates"
+const MiManagementConnectorResource = "connectors"
+const MiManagementMessageStoreResource = "message-stores"
+const MiManagementLocalEntrieResource = "local-entries"
+const MiManagementSequenceResource = "sequences"
+const MiManagementTaskResource = "tasks"
+const MiManagementLogResource = "logs"
+const MiManagementLoggingResource = "logging"
+const MiManagementServerResource = "server"
+const MiManagementDataServiceResource = "data-services"
+const MiManagementMiLoginResource = "login"
+const MiManagementMiLogoutResource = "logout"
+const MiManagementUserResource = "users"
+const MiManagementTransactionResource = "transactions"
+
+// MiHTTPRetryCount default retry count for HTTP calls
+const MiHTTPRetryCount = 2

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -381,3 +381,39 @@ func HasOnlyMIEndpoint(envEndpoints *EnvEndpoints) bool {
 		envEndpoints.PublisherEndpoint == "" && envEndpoints.RegistrationEndpoint == "" &&
 		envEndpoints.TokenEndpoint == "" && envEndpoints.MiManagementEndpoint != ""
 }
+
+// GetMIManagementEndpointOfEnv return the Mi Management Endpoint of a given environment
+func GetMIManagementEndpointOfEnv(env, filePath string) (string, error) {
+	envEndpoints, err := GetEndpointsOfEnvironment(env, filePath)
+	if err != nil {
+		return "", err
+	}
+	return envEndpoints.MiManagementEndpoint, nil
+}
+
+// GetMIManagementEndpointOfResource return the full resource url of a resource
+func GetMIManagementEndpointOfResource(resource, env, filePath string) string {
+	miEndpoint, _ := GetMIManagementEndpointOfEnv(env, filePath)
+	if strings.HasSuffix(miEndpoint, "/") {
+		return miEndpoint + MiManagementAPIContext + "/" + resource
+	}
+	return miEndpoint + "/" + MiManagementAPIContext + "/" + resource
+}
+
+// MIExistsInEnv check wether there is a micro integrator in the environment
+func MIExistsInEnv(env, filePath string) bool {
+	miEndpoint, err := GetMIManagementEndpointOfEnv(env, filePath)
+	if err != nil {
+		return false
+	}
+	return miEndpoint != ""
+}
+
+// APIMExistsInEnv check wether there is a apim in the environment
+func APIMExistsInEnv(env, filePath string) bool {
+	envEndpoints, err := GetEndpointsOfEnvironment(env, filePath)
+	if err != nil {
+		return false
+	}
+	return envEndpoints.ApiManagerEndpoint != "" || RequiredAPIMEndpointsExists(envEndpoints)
+}

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -319,7 +319,7 @@ func GetDefaultEnvironment(mainConfigFilePath string) string {
 
 //get default token endpoint given from an apim endpoint
 func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
-	if strings.HasSuffix(apimEndpoint,"/"){
+	if strings.HasSuffix(apimEndpoint, "/") {
 		return apimEndpoint + defaultTokenEndPoint
 	} else {
 		return apimEndpoint + "/" + defaultTokenEndPoint
@@ -327,13 +327,13 @@ func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
 }
 
 //get default token endpoint given from a publisher endpoint
-func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
-	if strings.Contains(publisherEndpoint,"publisher"){
-		trimmedString := strings.Split(publisherEndpoint,"publisher")
+func GetTokenEndPointFromPublisherEndpoint(publisherEndpoint string) string {
+	if strings.Contains(publisherEndpoint, "publisher") {
+		trimmedString := strings.Split(publisherEndpoint, "publisher")
 		publisherEndpoint = trimmedString[0]
 	}
 
-	if strings.HasSuffix(publisherEndpoint,"/"){
+	if strings.HasSuffix(publisherEndpoint, "/") {
 		return publisherEndpoint + defaultTokenEndPoint
 	} else {
 		return publisherEndpoint + "/" + defaultTokenEndPoint
@@ -342,14 +342,14 @@ func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
 
 // Get internalTokenEndpoint for REST api operations
 // @return endpoint url derived from publisher or apim endpoint
-func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
+func GetInternalTokenEndpointOfEnv(env, filePath string) string {
 	var internalTokenEndpoint string
 	apiManagerEndpointOfEnv := GetApiManagerEndpointOfEnv(env, filePath)
 	if apiManagerEndpointOfEnv != "" {
 		internalTokenEndpoint = GetTokenEndPointFromAPIMEndpoint(apiManagerEndpointOfEnv)
 
 	} else {
-		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env,filePath)
+		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env, filePath)
 		internalTokenEndpoint = GetTokenEndPointFromPublisherEndpoint(publisherEndpointOfEnv)
 	}
 	return internalTokenEndpoint
@@ -357,11 +357,27 @@ func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
 
 //Get token endpoint for Token revocation
 //@return endpoint URL of token revocation endpoint
-func GetTokenRevokeEndpoint (env, filePath string) string {
+func GetTokenRevokeEndpoint(env, filePath string) string {
 	//Get Internal token endpoint for the environment
-	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env,filePath)
-	slittedString := strings.Split(internalTokenEndpoint,defaultTokenEndPoint)
+	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env, filePath)
+	slittedString := strings.Split(internalTokenEndpoint, defaultTokenEndPoint)
 	//Get Apim endpoint or publisher endpoint
 	extractedTokenEndpoint := slittedString[0]
 	return extractedTokenEndpoint + defaultRevokeEndpointSuffix
+}
+
+// RequiredAPIMEndpointsExists checks for required apim endpoints.
+// It returns true if all the endpoints are present
+func RequiredAPIMEndpointsExists(envEndpoints *EnvEndpoints) bool {
+	return envEndpoints.AdminEndpoint != "" && envEndpoints.DevPortalEndpoint != "" &&
+		envEndpoints.PublisherEndpoint != "" && envEndpoints.RegistrationEndpoint != "" &&
+		envEndpoints.TokenEndpoint != ""
+}
+
+// HasOnlyMIEndpoint checks wether an MI instance is present in a given environment
+// It returns true if the only instance in an environment is MI
+func HasOnlyMIEndpoint(envEndpoints *EnvEndpoints) bool {
+	return envEndpoints.AdminEndpoint == "" && envEndpoints.DevPortalEndpoint == "" &&
+		envEndpoints.PublisherEndpoint == "" && envEndpoints.RegistrationEndpoint == "" &&
+		envEndpoints.TokenEndpoint == "" && envEndpoints.MiManagementEndpoint != ""
 }

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -55,6 +55,7 @@ type EnvEndpoints struct {
 	RegistrationEndpoint string `yaml:"registration"`
 	AdminEndpoint        string `yaml:"admin"`
 	TokenEndpoint        string `yaml:"token"`
+	MiManagementEndpoint string `yaml:"mi"`
 }
 
 // ---------------- End of Structs for YAML Config Files ---------------------------------


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/1999

## Goals
- Update login, logout and env command to use micro integrator instances
- Rewamp the mi cli commands under apictl using an alias **mi**
**apitcl mi [command] [args] [flags]**

## User stories
Below figure shows the updated command tree (only the changes are shown)
![apictl command tree](https://user-images.githubusercontent.com/18748929/101725295-5f3a4a00-3ad6-11eb-8569-6b9ae1de6cbf.png)

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64