### PR TITLE
Update commands to add MI instances

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -1,7 +1,7 @@
-# CLI for Importing and Exporting APIs and Applications
+# CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 ## For WSO2 API Manager 3.2.0
 
-Command Line tool for importing and exporting APIs/Applications between different API Environments
+Command Line tool for importing and exporting APIs/Applications between different API Environments of WSO2 API Manager and Managing WSO2 Micro Integrator
 
 ## Getting Started
 
@@ -55,6 +55,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
     > The flag `--environment` (-e) is mandatory
       You can either provide only the `--apim` flag, or all the other 5 flags (`--registration` `--publisher` `--devportal` `--admin` `--token`) without providing `--apim` flag.
       If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint.
+      To add a micro integrator instance to an environment you can use the `--mi` flag.
     
 - ### Command Autocomplete
     Copy the file `shell-completions/apictl_bash_completion.sh` to `/etc/bash_completion.d/` and source it with

--- a/import-export-cli/cmd/add.go
+++ b/import-export-cli/cmd/add.go
@@ -40,7 +40,7 @@ const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmd
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
---token https://gw.com:8243/token
+--token https://gw.com:8243/token \
 --mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \

--- a/import-export-cli/cmd/add.go
+++ b/import-export-cli/cmd/add.go
@@ -28,12 +28,16 @@ const AddCmdLongDesc = `Add new environment and its related endpoints to the con
 const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
 --apim  https://localhost:9443 
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+--mi  https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
 --token https://gw.com:8243/token
+--mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --apim https://apim.com:9443 \
@@ -43,7 +47,8 @@ const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmd
 NOTE: The flag --environment (-e) is mandatory.
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
-cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.`
 
 // AddCmd represents the add command
 var AddCmd = &cobra.Command{

--- a/import-export-cli/cmd/add.go
+++ b/import-export-cli/cmd/add.go
@@ -31,6 +31,10 @@ const addCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmd
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --mi  https://localhost:9164
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` prod \
+--apim  https://apim.com:9443 \
+--mi https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -45,6 +45,10 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnv
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --mi  https://localhost:9164
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` prod \
+--apim  https://apim.com:9443 \
+--mi https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -32,6 +32,7 @@ var flagDevPortalEndpoint string    // DevPortal endpoint of the environment to 
 var flagRegistrationEndpoint string // registration endpoint of the environment to be added
 var flagApiManagerEndpoint string   // api manager endpoint of the environment to be added
 var flagAdminEndpoint string        // admin endpoint of the environment to be added
+var flagMiManagementEndpoint string // mi management endpoint of the environment to be added
 
 // AddEnv command related Info
 const AddEnvCmdLiteral = "env [environment]"
@@ -41,12 +42,16 @@ const addEnvCmdLongDesc = "Add new environment and its related endpoints to the 
 const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` production \
 --apim  https://localhost:9443 
 
+` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
+--mi  https://localhost:9164
+
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
 --token https://gw.com:8243/token
+--mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \
 --apim https://apim.com:9443 \
@@ -55,7 +60,8 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnv
 
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
-cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.`
+cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.`
 
 // addEnvCmd represents the addEnv command
 var addEnvCmd = &cobra.Command{
@@ -81,6 +87,7 @@ func executeAddEnvCmd(mainConfigFilePath string) {
 	envEndpoints.DevPortalEndpoint = flagDevPortalEndpoint
 	envEndpoints.AdminEndpoint = flagAdminEndpoint
 	envEndpoints.TokenEndpoint = flagTokenEndpoint
+	envEndpoints.MiManagementEndpoint = flagMiManagementEndpoint
 	err := impl.AddEnv(envToBeAdded, envEndpoints, mainConfigFilePath, AddEnvCmdLiteral)
 	if err != nil {
 		utils.HandleErrorAndExit("Error adding environment", err)
@@ -98,5 +105,6 @@ func init() {
 	addEnvCmd.Flags().StringVar(&flagRegistrationEndpoint, "registration", "",
 		"Registration endpoint for the environment")
 	addEnvCmd.Flags().StringVar(&flagAdminEndpoint, "admin", "", "Admin endpoint for the environment")
+	addEnvCmd.Flags().StringVar(&flagMiManagementEndpoint, "mi", "", "Micro Integrator Management endpoint for the environment")
 	_ = addEnvCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/addEnv.go
+++ b/import-export-cli/cmd/addEnv.go
@@ -54,7 +54,7 @@ const addEnvCmdExamples = utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnv
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
---token https://gw.com:8243/token
+--token https://gw.com:8243/token \
 --mi https://localhost:9164
 
 ` + utils.ProjectName + ` ` + AddCmdLiteral + ` ` + AddEnvCmdLiteralTrimmed + ` dev \

--- a/import-export-cli/cmd/deprecated/listEnvs.go
+++ b/import-export-cli/cmd/deprecated/listEnvs.go
@@ -25,7 +25,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}"
+const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}\t{{.MiManagementEndpoint}}"
 
 var envsCmdFormat string
 

--- a/import-export-cli/cmd/getEnvs.go
+++ b/import-export-cli/cmd/getEnvs.go
@@ -24,7 +24,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}"
+const defaulEnvsTableFormat = "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}\t{{.MiManagementEndpoint}}"
 
 var envsCmdFormat string
 

--- a/import-export-cli/cmd/mi/logout.go
+++ b/import-export-cli/cmd/mi/logout.go
@@ -16,7 +16,7 @@
 * under the License.
  */
 
-package cmd
+package mi
 
 import (
 	"fmt"
@@ -28,8 +28,8 @@ import (
 )
 
 const logoutCmdLiteral = "logout [environment]"
-const logoutCmdShortDesc = "Logout to from an API Manager"
-const logoutCmdLongDesc = `Logout from an API Manager environment`
+const logoutCmdShortDesc = "Logout from a Micro Integrator"
+const logoutCmdLongDesc = `Logout from a Micro Integrator`
 const logoutCmdExamples = utils.ProjectName + " logout dev"
 
 // logoutCmd represents the logout command
@@ -40,7 +40,7 @@ var logoutCmd = &cobra.Command{
 	Example: logoutCmdExamples,
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		err := runLogout(args[0])
+		err := credentials.RunMILogout(args[0])
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)
@@ -48,23 +48,7 @@ var logoutCmd = &cobra.Command{
 	},
 }
 
-func runLogout(environment string) error {
-	cred, err := GetCredentials(environment)
-	//Get current access token for
-	accessToken, err := credentials.GetOAuthAccessToken(cred, environment)
-	error := credentials.RevokeAccessToken(cred, environment, accessToken)
-	if error != nil {
-		return err
-	}
-	store, err := credentials.GetDefaultCredentialStore()
-	if err != nil {
-		return err
-	}
-	fmt.Println("Logged out from APIM in", environment, "environment")
-	return store.EraseAPIM(environment)
-}
-
 // init using Cobra
 func init() {
-	RootCmd.AddCommand(logoutCmd)
+	MICmd.AddCommand(logoutCmd)
 }

--- a/import-export-cli/cmd/mi/mi.go
+++ b/import-export-cli/cmd/mi/mi.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package mi
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const miCmdShortDesc = "Micro Integrator related commands"
+
+const miCmdLongDesc = `Micro Integrator related commands such as login, logout, get, add, update, delete, activate, deactivate.`
+
+// MICmd represents the mi command
+var MICmd = &cobra.Command{
+	Use:   utils.MiCmdLiteral,
+	Short: miCmdShortDesc,
+	Long:  miCmdLongDesc,
+	// Example: miCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + utils.MiCmdLiteral + " called")
+	},
+}
+
+func init() {
+	// MICmd.AddCommand(miGetCmd.GetCmd)
+}

--- a/import-export-cli/cmd/removeEnv.go
+++ b/import-export-cli/cmd/removeEnv.go
@@ -82,10 +82,17 @@ func removeEnv(envName, mainConfigFilePath, envKeysFilePath string) error {
 
 		// remove keys also if user has already logged into this environment
 		store, err := credentials.GetDefaultCredentialStore()
-		if store.Has(envName) {
+		if store.HasAPIM(envName) {
 			err = runLogout(envName)
 			if err != nil {
-				utils.Logln("Log out is unsuccessful. ", err)
+				utils.Logln("Log out is unsuccessful for APIM. ", err)
+			}
+		}
+
+		if store.HasMI(envName) {
+			err = credentials.RunMILogout(envName)
+			if err != nil {
+				utils.Logln("Log out is unsuccessful for MI. ", err)
 			}
 		}
 

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/box"
+	mi "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi"
 	k8sUtils "github.com/wso2/product-apim-tooling/import-export-cli/operator/utils"
 
 	"path/filepath"
@@ -48,9 +49,9 @@ var CmdResourceTenantDomain string
 var CmdForceStartFromBegin bool
 
 // RootCmd related info
-const RootCmdShortDesc = "CLI for Importing and Exporting APIs and Applications"
-const RootCmdLongDesc = utils.ProjectName + ` is a Command Line Tool for Importing and Exporting APIs and Applications between different environments of WSO2 API Manager
-(Dev, Production, Staging, QA etc.)`
+const rootCmdShortDesc = "CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator"
+const rootCmdLongDesc = utils.ProjectName + ` is a Command Line Tool for Importing and Exporting APIs and Applications between different environments of WSO2 API Manager
+(Dev, Production, Staging, QA etc.) and Managing WSO2 Micro Integrator`
 
 // This represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -63,8 +64,8 @@ var RootCmd = &cobra.Command{
 		}
 	},
 	DisableFlagParsing: isK8sEnabled(),
-	Short:              RootCmdShortDesc,
-	Long:               RootCmdLongDesc,
+	Short:              rootCmdShortDesc,
+	Long:               rootCmdLongDesc,
 	Run: func(cmd *cobra.Command, args []string) {
 		if isK8sEnabled() {
 			executeKubernetes(args...)
@@ -109,7 +110,7 @@ func init() {
 	if err != nil {
 		utils.HandleErrorAndExit("Error reading "+utils.MainConfigFilePath+".", err)
 	}
-
+	RootCmd.AddCommand(mi.MICmd)
 }
 
 // createConfigFiles() creates the ConfigDir and necessary ConfigFiles inside the user's $HOME directory

--- a/import-export-cli/credentials/credentials.go
+++ b/import-export-cli/credentials/credentials.go
@@ -31,7 +31,7 @@ import (
 // DefaultConfigFile name
 var DefaultConfigFile = "keys.json"
 
-// Credential for storing user details
+// Credential for storing apim user details
 type Credential struct {
 	// Username of user
 	Username string `json:"username"`
@@ -46,9 +46,15 @@ type Credential struct {
 // Credentials of cli
 type Credentials struct {
 	// Environments specific credentials
-	Environments map[string]Credential `json:"environments"`
+	Environments map[string]Environment `json:"environments"`
 	// CredStore represent type of store to be used
 	CredStore string `json:"credStore,omitempty"`
+}
+
+// Environment containing credentials of apim and mi
+type Environment struct {
+	APIM Credential   `json:"apim"`
+	MI   MiCredential `json:"mi"`
 }
 
 // GetCredentialStore from file

--- a/import-export-cli/credentials/jsonstore.go
+++ b/import-export-cli/credentials/jsonstore.go
@@ -62,7 +62,7 @@ func (s *JsonStore) Load() error {
 		return fmt.Errorf("%s is a directory", s.Path)
 	}
 
-	s.credentials = Credentials{Environments: make(map[string]Credential)}
+	s.credentials = Credentials{Environments: make(map[string]Environment)}
 	return nil
 }
 
@@ -79,41 +79,43 @@ func (s *JsonStore) persist() error {
 	return nil
 }
 
-// Get credential for env
-func (s *JsonStore) Get(env string) (Credential, error) {
-	if cred, ok := s.credentials.Environments[env]; ok {
-		username, err := Base64Decode(cred.Username)
+// GetAPIMCredentials returns credentials for apim from the store or an error
+func (s *JsonStore) GetAPIMCredentials(env string) (Credential, error) {
+	if environment, ok := s.credentials.Environments[env]; ok {
+		username, err := Base64Decode(environment.APIM.Username)
 		if err != nil {
 			return Credential{}, err
 		}
-		password, err := Base64Decode(cred.Password)
+		password, err := Base64Decode(environment.APIM.Password)
 		if err != nil {
 			return Credential{}, err
 		}
-		clientId, err := Base64Decode(cred.ClientId)
+		clientID, err := Base64Decode(environment.APIM.ClientId)
 		if err != nil {
 			return Credential{}, err
 		}
-		clientSecret, err := Base64Decode(cred.ClientSecret)
+		clientSecret, err := Base64Decode(environment.APIM.ClientSecret)
 		if err != nil {
 			return Credential{}, err
 		}
 		credential := Credential{
-			username, password, clientId, clientSecret,
+			username, password, clientID, clientSecret,
 		}
 		return credential, nil
 	}
-	return Credential{}, fmt.Errorf("credentials not found for %s, use login", env)
+	return Credential{}, fmt.Errorf("credentials not found for APIM in %s, use login", env)
 }
 
-// Set credentials for env using username, password, clientId, clientSecret
-func (s *JsonStore) Set(env, username, password, clientId, clientSecret string) error {
-	s.credentials.Environments[env] = Credential{
+// SetAPIMCredentials sets credentials for micro integrator using username, password, clientID and client secret
+func (s *JsonStore) SetAPIMCredentials(env, username, password, clientId, clientSecret string) error {
+	environment := s.credentials.Environments[env]
+	environment.APIM = Credential{
 		Username:     Base64Encode(username),
 		Password:     Base64Encode(password),
 		ClientId:     Base64Encode(clientId),
 		ClientSecret: Base64Encode(clientSecret),
 	}
+	s.credentials.Environments[env] = environment
 	err := s.persist()
 	if err != nil {
 		return err
@@ -122,12 +124,77 @@ func (s *JsonStore) Set(env, username, password, clientId, clientSecret string) 
 	return nil
 }
 
-// Erase an env
-func (s *JsonStore) Erase(env string) error {
-	if _, ok := s.credentials.Environments[env]; !ok {
+// GetMICredentials returns credentials for micro integrator from the store or an error
+func (s *JsonStore) GetMICredentials(env string) (MiCredential, error) {
+	if environment, ok := s.credentials.Environments[env]; ok {
+		username, err := Base64Decode(environment.MI.Username)
+		if err != nil {
+			return MiCredential{}, err
+		}
+		password, err := Base64Decode(environment.MI.Password)
+		if err != nil {
+			return MiCredential{}, err
+		}
+		accessToken, err := Base64Decode(environment.MI.AccessToken)
+		if err != nil {
+			return MiCredential{}, err
+		}
+		credential := MiCredential{
+			username, password, accessToken,
+		}
+		return credential, nil
+	}
+	return MiCredential{}, fmt.Errorf("credentials not found for Mi in %s, use login", env)
+}
+
+// SetMICredentials set credentials for mi using username, password, accessToken
+func (s *JsonStore) SetMICredentials(env, username, password, accessToken string) error {
+	environment := s.credentials.Environments[env]
+	environment.MI = MiCredential{
+		Username:    Base64Encode(username),
+		Password:    Base64Encode(password),
+		AccessToken: Base64Encode(accessToken),
+	}
+	s.credentials.Environments[env] = environment
+	err := s.persist()
+	if err != nil {
+		return err
+	}
+	fmt.Printf(PlainTextWarnMessage, s.Path)
+	return nil
+}
+
+// EraseAPIM remove apim credentials from the store
+func (s *JsonStore) EraseAPIM(env string) error {
+	environment, ok := s.credentials.Environments[env]
+	if !ok {
 		return fmt.Errorf("%s was not found", env)
 	}
-	delete(s.credentials.Environments, env)
+	if !miCredentialsExists(environment.MI) {
+		// delete the environment
+		delete(s.credentials.Environments, env)
+	} else {
+		// remove only apim credentials
+		environment.APIM = Credential{}
+		s.credentials.Environments[env] = environment
+	}
+	return s.persist()
+}
+
+// EraseMI remove mi credentials from the store
+func (s *JsonStore) EraseMI(env string) error {
+	environment, ok := s.credentials.Environments[env]
+	if !ok {
+		return fmt.Errorf("%s was not found", env)
+	}
+	if !apimCredentialsExists(environment.APIM) {
+		// delete the environment
+		delete(s.credentials.Environments, env)
+	} else {
+		// remove only mi credentials
+		environment.MI = MiCredential{}
+		s.credentials.Environments[env] = environment
+	}
 	return s.persist()
 }
 
@@ -136,8 +203,26 @@ func (s *JsonStore) IsKeychainEnabled() bool {
 	return s.credentials.CredStore != ""
 }
 
-// Has env in the store
-func (s *JsonStore) Has(env string) bool {
-	_, ok := s.credentials.Environments[env]
-	return ok
+// HasAPIM return the existance of apim credentials in the store for a given environment
+func (s *JsonStore) HasAPIM(env string) bool {
+	if environment, ok := s.credentials.Environments[env]; ok {
+		return apimCredentialsExists(environment.APIM)
+	}
+	return false
+}
+
+// HasMI return the existance of mi credentials in the store for a given environment
+func (s *JsonStore) HasMI(env string) bool {
+	if environment, ok := s.credentials.Environments[env]; ok {
+		return miCredentialsExists(environment.MI)
+	}
+	return false
+}
+
+func miCredentialsExists(miCred MiCredential) bool {
+	return miCred.AccessToken != "" && miCred.Username != "" && miCred.Password != ""
+}
+
+func apimCredentialsExists(apimCred Credential) bool {
+	return apimCred.ClientId != "" && apimCred.ClientSecret != "" && apimCred.Username != "" && apimCred.Password != ""
 }

--- a/import-export-cli/credentials/miCredentials.go
+++ b/import-export-cli/credentials/miCredentials.go
@@ -1,0 +1,192 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package credentials
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"syscall"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// MiCredential for storing mi user details
+type MiCredential struct {
+	// Username of mi user
+	Username string `json:"username"`
+	// Password of mi user
+	Password string `json:"password"`
+	// AccessToken of mi
+	AccessToken string `json:"accessToken"`
+}
+
+// GetMICredentials returns credentials for mi
+func GetMICredentials(env string) (MiCredential, error) {
+
+	store, err := GetDefaultCredentialStore()
+	if err != nil {
+		return MiCredential{}, err
+	}
+
+	if !utils.MIExistsInEnv(env, utils.MainConfigFilePath) {
+		fmt.Println("MI does not exists in", env, "Add it using add env")
+		os.Exit(1)
+	}
+
+	if !store.HasMI(env) {
+
+		fmt.Println("Login to MI in", env)
+		err = RunMILogin(store, env, "", "")
+		if err != nil {
+			return MiCredential{}, err
+		}
+		fmt.Println()
+	}
+	cred, err := store.GetMICredentials(env)
+	if err != nil {
+		return MiCredential{}, err
+	}
+	return cred, nil
+}
+
+// UpdateMIAccessToken updates the access token for mi
+func UpdateMIAccessToken(env, accessToken string) error {
+
+	store, err := GetDefaultCredentialStore()
+	if err != nil {
+		return err
+	}
+	cred, err := store.GetMICredentials(env)
+	if err != nil {
+		return err
+	}
+	return store.SetMICredentials(env, cred.Username, cred.Password, accessToken)
+}
+
+// GetOAuthAccessTokenForMI returns access token for mi
+func GetOAuthAccessTokenForMI(username, password, env string) (string, error) {
+
+	b64encodedCredentials := Base64Encode(username + ":" + password)
+
+	tokenEndpoint := utils.GetMIManagementEndpointOfResource(utils.MiManagementMiLoginResource, env, utils.MainConfigFilePath)
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+
+	resp, err := utils.InvokeGETRequest(tokenEndpoint, headers)
+	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenEndpoint)
+
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return "", errors.New("Unable to connect to MI Token endpoint. Status: " + resp.Status())
+	}
+	responseDataMap := make(map[string]string)
+	data := []byte(resp.Body())
+	unmarshalError := json.Unmarshal(data, &responseDataMap)
+
+	if unmarshalError != nil {
+		return "", unmarshalError
+	}
+	if accessToken, ok := responseDataMap["AccessToken"]; ok {
+		return accessToken, nil
+	}
+	return "", errors.New("AccessToken not found")
+}
+
+// RevokeAccessTokenForMI revokes the mi management token when the user log out from the environment
+func RevokeAccessTokenForMI(env, token string) error {
+
+	tokenRevokeEndpoint := utils.GetMIManagementEndpointOfResource(utils.MiManagementMiLogoutResource, env, utils.MainConfigFilePath)
+
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + token
+
+	resp, err := utils.InvokeGETRequest(tokenRevokeEndpoint, headers)
+	utils.Logln(utils.LogPrefixInfo + "connecting to " + tokenRevokeEndpoint)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return errors.New("Error logging out of the MI in " + env + " Status: " + resp.Status())
+	}
+
+	return nil
+}
+
+// RunMILogin prompt user to input MI management API username and password
+func RunMILogin(store Store, environment, username, password string) error {
+
+	if username == "" {
+		fmt.Print("Username:")
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			username = scanner.Text()
+		}
+	}
+
+	if password == "" {
+		fmt.Print("Password:")
+		pass, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		password = string(pass)
+		fmt.Println()
+	}
+
+	accessToken, err := GetOAuthAccessTokenForMI(username, password, environment)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Logged into MI in", environment, "environment")
+	err = store.SetMICredentials(environment, username, password, accessToken)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RunMILogout revoke mi management token and remove credentials from the store
+func RunMILogout(environment string) error {
+	cred, err := GetMICredentials(environment)
+	if err != nil {
+		return err
+	}
+	err = RevokeAccessTokenForMI(environment, cred.AccessToken)
+	if err != nil {
+		return err
+	}
+	store, err := GetDefaultCredentialStore()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Logged out from MI in", environment, "environment")
+	return store.EraseMI(environment)
+}

--- a/import-export-cli/credentials/store.go
+++ b/import-export-cli/credentials/store.go
@@ -19,14 +19,22 @@
 package credentials
 
 type Store interface {
-	// Has an env in the store
-	Has(env string) bool
-	// Get an env from store returns intended Credential or an error
-	Get(env string) (Credential, error)
-	// Set credentials for env using given username,password,clientId,clientSecret
-	Set(env, username, password, clientId, clientSecret string) error
-	// Erase credentials from given env
-	Erase(env string) error
+	// Has return the existance of apim credentials in the store for a given environment
+	HasAPIM(env string) bool
+	// HasMI return the existance of mi credentials in the store for a given environment
+	HasMI(env string) bool
+	// GetAPIMCredentials returns credentials for apim from the store or an error
+	GetAPIMCredentials(env string) (Credential, error)
+	// GetMICredentials returns credentials for micro integrator from the store or an error
+	GetMICredentials(env string) (MiCredential, error)
+	// SetAPIMCredentials sets credentials for micro integrator using username, password, clientID and client secret
+	SetAPIMCredentials(env, username, password, clientID, clientSecret string) error
+	// SetMICredentials sets credentials for micro integrator using username, password and access token
+	SetMICredentials(env, username, password, accessToken string) error
+	// Erase apim credentials in a given environment
+	EraseAPIM(env string) error
+	// Erase mi credentials in a given environment
+	EraseMI(env string) error
 	// Load store
 	Load() error
 }

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -1,11 +1,11 @@
 ## apictl
 
-CLI for Importing and Exporting APIs and Applications
+CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 
 ### Synopsis
 
 apictl is a Command Line Tool for Importing and Exporting APIs and Applications between different environments of WSO2 API Manager
-(Dev, Production, Staging, QA etc.)
+(Dev, Production, Staging, QA etc.) and Managing WSO2 Micro Integrator
 
 ```
 apictl [flags]
@@ -31,6 +31,7 @@ apictl [flags]
 * [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
 * [apictl login](apictl_login.md)	 - Login to an API Manager
 * [apictl logout](apictl_logout.md)	 - Logout to from an API Manager
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
 * [apictl remove](apictl_remove.md)	 - Remove an environment
 * [apictl set](apictl_set.md)	 - Set configuration parameters
 * [apictl vcs](apictl_vcs.md)	 - Checks status and deploys projects

--- a/import-export-cli/docs/apictl_add.md
+++ b/import-export-cli/docs/apictl_add.md
@@ -12,12 +12,20 @@ Add new environment and its related endpoints to the config file
 apictl add env production \
 --apim  https://localhost:9443 
 
+apictl add env dev \
+--mi  https://localhost:9164
+
+apictl add env prod \
+--apim  https://apim.com:9443 \
+--mi https://localhost:9164
+
 apictl add env test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
---token https://gw.com:8243/token
+--token https://gw.com:8243/token \
+--mi https://localhost:9164
 
 apictl add env dev \
 --apim https://apim.com:9443 \
@@ -28,6 +36,7 @@ NOTE: The flag --environment (-e) is mandatory.
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
 cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.
 ```
 
 ### Options
@@ -45,6 +54,6 @@ cases --token flag is optional and use it to specify the gateway token endpoint.
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl add env](apictl_add_env.md)	 - Add Environment to Config file
 

--- a/import-export-cli/docs/apictl_add_env.md
+++ b/import-export-cli/docs/apictl_add_env.md
@@ -16,12 +16,20 @@ apictl add env [environment] [flags]
 apictl add env production \
 --apim  https://localhost:9443 
 
+apictl add env dev \
+--mi  https://localhost:9164
+
+apictl add env prod \
+--apim  https://apim.com:9443 \
+--mi https://localhost:9164
+
 apictl add env test \
 --registration https://idp.com:9443 \
 --publisher https://apim.com:9443 \
 --devportal  https://apps.com:9443 \
 --admin  https://apim.com:9443 \
---token https://gw.com:8243/token
+--token https://gw.com:8243/token \
+--mi https://localhost:9164
 
 apictl add env dev \
 --apim https://apim.com:9443 \
@@ -31,6 +39,7 @@ apictl add env dev \
 You can either provide only the flag --apim , or all the other 4 flags (--registration --publisher --devportal --admin) without providing --apim flag.
 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify --apim flag with the API Manager endpoint. In both of the
 cases --token flag is optional and use it to specify the gateway token endpoint. This will be used for "apictl get-keys" operation.
+To add a micro integrator instance to an environment you can use the --mi flag.
 ```
 
 ### Options
@@ -40,6 +49,7 @@ cases --token flag is optional and use it to specify the gateway token endpoint.
       --apim string           API Manager endpoint for the environment
       --devportal string      DevPortal endpoint for the environment
   -h, --help                  help for env
+      --mi string             Micro Integrator Management endpoint for the environment
       --publisher string      Publisher endpoint for the environment
       --registration string   Registration endpoint for the environment
       --token string          Token endpoint for the environment

--- a/import-export-cli/docs/apictl_change-status.md
+++ b/import-export-cli/docs/apictl_change-status.md
@@ -32,6 +32,6 @@ apictl change-status api -a Publish -n FacebookAPI -v 2.1.0 -e production
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl change-status api](apictl_change-status_api.md)	 - Change Status of an API
 

--- a/import-export-cli/docs/apictl_delete.md
+++ b/import-export-cli/docs/apictl_delete.md
@@ -35,7 +35,7 @@ apictl delete app -n TestApplication -o admin -e dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl delete api](apictl_delete_api.md)	 - Delete API
 * [apictl delete api-product](apictl_delete_api-product.md)	 - Delete API Product
 * [apictl delete app](apictl_delete_app.md)	 - Delete App

--- a/import-export-cli/docs/apictl_export.md
+++ b/import-export-cli/docs/apictl_export.md
@@ -37,7 +37,7 @@ apictl export app -n SampleApp -o admin -e dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl export api](apictl_export_api.md)	 - Export API
 * [apictl export api-product](apictl_export_api-product.md)	 - Export API Product
 * [apictl export apis](apictl_export_apis.md)	 - Export APIs for migration

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -38,7 +38,7 @@ apictl get apps -e dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl get api-products](apictl_get_api-products.md)	 - Display a list of API Products in an environment
 * [apictl get apis](apictl_get_apis.md)	 - Display a list of APIs in an environment
 * [apictl get apps](apictl_get_apps.md)	 - Display a list of Applications in an environment specific to an owner

--- a/import-export-cli/docs/apictl_get_envs.md
+++ b/import-export-cli/docs/apictl_get_envs.md
@@ -19,7 +19,7 @@ apictl list envs
 ### Options
 
 ```
-      --format string   Pretty-print environments using go templates (default "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}")
+      --format string   Pretty-print environments using go templates (default "table {{.Name}}\t{{.ApiManagerEndpoint}}\t{{.RegistrationEndpoint}}\t{{.TokenEndpoint}}\t{{.PublisherEndpoint}}\t{{.ApplicationEndpoint}}\t{{.AdminEndpoint}}\t{{.MiManagementEndpoint}}")
   -h, --help            help for envs
 ```
 

--- a/import-export-cli/docs/apictl_import.md
+++ b/import-export-cli/docs/apictl_import.md
@@ -35,7 +35,7 @@ apictl import app -f qa/apps/sampleApp.zip -e dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl import api](apictl_import_api.md)	 - Import API
 * [apictl import api-product](apictl_import_api-product.md)	 - Import API Product
 * [apictl import app](apictl_import_app.md)	 - Import App

--- a/import-export-cli/docs/apictl_init.md
+++ b/import-export-cli/docs/apictl_init.md
@@ -38,5 +38,5 @@ apictl init MyAwesomeAPI --oas ./swagger.yaml -d definition.yaml
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 

--- a/import-export-cli/docs/apictl_k8s.md
+++ b/import-export-cli/docs/apictl_k8s.md
@@ -35,7 +35,7 @@ apictl k8s change registry
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl k8s add](apictl_k8s_add.md)	 - Add an API to the kubernetes cluster
 * [apictl k8s change](apictl_k8s_change.md)	 - Change a configuration in K8s cluster resource
 * [apictl k8s delete](apictl_k8s_delete.md)	 - Delete resources related to kubernetes

--- a/import-export-cli/docs/apictl_mi.md
+++ b/import-export-cli/docs/apictl_mi.md
@@ -1,0 +1,31 @@
+## apictl mi
+
+Micro Integrator related commands
+
+### Synopsis
+
+Micro Integrator related commands such as login, logout, get, add, update, delete, activate, deactivate.
+
+```
+apictl mi [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for mi
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi login](apictl_mi_login.md)	 - Login to a Micro Integrator
+* [apictl mi logout](apictl_mi_logout.md)	 - Logout from a Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_login.md
+++ b/import-export-cli/docs/apictl_mi_login.md
@@ -1,21 +1,21 @@
-## apictl login
+## apictl mi login
 
-Login to an API Manager
+Login to a Micro Integrator
 
 ### Synopsis
 
-Login to an API Manager using credentials
+Login to a Micro Integrator using credentials
 
 ```
-apictl login [environment] [flags]
+apictl mi login [environment] [flags]
 ```
 
 ### Examples
 
 ```
-apictl login dev -u admin -p admin
-apictl login dev -u admin
-cat ~/.mypassword | apictl login dev -u admin
+apictl mi login dev -u admin -p admin
+apictl mi login dev -u admin
+cat ~/.mypassword | apictl mi login dev -u admin
 ```
 
 ### Options
@@ -36,5 +36,5 @@ cat ~/.mypassword | apictl login dev -u admin
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
 

--- a/import-export-cli/docs/apictl_mi_logout.md
+++ b/import-export-cli/docs/apictl_mi_logout.md
@@ -1,13 +1,13 @@
-## apictl logout
+## apictl mi logout
 
-Logout to from an API Manager
+Logout from a Micro Integrator
 
 ### Synopsis
 
-Logout from an API Manager environment
+Logout from a Micro Integrator
 
 ```
-apictl logout [environment] [flags]
+apictl mi logout [environment] [flags]
 ```
 
 ### Examples
@@ -31,5 +31,5 @@ apictl logout dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
 

--- a/import-export-cli/docs/apictl_remove.md
+++ b/import-export-cli/docs/apictl_remove.md
@@ -31,6 +31,6 @@ apictl remove env [environment]  production
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl remove env](apictl_remove_env.md)	 - Remove Environment from Config file
 

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -43,5 +43,5 @@ apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 

--- a/import-export-cli/docs/apictl_vcs.md
+++ b/import-export-cli/docs/apictl_vcs.md
@@ -34,7 +34,7 @@ apictl vcs deploy -e dev
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl vcs deploy](apictl_vcs_deploy.md)	 - Deploys projects to the specified environment
 * [apictl vcs init](apictl_vcs_init.md)	 - Initializes a GIT repository with API Controller
 * [apictl vcs status](apictl_vcs_status.md)	 - Shows the list of projects that are ready to deploy

--- a/import-export-cli/docs/apictl_version.md
+++ b/import-export-cli/docs/apictl_version.md
@@ -31,5 +31,5 @@ apictl version
 
 ### SEE ALSO
 
-* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 

--- a/import-export-cli/impl/addEnv.go
+++ b/import-export-cli/impl/addEnv.go
@@ -40,7 +40,7 @@ func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath
 		return errors.New("Name of the environment cannot be blank")
 	}
 
-	if envEndpoints.TokenEndpoint == "" {
+	if !utils.HasOnlyMIEndpoint(envEndpoints) && envEndpoints.TokenEndpoint == "" {
 		// If token endpoint string is empty,then assign the default value
 		if envEndpoints.ApiManagerEndpoint != "" && !isDefaultTokenEndpointSet {
 			isDefaultTokenEndpointSet = true
@@ -53,11 +53,11 @@ func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath
 	}
 
 	if envEndpoints.ApiManagerEndpoint == "" {
-		if envEndpoints.AdminEndpoint == "" || envEndpoints.DevPortalEndpoint == "" ||
-			envEndpoints.PublisherEndpoint == "" || envEndpoints.RegistrationEndpoint == "" ||
-			envEndpoints.TokenEndpoint == "" {
-			utils.ShowHelpCommandTip(addEnvCmdLiteral)
-			return errors.New("Endpoint(s) cannot be blank")
+		if !utils.HasOnlyMIEndpoint(envEndpoints) {
+			if !utils.RequiredAPIMEndpointsExists(envEndpoints) {
+				utils.ShowHelpCommandTip(addEnvCmdLiteral)
+				return errors.New("Endpoint(s) cannot be blank")
+			}
 		}
 	}
 
@@ -90,6 +90,10 @@ func AddEnv(envName string, envEndpoints *utils.EnvEndpoints, mainConfigFilePath
 
 	if envEndpoints.AdminEndpoint != "" {
 		validatedEnvEndpoints.AdminEndpoint = envEndpoints.AdminEndpoint
+	}
+
+	if envEndpoints.MiManagementEndpoint != "" {
+		validatedEnvEndpoints.MiManagementEndpoint = envEndpoints.MiManagementEndpoint
 	}
 
 	mainConfig.Environments[envName] = validatedEnvEndpoints

--- a/import-export-cli/impl/getEnvs.go
+++ b/import-export-cli/impl/getEnvs.go
@@ -36,6 +36,7 @@ const (
 	envsAdminEndpointHeader        = "ADMIN ENDPOINT"
 	envsApiManagerEndpoint         = "API MANAGER ENDPOINT"
 	envsApplicationEndpoint        = "DEVPORTAL ENDPOINT"
+	envsMiManagementEndpoint       = "MI MANAGEMENT ENDPOINT"
 )
 
 // endpoint contains information about endpoint of API Manager
@@ -47,6 +48,7 @@ type endpoints struct {
 	adminEndpoint        string
 	apiManagerEndpoint   string
 	applicationEndpoint  string
+	miManagementEndpoint string
 }
 
 func newEndpointFromEnvEndpoints(name string, e utils.EnvEndpoints) *endpoints {
@@ -58,6 +60,7 @@ func newEndpointFromEnvEndpoints(name string, e utils.EnvEndpoints) *endpoints {
 		publisherEndpoint:    e.PublisherEndpoint,
 		registrationEndpoint: e.RegistrationEndpoint,
 		tokenEndpoint:        e.TokenEndpoint,
+		miManagementEndpoint: e.MiManagementEndpoint,
 	}
 }
 
@@ -96,6 +99,11 @@ func (e endpoints) AdminEndpoint() string {
 	return e.adminEndpoint
 }
 
+// MiManagementEndpoint
+func (e endpoints) MiManagementEndpoint() string {
+	return e.miManagementEndpoint
+}
+
 // MarshalJSON returns marshaled methods
 func (e *endpoints) MarshalJSON() ([]byte, error) {
 	return formatter.MarshalJSON(e)
@@ -130,6 +138,7 @@ func PrintEnvs(envData map[string]utils.EnvEndpoints, format, defaulEnvsTableFor
 		"AdminEndpoint":        envsAdminEndpointHeader,
 		"ApiManagerEndpoint":   envsApiManagerEndpoint,
 		"ApplicationEndpoint":  envsApplicationEndpoint,
+		"MiManagementEndpoint": envsMiManagementEndpoint,
 	}
 
 	// execute context

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -1,7 +1,7 @@
-<h1 id="cli-for-importing-and-exporting-apis-and-applications">CLI for Importing and Exporting APIs and Applications
+<h1 id="cli-for-importing-and-exporting-apis-and-applications">CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 </h1>
 <h2 id="for-wso2-api-manager-3-2.0">For WSO2 API Manager 3.2.0</h2>
-<p>Command Line tool for importing and exporting APIs and Applications between different API Environments</p>
+<p>Command Line tool for importing and exporting APIs and Applications between different API Environments of WSO2 API Manager and Managing WSO2 Micro Integrator</p>
 <h2 id="getting-started">Getting Started</h2>
 <ul>
     <li>
@@ -30,7 +30,7 @@
                 flags (<code>--registration</code>, <code>--publisher</code>, <code>--devportal</code>,
                 <code>--admin</code>, <code>--token</code>) without providing <code>--apim</code> flag.
                 If you are omitting any of --registration --publisher --devportal --admin flags, you need to specify
-                --apim flag with the API Manager endpoint.</p>
+                --apim flag with the API Manager endpoint.To add a micro integrator instance to an environment you can use the <code>--mi</code> flag.</p>
         </blockquote>
     </li>
     <li>
@@ -256,6 +256,7 @@
         <h4 id="add-env">add env [environment]</h4>
         <pre><code class="lang-bash">      Flags:
         Required:
+            To add an API Manager
             (either)
             --apim (API Manager endpoint)
             OR (the following 4)
@@ -263,6 +264,8 @@
             --publisher https://localhost:9443 \
             --devportal https://localhost:9443 \
             --admin https://localhost:9443
+            To add a Micro Integrator
+            --mi (MI Management endpoint)
         Optional:
             --token (Token Endpoint)
 
@@ -270,12 +273,20 @@
         apictl add env dev \
             --apim https://localhost:9443
 
+        apictl add env dev \
+            --mi  https://localhost:9164
+
+        apictl add env prod \
+            --apim  https://apim.com:9443 \
+            --mi https://localhost:9164
+
         apictl add env staging \
             --registration https://idp.com:9443 \
             --publisher https://apim.com:9443 \
             --devportal https://apps.com:9443 \
             --admin https://apim.com:9443 \
-            --token https://gw.com:8243/token
+            --token https://gw.com:8243/token \
+            --mi https://localhost:9164
             
         apictl add env prod \
             --apim https://apim.com:9443 \

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -383,6 +383,10 @@ _apictl_add_env()
     flags+=("-h")
     local_nonpersistent_flags+=("--help")
     local_nonpersistent_flags+=("-h")
+    flags+=("--mi=")
+    two_word_flags+=("--mi")
+    local_nonpersistent_flags+=("--mi")
+    local_nonpersistent_flags+=("--mi=")
     flags+=("--publisher=")
     two_word_flags+=("--publisher")
     local_nonpersistent_flags+=("--publisher")
@@ -2479,6 +2483,128 @@ _apictl_logout()
     noun_aliases=()
 }
 
+_apictl_mi_help()
+{
+    last_command="apictl_mi_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_login()
+{
+    last_command="apictl_mi_login"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--password=")
+    two_word_flags+=("--password")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--password")
+    local_nonpersistent_flags+=("--password=")
+    local_nonpersistent_flags+=("-p")
+    flags+=("--password-stdin")
+    local_nonpersistent_flags+=("--password-stdin")
+    flags+=("--username=")
+    two_word_flags+=("--username")
+    two_word_flags+=("-u")
+    local_nonpersistent_flags+=("--username")
+    local_nonpersistent_flags+=("--username=")
+    local_nonpersistent_flags+=("-u")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_logout()
+{
+    last_command="apictl_mi_logout"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi()
+{
+    last_command="apictl_mi"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("login")
+    commands+=("logout")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_remove_env()
 {
     last_command="apictl_remove_env"
@@ -2803,6 +2929,7 @@ _apictl_root_command()
     commands+=("k8s")
     commands+=("login")
     commands+=("logout")
+    commands+=("mi")
     commands+=("remove")
     commands+=("set")
     commands+=("vcs")

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -32,11 +32,12 @@ var CurrentDir, _ = os.Getwd()
 const ConfigDirName = ".wso2apictl"
 
 var HomeDirectory = getConfigHomeDir()
+
 func getConfigHomeDir() string {
 	value := os.Getenv("APICTL_CONFIG_DIR")
 	if len(value) == 0 {
 		value, err := os.UserHomeDir()
-		if len(value) == 0 || err != nil  {
+		if len(value) == 0 || err != nil {
 			current, err := user.Current()
 			if err != nil || current == nil {
 				HandleErrorAndExit("User's HOME folder location couldn't be identified", nil)
@@ -193,3 +194,32 @@ const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"
 const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
 const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
 const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
+
+// MiCmdLiteral denote the alias for micro integrator related commands
+const MiCmdLiteral = "mi"
+
+// MiManagementAPIContext
+const MiManagementAPIContext = "management"
+
+// Mi Management Resource paths
+const MiManagementCarbonAppResource = "applications"
+const MiManagementServiceResource = "services"
+const MiManagementAPIResource = "apis"
+const MiManagementProxyServiceResource = "proxy-services"
+const MiManagementInboundEndpointResource = "inbound-endpoints"
+const MiManagementEndpointResource = "endpoints"
+const MiManagementMessageProcessorResource = "message-processors"
+const MiManagementTemplateResource = "templates"
+const MiManagementConnectorResource = "connectors"
+const MiManagementMessageStoreResource = "message-stores"
+const MiManagementLocalEntrieResource = "local-entries"
+const MiManagementSequenceResource = "sequences"
+const MiManagementTaskResource = "tasks"
+const MiManagementLogResource = "logs"
+const MiManagementLoggingResource = "logging"
+const MiManagementServerResource = "server"
+const MiManagementDataServiceResource = "data-services"
+const MiManagementMiLoginResource = "login"
+const MiManagementMiLogoutResource = "logout"
+const MiManagementUserResource = "users"
+const MiManagementTransactionResource = "transactions"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -381,3 +381,39 @@ func HasOnlyMIEndpoint(envEndpoints *EnvEndpoints) bool {
 		envEndpoints.PublisherEndpoint == "" && envEndpoints.RegistrationEndpoint == "" &&
 		envEndpoints.TokenEndpoint == "" && envEndpoints.MiManagementEndpoint != ""
 }
+
+// GetMIManagementEndpointOfEnv return the Mi Management Endpoint of a given environment
+func GetMIManagementEndpointOfEnv(env, filePath string) (string, error) {
+	envEndpoints, err := GetEndpointsOfEnvironment(env, filePath)
+	if err != nil {
+		return "", err
+	}
+	return envEndpoints.MiManagementEndpoint, nil
+}
+
+// GetMIManagementEndpointOfResource return the full resource url of a resource
+func GetMIManagementEndpointOfResource(resource, env, filePath string) string {
+	miEndpoint, _ := GetMIManagementEndpointOfEnv(env, filePath)
+	if strings.HasSuffix(miEndpoint, "/") {
+		return miEndpoint + MiManagementAPIContext + "/" + resource
+	}
+	return miEndpoint + "/" + MiManagementAPIContext + "/" + resource
+}
+
+// MIExistsInEnv check wether there is a micro integrator in the environment
+func MIExistsInEnv(env, filePath string) bool {
+	miEndpoint, err := GetMIManagementEndpointOfEnv(env, filePath)
+	if err != nil {
+		return false
+	}
+	return miEndpoint != ""
+}
+
+// APIMExistsInEnv check wether there is a apim in the environment
+func APIMExistsInEnv(env, filePath string) bool {
+	envEndpoints, err := GetEndpointsOfEnvironment(env, filePath)
+	if err != nil {
+		return false
+	}
+	return envEndpoints.ApiManagerEndpoint != "" || RequiredAPIMEndpointsExists(envEndpoints)
+}

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -319,7 +319,7 @@ func GetDefaultEnvironment(mainConfigFilePath string) string {
 
 //get default token endpoint given from an apim endpoint
 func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
-	if strings.HasSuffix(apimEndpoint,"/"){
+	if strings.HasSuffix(apimEndpoint, "/") {
 		return apimEndpoint + defaultTokenEndPoint
 	} else {
 		return apimEndpoint + "/" + defaultTokenEndPoint
@@ -327,13 +327,13 @@ func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
 }
 
 //get default token endpoint given from a publisher endpoint
-func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
-	if strings.Contains(publisherEndpoint,"publisher"){
-		trimmedString := strings.Split(publisherEndpoint,"publisher")
+func GetTokenEndPointFromPublisherEndpoint(publisherEndpoint string) string {
+	if strings.Contains(publisherEndpoint, "publisher") {
+		trimmedString := strings.Split(publisherEndpoint, "publisher")
 		publisherEndpoint = trimmedString[0]
 	}
 
-	if strings.HasSuffix(publisherEndpoint,"/"){
+	if strings.HasSuffix(publisherEndpoint, "/") {
 		return publisherEndpoint + defaultTokenEndPoint
 	} else {
 		return publisherEndpoint + "/" + defaultTokenEndPoint
@@ -342,14 +342,14 @@ func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
 
 // Get internalTokenEndpoint for REST api operations
 // @return endpoint url derived from publisher or apim endpoint
-func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
+func GetInternalTokenEndpointOfEnv(env, filePath string) string {
 	var internalTokenEndpoint string
 	apiManagerEndpointOfEnv := GetApiManagerEndpointOfEnv(env, filePath)
 	if apiManagerEndpointOfEnv != "" {
 		internalTokenEndpoint = GetTokenEndPointFromAPIMEndpoint(apiManagerEndpointOfEnv)
 
 	} else {
-		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env,filePath)
+		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env, filePath)
 		internalTokenEndpoint = GetTokenEndPointFromPublisherEndpoint(publisherEndpointOfEnv)
 	}
 	return internalTokenEndpoint
@@ -357,11 +357,27 @@ func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
 
 //Get token endpoint for Token revocation
 //@return endpoint URL of token revocation endpoint
-func GetTokenRevokeEndpoint (env, filePath string) string {
+func GetTokenRevokeEndpoint(env, filePath string) string {
 	//Get Internal token endpoint for the environment
-	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env,filePath)
-	slittedString := strings.Split(internalTokenEndpoint,defaultTokenEndPoint)
+	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env, filePath)
+	slittedString := strings.Split(internalTokenEndpoint, defaultTokenEndPoint)
 	//Get Apim endpoint or publisher endpoint
 	extractedTokenEndpoint := slittedString[0]
 	return extractedTokenEndpoint + defaultRevokeEndpointSuffix
+}
+
+// RequiredAPIMEndpointsExists checks for required apim endpoints.
+// It returns true if all the endpoints are present
+func RequiredAPIMEndpointsExists(envEndpoints *EnvEndpoints) bool {
+	return envEndpoints.AdminEndpoint != "" && envEndpoints.DevPortalEndpoint != "" &&
+		envEndpoints.PublisherEndpoint != "" && envEndpoints.RegistrationEndpoint != "" &&
+		envEndpoints.TokenEndpoint != ""
+}
+
+// HasOnlyMIEndpoint checks wether an MI instance is present in a given environment
+// It returns true if the only instance in an environment is MI
+func HasOnlyMIEndpoint(envEndpoints *EnvEndpoints) bool {
+	return envEndpoints.ApiManagerEndpoint == "" && envEndpoints.AdminEndpoint == "" && envEndpoints.DevPortalEndpoint == "" &&
+		envEndpoints.PublisherEndpoint == "" && envEndpoints.RegistrationEndpoint == "" &&
+		envEndpoints.TokenEndpoint == "" && envEndpoints.MiManagementEndpoint != ""
 }

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -55,6 +55,7 @@ type EnvEndpoints struct {
 	RegistrationEndpoint string `yaml:"registration"`
 	AdminEndpoint        string `yaml:"admin"`
 	TokenEndpoint        string `yaml:"token"`
+	MiManagementEndpoint string `yaml:"mi"`
 }
 
 // ---------------- End of Structs for YAML Config Files ---------------------------------


### PR DESCRIPTION
## Purpose
Update MI CLI tool and merge with APICTL
wso2/micro-integrator#1999

## Goals
- Update env command to add/remove MI instances
- Add new alias **mi** to add MI related commands
- Add new login command under mi to login to MI instances
- Add new logout command under mi to logout from MI instances

## User stories
- A new flag **--mi** is introduced under add env command to add a MI instance
`apictl add env dev --mi  https://localhost:9164`
- To login to MI instance
`apictl mi login <env> -u <username> -p <password>`
- To logout from MI instance
`apictl mi logout <env>`

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64