### PR TITLE
Change the import/export APIs/API Products endpoints to Publisher REST API

### DIFF
--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -63,7 +63,7 @@ func ExecuteNewFileUploadRequest(uri string, params map[string]string, paramName
     headers := make(map[string]string)
     headers[utils.HeaderContentType] = writer.FormDataContentType()
     headers[utils.HeaderAuthorization] =  utils.HeaderValueAuthBearerPrefix+" "+accessToken
-    headers[utils.HeaderAccept] = "*/*"
+    headers[utils.HeaderAccept] = "application/json"
     headers[utils.HeaderConnection] = utils.HeaderValueKeepAlive
 
     resp, err := utils.InvokePOSTRequestWithBytes(uri, headers, body.Bytes())

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -29,26 +29,26 @@ import (
 
 // ExportAPIFromEnv function is used with export api command
 func ExportAPIFromEnv(accessToken, name, version, provider, format, exportEnvironment string, preserveStatus bool) (*resty.Response, error) {
-	adminEndpoint := utils.GetAdminEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
-	return exportAPI(name, version, provider, format, adminEndpoint, accessToken, preserveStatus)
+	publisherEndpoint := utils.GetPublisherEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
+	return exportAPI(name, version, provider, format, publisherEndpoint, accessToken, preserveStatus)
 }
 
 // exportAPI function is used with export api command
 // @param name : Name of the API to be exported
 // @param version : Version of the API to be exported
 // @param provider : Provider of the API
-// @param adminEndpoint : API Manager Admin Endpoint for the environment
+// @param publisherEndpoint : API Manager Publisher Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
-func exportAPI(name, version, provider, format, adminEndpoint, accessToken string, preserveStatus bool) (*resty.Response, error) {
-	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
-	query := "export/api?name=" + name + "&version=" + version + "&providerName=" + provider +
+func exportAPI(name, version, provider, format, publisherEndpoint, accessToken string, preserveStatus bool) (*resty.Response, error) {
+	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
+	query := "apis/export?name=" + name + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(preserveStatus)
 	if format != "" {
 		query += "&format=" + format
 	}
 
-	url := adminEndpoint + query
+	url := publisherEndpoint + query
 	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", url)
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken

--- a/import-export-cli/impl/exportAPIProduct.go
+++ b/import-export-cli/impl/exportAPIProduct.go
@@ -28,25 +28,25 @@ import (
 
 // ExportAPIProductFromEnv function is used with export api command
 func ExportAPIProductFromEnv(accessToken, name, version, provider, format, exportEnvironment string) (*resty.Response, error) {
-	adminEndpoint := utils.GetAdminEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
-	return exportAPIProduct(name, version, provider, format, adminEndpoint, accessToken)
+	publisherEndpoint := utils.GetPublisherEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
+	return exportAPIProduct(name, version, provider, format, publisherEndpoint, accessToken)
 }
 
 // exportAPIProduct
 // @param name : Name of the API Product to be exported
 // @param version : Version of the API Product to be exported
 // @param provider : Provider of the API Product
-// @param adminEndpoint : API Manager Admin Endpoint for the environment
+// @param publisherEndpoint : API Manager Publisher Endpoint for the environment
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
-func exportAPIProduct(name, version, provider, format, adminEndpoint, accessToken string) (*resty.Response, error) {
-	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
-	query := "export/api-product?name=" + name + "&version=" + version + "&providerName=" + provider
+func exportAPIProduct(name, version, provider, format, publisherEndpoint, accessToken string) (*resty.Response, error) {
+	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
+	query := "api-products/export?name=" + name + "&version=" + version + "&providerName=" + provider
 	if format != "" {
 		query += "&format=" + format
 	}
 
-	url := adminEndpoint + query
+	url := publisherEndpoint + query
 	utils.Logln(utils.LogPrefixInfo+"ExportAPIProduct: URL:", url)
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -50,7 +50,7 @@ func TestExportApiNonAdminSuperTenantUser(t *testing.T) {
 		SrcAPIM:     dev,
 	}
 
-	testutils.ValidateAPIExportFailure(t, args)
+	testutils.ValidateAPIExport(t, args)
 }
 
 // Export an API from one environment and import to another environment as super tenant admin by specifying the provider name
@@ -122,7 +122,7 @@ func TestExportApiNonAdminTenantUser(t *testing.T) {
 		SrcAPIM:     dev,
 	}
 
-	testutils.ValidateAPIExportFailure(t, args)
+	testutils.ValidateAPIExport(t, args)
 }
 
 // Export an API from one environment and import to another environment as tenant admin by specifying the provider name
@@ -183,15 +183,13 @@ func TestExportApiAdminSuperTenantUserWithoutProvider(t *testing.T) {
 	apiCreatorPassword := creator.Password
 
 	dev := apimClients[0]
-	prod := apimClients[1]
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
 	args := &testutils.ApiImportExportTestArgs{
-		CtlUser:  testutils.Credentials{Username: adminUsername, Password: adminPassword},
-		Api:      api,
-		SrcAPIM:  dev,
-		DestAPIM: prod,
+		CtlUser: testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		Api:     api,
+		SrcAPIM: dev,
 	}
 
 	testutils.ValidateAPIExport(t, args)
@@ -206,15 +204,13 @@ func TestExportApiDevopsSuperTenantUserWithoutProvider(t *testing.T) {
 	apiCreatorPassword := creator.Password
 
 	dev := apimClients[0]
-	prod := apimClients[1]
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
 	args := &testutils.ApiImportExportTestArgs{
-		CtlUser:  testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
-		Api:      api,
-		SrcAPIM:  dev,
-		DestAPIM: prod,
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:     api,
+		SrcAPIM: dev,
 	}
 
 	testutils.ValidateAPIExport(t, args)
@@ -229,15 +225,13 @@ func TestExportApiAdminTenantUserWithoutProvider(t *testing.T) {
 	tenantApiCreatorPassword := creator.Password
 
 	dev := apimClients[0]
-	prod := apimClients[1]
 
 	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
 
 	args := &testutils.ApiImportExportTestArgs{
-		CtlUser:  testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
-		Api:      api,
-		SrcAPIM:  dev,
-		DestAPIM: prod,
+		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		Api:     api,
+		SrcAPIM: dev,
 	}
 
 	testutils.ValidateAPIExport(t, args)
@@ -252,15 +246,13 @@ func TestExportApiDevopsTenantUserWithoutProvider(t *testing.T) {
 	tenantApiCreatorPassword := creator.Password
 
 	dev := apimClients[0]
-	prod := apimClients[1]
 
 	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
 
 	args := &testutils.ApiImportExportTestArgs{
-		CtlUser:  testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
-		Api:      api,
-		SrcAPIM:  dev,
-		DestAPIM: prod,
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:     api,
+		SrcAPIM: dev,
 	}
 
 	testutils.ValidateAPIExport(t, args)

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -152,6 +152,7 @@ func (instance *Client) GenerateSampleAPIData(provider string) *API {
 	api.Type = "HTTP"
 	api.SubscriptionAvailability = "CURRENT_TENANT"
 	api.AccessControl = "NONE"
+	api.AuthorizationHeader = "Authorization"
 	api.EndpointImplementationType = "ENDPOINT"
 	api.GatewayEnvironments = []string{"Production and Sandbox"}
 	api.BusinessInformation = BusinessInfo{"Jane Roe", "marketing@pizzashack.com", "John Doe", "architecture@pizzashack.com"}
@@ -541,7 +542,7 @@ func (instance *Client) AddAPIFromOpenAPIDefinition(t *testing.T, path string, a
 	return apiResponse.ID
 }
 
-// AddAPIProductFromYaml : Add SampleAPIProduct using using a yaml file
+// AddAPIProductFromJSON : Add SampleAPIProduct using using a json file
 func (instance *Client) AddAPIProductFromJSON(t *testing.T, path string, username string, password string, apisList map[string]*API, doClean bool) string {
 	apiProductsURL := instance.publisherRestURL + "/api-products"
 
@@ -586,7 +587,7 @@ func (instance *Client) AddAPIProductFromJSON(t *testing.T, path string, usernam
 
 	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
 
-	base.LogRequest("apim.AddAPIProductFromYaml()", request)
+	base.LogRequest("apim.AddAPIProductFromJSON()", request)
 
 	response := base.SendHTTPRequest(request)
 

--- a/import-export-cli/integration/deprecatedCommands_TestUtils.go
+++ b/import-export-cli/integration/deprecatedCommands_TestUtils.go
@@ -132,19 +132,18 @@ func getKeys(t *testing.T, provider string, name string, version string, env str
 	return base.Execute(t, "get-keys", "-n", name, "-v", version, "-r", provider, "-e", env, "-k", "--verbose")
 }
 
-func validateAPIExportFailureDeprecated(t *testing.T, args *testutils.ApiImportExportTestArgs) {
+func validateAPIExportDeprecated(t *testing.T, args *testutils.ApiImportExportTestArgs) {
 	t.Helper()
 
-	// Setup apictl env
+	// Setup apictl envs
 	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
 
-	// Attempt exporting api from env
+	// Export api from env 1
 	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
 	exportAPI(t, args.Api.Name, args.Api.Version, args.ApiProvider.Username, args.SrcAPIM.GetEnvName())
 
-	// Validate that export failed
-	assert.False(t, base.IsAPIArchiveExists(t, testutils.GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
+	assert.True(t, base.IsAPIArchiveExists(t, testutils.GetEnvAPIExportPath(args.SrcAPIM.GetEnvName()),
 		args.Api.Name, args.Api.Version))
 }
 

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -56,7 +56,7 @@ func TestExportApiNonAdminSuperTenantUserDeprecated(t *testing.T) {
 		SrcAPIM:     dev,
 	}
 
-	validateAPIExportFailureDeprecated(t, args)
+	validateAPIExportDeprecated(t, args)
 }
 
 // Export an API from one environment and import to another environment as tenant user with

--- a/import-export-cli/integration/testdata/SampleAPIProduct.json
+++ b/import-export-cli/integration/testdata/SampleAPIProduct.json
@@ -1,141 +1,139 @@
 {
-   "id": "e62c19bf-51b8-4767-b8b8-690085241f26",
-   "name": "SampleAPIProduct",
-   "context": "/sampleapiproduct",
-   "description": null,
-   "provider": "admin",
-   "hasThumbnail": null,
-   "state": "PUBLISHED",
-   "enableSchemaValidation": false,
-   "responseCachingEnabled": false,
-   "cacheTimeout": 300,
-   "visibility": "PUBLIC",
-   "visibleRoles": [],
-   "visibleTenants": [],
-   "accessControl": "NONE",
-   "accessControlRoles": [],
-   "gatewayEnvironments": [
-     "Production and Sandbox"
-   ],
-   "apiType": "APIProduct",
-   "transport": [
-     "http",
-     "https"
-   ],
-   "tags": [],
-   "policies": [
-     "Bronze",
-     "Gold"
-   ],
-   "apiThrottlingPolicy": null,
-   "authorizationHeader": "Authorization",
-   "securityScheme": [
-     "oauth2",
-     "oauth_basic_auth_api_key_mandatory"
-   ],
-   "subscriptionAvailability": "ALL_TENANTS",
-   "subscriptionAvailableTenants": [],
-   "additionalProperties": {},
-   "monetization": null,
-   "businessInformation": {
-     "businessOwner": null,
-     "businessOwnerEmail": null,
-     "technicalOwner": null,
-     "technicalOwnerEmail": null
-   },
-   "corsConfiguration": {
-     "corsConfigurationEnabled": false,
-     "accessControlAllowOrigins": [
-       "*"
-     ],
-     "accessControlAllowCredentials": false,
-     "accessControlAllowHeaders": [
-       "authorization",
-       "Access-Control-Allow-Origin",
-       "Content-Type",
-       "SOAPAction",
-       "apikey"
-     ],
-     "accessControlAllowMethods": [
-       "GET",
-       "PUT",
-       "POST",
-       "DELETE",
-       "PATCH",
-       "OPTIONS"
-     ]
-   },
-   "createdTime": "2020-05-23 20:06:33.931",
-   "lastUpdatedTime": "2020-05-23 20:06:34.097",
-   "apis": [
-     {
-       "name": "PizzaShackAPI",
-       "apiId": "4df14bdd-5934-47ab-9afe-4704d5a1cb2b",
-       "operations": [
-         {
-           "id": "",
-           "target": "/menu",
-           "verb": "GET",
-           "authType": "Application & Application User",
-           "throttlingPolicy": "Unlimited",
-           "scopes": [],
-           "usedProductIds": [],
-           "amznResourceName": null,
-           "amznResourceTimeout": null
-         },
-         {
-           "id": "",
-           "target": "/order/{orderId}",
-           "verb": "PUT",
-           "authType": "Application & Application User",
-           "throttlingPolicy": "Unlimited",
-           "scopes": [],
-           "usedProductIds": [],
-           "amznResourceName": null,
-           "amznResourceTimeout": null
-         }
-       ]
-     },
-     {
-       "name": "SwaggerPetstore",
-       "apiId": "a2479626-453b-4204-b502-9b372a3ef29f",
-       "operations": [
-         {
-           "id": "",
-           "target": "/pet/{petId}/uploadImage",
-           "verb": "POST",
-           "authType": "Application & Application User",
-           "throttlingPolicy": "Unlimited",
-           "scopes": [],
-           "usedProductIds": [],
-           "amznResourceName": null,
-           "amznResourceTimeout": null
-         },
-         {
-           "id": "",
-           "target": "/pet/findByStatus",
-           "verb": "GET",
-           "authType": "Application & Application User",
-           "throttlingPolicy": "Unlimited",
-           "scopes": [],
-           "usedProductIds": [],
-           "amznResourceName": null,
-           "amznResourceTimeout": null
-         },
-         {
-           "id": "",
-           "target": "/pet/findByTags",
-           "verb": "GET",
-           "authType": "Application & Application User",
-           "throttlingPolicy": "Unlimited",
-           "scopes": [],
-           "usedProductIds": [],
-           "amznResourceName": null,
-           "amznResourceTimeout": null
-         }
-       ]
-     }
-   ],
-   "scopes": [],
-   "categories": []
- }
+  "id": "e62c19bf-51b8-4767-b8b8-690085241f26",
+  "name": "SampleAPIProduct",
+  "context": "/sampleapiproduct",
+  "description": null,
+  "provider": "admin",
+  "hasThumbnail": null,
+  "state": "PUBLISHED",
+  "enableSchemaValidation": false,
+  "responseCachingEnabled": false,
+  "cacheTimeout": 300,
+  "visibility": "PUBLIC",
+  "visibleRoles": [],
+  "visibleTenants": [],
+  "accessControl": "NONE",
+  "accessControlRoles": [],
+  "gatewayEnvironments": [
+    "Production and Sandbox"
+  ],
+  "apiType": "APIProduct",
+  "transport": [
+    "http",
+    "https"
+  ],
+  "tags": [],
+  "policies": [
+    "Bronze",
+    "Gold"
+  ],
+  "apiThrottlingPolicy": null,
+  "authorizationHeader": "Authorization",
+  "securityScheme": [
+    "oauth2",
+    "oauth_basic_auth_api_key_mandatory"
+  ],
+  "subscriptionAvailability": "ALL_TENANTS",
+  "subscriptionAvailableTenants": [],
+  "additionalProperties": {},
+  "monetization": null,
+  "businessInformation": {
+    "businessOwner": null,
+    "businessOwnerEmail": null,
+    "technicalOwner": null,
+    "technicalOwnerEmail": null
+  },
+  "corsConfiguration": {
+    "corsConfigurationEnabled": false,
+    "accessControlAllowOrigins": [
+      "*"
+    ],
+    "accessControlAllowCredentials": false,
+    "accessControlAllowHeaders": [
+      "authorization",
+      "Access-Control-Allow-Origin",
+      "Content-Type",
+      "SOAPAction",
+      "apikey"
+    ],
+    "accessControlAllowMethods": [
+      "GET",
+      "PUT",
+      "POST",
+      "DELETE",
+      "PATCH",
+      "OPTIONS"
+    ]
+  },
+  "apis": [
+    {
+      "name": "PizzaShackAPI",
+      "apiId": "4df14bdd-5934-47ab-9afe-4704d5a1cb2b",
+      "operations": [
+        {
+          "id": "",
+          "target": "/menu",
+          "verb": "GET",
+          "authType": "Application & Application User",
+          "throttlingPolicy": "Unlimited",
+          "scopes": [],
+          "usedProductIds": [],
+          "amznResourceName": null,
+          "amznResourceTimeout": null
+        },
+        {
+          "id": "",
+          "target": "/order/{orderId}",
+          "verb": "PUT",
+          "authType": "Application & Application User",
+          "throttlingPolicy": "Unlimited",
+          "scopes": [],
+          "usedProductIds": [],
+          "amznResourceName": null,
+          "amznResourceTimeout": null
+        }
+      ]
+    },
+    {
+      "name": "SwaggerPetstore",
+      "apiId": "a2479626-453b-4204-b502-9b372a3ef29f",
+      "operations": [
+        {
+          "id": "",
+          "target": "/pet/{petId}/uploadImage",
+          "verb": "POST",
+          "authType": "Application & Application User",
+          "throttlingPolicy": "Unlimited",
+          "scopes": [],
+          "usedProductIds": [],
+          "amznResourceName": null,
+          "amznResourceTimeout": null
+        },
+        {
+          "id": "",
+          "target": "/pet/findByStatus",
+          "verb": "GET",
+          "authType": "Application & Application User",
+          "throttlingPolicy": "Unlimited",
+          "scopes": [],
+          "usedProductIds": [],
+          "amznResourceName": null,
+          "amznResourceTimeout": null
+        },
+        {
+          "id": "",
+          "target": "/pet/findByTags",
+          "verb": "GET",
+          "authType": "Application & Application User",
+          "throttlingPolicy": "Unlimited",
+          "scopes": [],
+          "usedProductIds": [],
+          "amznResourceName": null,
+          "amznResourceTimeout": null
+        }
+      ]
+    }
+  ],
+  "scopes": [],
+  "categories": []
+}

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -276,7 +276,6 @@ func ValidateAPIExport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	// Setup apictl envs
 	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
-	base.SetupEnv(t, args.DestAPIM.GetEnvName(), args.DestAPIM.GetApimURL(), args.DestAPIM.GetTokenURL())
 
 	// Export api from env 1
 	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -32,11 +32,12 @@ var CurrentDir, _ = os.Getwd()
 const ConfigDirName = ".wso2apictl"
 
 var HomeDirectory = getConfigHomeDir()
+
 func getConfigHomeDir() string {
 	value := os.Getenv("APICTL_CONFIG_DIR")
 	if len(value) == 0 {
 		value, err := os.UserHomeDir()
-		if len(value) == 0 || err != nil  {
+		if len(value) == 0 || err != nil {
 			current, err := user.Current()
 			if err != nil || current == nil {
 				HandleErrorAndExit("User's HOME folder location couldn't be identified", nil)
@@ -74,6 +75,7 @@ var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
 var DefaultCertDirPath = filepath.Join(ConfigDirPath, CertificatesDirName)
 
 const defaultApiApplicationImportExportSuffix = "api/am/admin/v1"
+const defaultPublisherApiImportExportSuffix = "api/am/publisher/v1"
 const defaultApiListEndpointSuffix = "api/am/publisher/v1/apis"
 const defaultApiProductListEndpointSuffix = "api/am/publisher/v1/api-products"
 const defaultUnifiedSearchEndpointSuffix = "api/am/publisher/v1/search"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -162,7 +162,14 @@ func GetApiManagerEndpointOfEnv(env, filePath string) string {
 // Get PublisherEndpoint of a given environment
 func GetPublisherEndpointOfEnv(env, filePath string) string {
 	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)
-	return envEndpoints.PublisherEndpoint
+	if !(envEndpoints.PublisherEndpoint == "" || envEndpoints == nil) {
+		envEndpoints.PublisherEndpoint = AppendSlashToString(envEndpoints.PublisherEndpoint)
+		return envEndpoints.AdminEndpoint + defaultPublisherApiImportExportSuffix
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint + defaultPublisherApiImportExportSuffix
+	}
 }
 
 // Get AdminEndpoint of a given environment
@@ -319,7 +326,7 @@ func GetDefaultEnvironment(mainConfigFilePath string) string {
 
 //get default token endpoint given from an apim endpoint
 func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
-	if strings.HasSuffix(apimEndpoint,"/"){
+	if strings.HasSuffix(apimEndpoint, "/") {
 		return apimEndpoint + defaultTokenEndPoint
 	} else {
 		return apimEndpoint + "/" + defaultTokenEndPoint
@@ -327,13 +334,13 @@ func GetTokenEndPointFromAPIMEndpoint(apimEndpoint string) string {
 }
 
 //get default token endpoint given from a publisher endpoint
-func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
-	if strings.Contains(publisherEndpoint,"publisher"){
-		trimmedString := strings.Split(publisherEndpoint,"publisher")
+func GetTokenEndPointFromPublisherEndpoint(publisherEndpoint string) string {
+	if strings.Contains(publisherEndpoint, "publisher") {
+		trimmedString := strings.Split(publisherEndpoint, "publisher")
 		publisherEndpoint = trimmedString[0]
 	}
 
-	if strings.HasSuffix(publisherEndpoint,"/"){
+	if strings.HasSuffix(publisherEndpoint, "/") {
 		return publisherEndpoint + defaultTokenEndPoint
 	} else {
 		return publisherEndpoint + "/" + defaultTokenEndPoint
@@ -342,14 +349,14 @@ func GetTokenEndPointFromPublisherEndpoint (publisherEndpoint string) string {
 
 // Get internalTokenEndpoint for REST api operations
 // @return endpoint url derived from publisher or apim endpoint
-func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
+func GetInternalTokenEndpointOfEnv(env, filePath string) string {
 	var internalTokenEndpoint string
 	apiManagerEndpointOfEnv := GetApiManagerEndpointOfEnv(env, filePath)
 	if apiManagerEndpointOfEnv != "" {
 		internalTokenEndpoint = GetTokenEndPointFromAPIMEndpoint(apiManagerEndpointOfEnv)
 
 	} else {
-		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env,filePath)
+		publisherEndpointOfEnv := GetPublisherEndpointOfEnv(env, filePath)
 		internalTokenEndpoint = GetTokenEndPointFromPublisherEndpoint(publisherEndpointOfEnv)
 	}
 	return internalTokenEndpoint
@@ -357,10 +364,10 @@ func GetInternalTokenEndpointOfEnv(env, filePath string ) string {
 
 //Get token endpoint for Token revocation
 //@return endpoint URL of token revocation endpoint
-func GetTokenRevokeEndpoint (env, filePath string) string {
+func GetTokenRevokeEndpoint(env, filePath string) string {
 	//Get Internal token endpoint for the environment
-	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env,filePath)
-	slittedString := strings.Split(internalTokenEndpoint,defaultTokenEndPoint)
+	internalTokenEndpoint := GetInternalTokenEndpointOfEnv(env, filePath)
+	slittedString := strings.Split(internalTokenEndpoint, defaultTokenEndPoint)
 	//Get Apim endpoint or publisher endpoint
 	extractedTokenEndpoint := slittedString[0]
 	return extractedTokenEndpoint + defaultRevokeEndpointSuffix


### PR DESCRIPTION
## Purpose
Earlier we were using Admin REST API when importing and exporting API and API Product artifacts. But with this, from now onwards APICTL will be using the new Publisher REST APIs which was implemented via [1] and [2] for this task. Hence, this will reduce the burden of CTL code base by removing/modifying most of the code segments due to the simple structure that we are going to maintain using the API DTOs from server side.

Further this is related to the below issues as well.
Fixes: https://github.com/wso2/product-apim-tooling/issues/324
Fixes: https://github.com/wso2/product-apim-tooling/issues/158

## Goals
Change the export/import APIs/API Products endpoints to Publisher REST API and remove the unnecessary code.

## Approach
- Changed the export/import APIs/API Products REST API endpoints as shown below.
<table>
  <tr>
    <th>Operation</th>
    <th>Old REST API Endpoint</th>
    <th>New REST API Endpoint</th> 
  </tr>
  <tr>
    <td>Export API</td>
    <td>GET admin/v1/export/api</td>
    <td>GET publisher/v1/apis/export</td>
  </tr>
  <tr>
    <td>Export API Product</td>
    <td>GET admin/v1/export/api-product</td>
    <td>GET publisher/v1/api-products/export</td>
  </tr>
  <tr>
    <td>Import API</td>
    <td>POST admin/v1/import/api</td>
    <td>POST publisher/v1/apis/import</td>
  </tr>
  <tr>
    <td>Import API Product</td>
    <td>POST admin/v1/import/api-product</td>
    <td>POST publisher/v1/api-products/import</td>
  </tr>
</table>
- Removed the API structural validations which were happening during import, since those will be handled by the server side.
- Modified integration test related to importing APIs/API Products.

## User stories
Now, when exporting/importing APIs/API Products, the users will be using Publisher REST API. Hence the folder structure and the schema structure will be changed according to [1] and [2].

## Release note
Now APICTL uses Publisher REST API instead of Admin REST API during the import/export operations related to APIs and API Products.

## Documentation
Documentation changes should be done according to [3].

## Related PRs
[1] https://github.com/wso2/carbon-apimgt/pull/9406
[2] https://github.com/wso2/carbon-apimgt/pull/9464
[3] https://github.com/wso2/product-apim-tooling/issues/544

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64
