### PR TITLE
Add commands to retrieve details about artifacts deployed in MI instances

### DIFF
--- a/import-export-cli/cmd/mi/get/apis.go
+++ b/import-export-cli/cmd/mi/get/apis.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getIntegrationAPICmdEnvironment string
+var getIntegrationAPICmdFormat string
+
+const artifactAPIs = "apis"
+const getIntegrationAPICmdLiteral = "apis [api-name]"
+
+var getIntegrationAPICmd = &cobra.Command{
+	Use:     getIntegrationAPICmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactAPIs),
+	Long:    generateGetCmdLongDescForArtifact(artifactAPIs, "api-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactAPIs, getTrimmedCmdLiteral(getIntegrationAPICmdLiteral), "SampleIntegrationAPI"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetIntegrationAPICmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getIntegrationAPICmd)
+	getIntegrationAPICmd.Flags().StringVarP(&getIntegrationAPICmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getIntegrationAPICmd.Flags().StringVarP(&getIntegrationAPICmdFormat, "format", "", "", generateFormatFlagUsage(artifactAPIs))
+	getIntegrationAPICmd.MarkFlagRequired("environment")
+}
+
+func handleGetIntegrationAPICmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getIntegrationAPICmdLiteral))
+	credentials.HandleMissingCredentials(getIntegrationAPICmdEnvironment)
+	if len(args) == 1 {
+		var IntegrationAPIName = args[0]
+		executeShowIntegrationAPI(IntegrationAPIName)
+	} else {
+		executeListIntegrationAPIs()
+	}
+}
+
+func executeListIntegrationAPIs() {
+
+	apiList, err := impl.GetIntegrationAPIList(getIntegrationAPICmdEnvironment)
+	if err == nil {
+		impl.PrintIntegrationAPIList(apiList, getIntegrationAPICmdFormat)
+	} else {
+		printErrorForArtifactList(artifactAPIs, err)
+	}
+}
+
+func executeShowIntegrationAPI(apiName string) {
+	integrationAPI, err := impl.GetIntegrationAPI(getIntegrationAPICmdEnvironment, apiName)
+	if err == nil {
+		impl.PrintIntegrationAPIDetails(integrationAPI, getIntegrationAPICmdFormat)
+	} else {
+		printErrorForArtifact(artifactAPIs, apiName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/apis.go
+++ b/import-export-cli/cmd/mi/get/apis.go
@@ -43,10 +43,8 @@ var getIntegrationAPICmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getIntegrationAPICmd)
-	getIntegrationAPICmd.Flags().StringVarP(&getIntegrationAPICmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getIntegrationAPICmd.Flags().StringVarP(&getIntegrationAPICmdFormat, "format", "", "", generateFormatFlagUsage(artifactAPIs))
-	getIntegrationAPICmd.MarkFlagRequired("environment")
+	setEnvFlag(getIntegrationAPICmd, &getIntegrationAPICmdEnvironment)
+	setFormatFlag(getIntegrationAPICmd, &getIntegrationAPICmdFormat)
 }
 
 func handleGetIntegrationAPICmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetIntegrationAPICmdArguments(args []string) {
 }
 
 func executeListIntegrationAPIs() {
-
 	apiList, err := impl.GetIntegrationAPIList(getIntegrationAPICmdEnvironment)
 	if err == nil {
 		impl.PrintIntegrationAPIList(apiList, getIntegrationAPICmdFormat)

--- a/import-export-cli/cmd/mi/get/compositeApps.go
+++ b/import-export-cli/cmd/mi/get/compositeApps.go
@@ -43,10 +43,8 @@ var getApplicationCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getApplicationCmd)
-	getApplicationCmd.Flags().StringVarP(&getApplicationCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getApplicationCmd.Flags().StringVarP(&getApplicationCmdFormat, "format", "", "", generateFormatFlagUsage(artifactCompositeApps))
-	getApplicationCmd.MarkFlagRequired("environment")
+	setEnvFlag(getApplicationCmd, &getApplicationCmdEnvironment)
+	setFormatFlag(getApplicationCmd, &getApplicationCmdFormat)
 }
 
 func handleGetApplicationCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetApplicationCmdArguments(args []string) {
 }
 
 func executeListCarbonApps() {
-
 	appList, err := impl.GetCompositeAppList(getApplicationCmdEnvironment)
 	if err == nil {
 		impl.PrintCompositeAppList(appList, getApplicationCmdFormat)

--- a/import-export-cli/cmd/mi/get/compositeApps.go
+++ b/import-export-cli/cmd/mi/get/compositeApps.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getApplicationCmdEnvironment string
+var getApplicationCmdFormat string
+
+const artifactCompositeApps = "composite apps"
+const getApplicationCmdLiteral = "composite-apps [app-name]"
+
+var getApplicationCmd = &cobra.Command{
+	Use:     getApplicationCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactCompositeApps),
+	Long:    generateGetCmdLongDescForArtifact(artifactCompositeApps, "app-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactCompositeApps, getTrimmedCmdLiteral(getApplicationCmdLiteral), "SampleApp"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetApplicationCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getApplicationCmd)
+	getApplicationCmd.Flags().StringVarP(&getApplicationCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getApplicationCmd.Flags().StringVarP(&getApplicationCmdFormat, "format", "", "", generateFormatFlagUsage(artifactCompositeApps))
+	getApplicationCmd.MarkFlagRequired("environment")
+}
+
+func handleGetApplicationCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getApplicationCmdLiteral))
+	credentials.HandleMissingCredentials(getApplicationCmdEnvironment)
+	if len(args) == 1 {
+		var appName = args[0]
+		executeShowCarbonApp(appName)
+	} else {
+		executeListCarbonApps()
+	}
+}
+
+func executeListCarbonApps() {
+
+	appList, err := impl.GetCompositeAppList(getApplicationCmdEnvironment)
+	if err == nil {
+		impl.PrintCompositeAppList(appList, getApplicationCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactCompositeApps, err)
+	}
+}
+
+func executeShowCarbonApp(appname string) {
+	app, err := impl.GetCompositeApp(getApplicationCmdEnvironment, appname)
+	if err == nil {
+		impl.PrintCompositeAppDetails(app, getApplicationCmdFormat)
+	} else {
+		printErrorForArtifact(artifactCompositeApps, appname, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/connectors.go
+++ b/import-export-cli/cmd/mi/get/connectors.go
@@ -1,0 +1,73 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getConnectorCmdEnvironment string
+var getConnectorCmdFormat string
+
+const getConnectorCmdLiteral = "connectors"
+const getConnectorCmdShortDesc = "Get information about connectors deployed in a Micro Integrator"
+
+const getConnectorCmdLongDesc = "List all the connectors deployed in a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getConnectorCmdExamples = "To list all the connectors\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getConnectorCmdLiteral + " -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var getConnectorCmd = &cobra.Command{
+	Use:     getConnectorCmdLiteral,
+	Short:   getConnectorCmdShortDesc,
+	Long:    getConnectorCmdLongDesc,
+	Example: getConnectorCmdExamples,
+	Args:    cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetConnectorCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getConnectorCmd)
+	getConnectorCmd.Flags().StringVarP(&getConnectorCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getConnectorCmd.Flags().StringVarP(&getConnectorCmdFormat, "format", "", "", generateFormatFlagUsage(getConnectorCmdLiteral))
+	getConnectorCmd.MarkFlagRequired("environment")
+}
+
+func handleGetConnectorCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getConnectorCmdLiteral)
+	credentials.HandleMissingCredentials(getConnectorCmdEnvironment)
+	executeListConnectors()
+}
+
+func executeListConnectors() {
+
+	connectorList, err := impl.GetConnectorList(getConnectorCmdEnvironment)
+	if err == nil {
+		impl.PrintConnectorList(connectorList, getConnectorCmdFormat)
+	} else {
+		printErrorForArtifactList(getConnectorCmdLiteral, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/connectors.go
+++ b/import-export-cli/cmd/mi/get/connectors.go
@@ -50,10 +50,8 @@ var getConnectorCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getConnectorCmd)
-	getConnectorCmd.Flags().StringVarP(&getConnectorCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getConnectorCmd.Flags().StringVarP(&getConnectorCmdFormat, "format", "", "", generateFormatFlagUsage(getConnectorCmdLiteral))
-	getConnectorCmd.MarkFlagRequired("environment")
+	setEnvFlag(getConnectorCmd, &getConnectorCmdEnvironment)
+	setFormatFlag(getConnectorCmd, &getConnectorCmdFormat)
 }
 
 func handleGetConnectorCmdArguments(args []string) {
@@ -63,7 +61,6 @@ func handleGetConnectorCmdArguments(args []string) {
 }
 
 func executeListConnectors() {
-
 	connectorList, err := impl.GetConnectorList(getConnectorCmdEnvironment)
 	if err == nil {
 		impl.PrintConnectorList(connectorList, getConnectorCmdFormat)

--- a/import-export-cli/cmd/mi/get/dataservices.go
+++ b/import-export-cli/cmd/mi/get/dataservices.go
@@ -43,10 +43,8 @@ var getDataServiceCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getDataServiceCmd)
-	getDataServiceCmd.Flags().StringVarP(&getDataServiceCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getDataServiceCmd.Flags().StringVarP(&getDataServiceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactDataServices))
-	getDataServiceCmd.MarkFlagRequired("environment")
+	setEnvFlag(getDataServiceCmd, &getDataServiceCmdEnvironment)
+	setFormatFlag(getDataServiceCmd, &getDataServiceCmdFormat)
 }
 
 func handleGetDataServiceCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetDataServiceCmdArguments(args []string) {
 }
 
 func executeListDataServices() {
-
 	dataServiceList, err := impl.GetDataServiceList(getDataServiceCmdEnvironment)
 	if err == nil {
 		impl.PrintDataServiceList(dataServiceList, getDataServiceCmdFormat)

--- a/import-export-cli/cmd/mi/get/dataservices.go
+++ b/import-export-cli/cmd/mi/get/dataservices.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getDataServiceCmdEnvironment string
+var getDataServiceCmdFormat string
+
+const artifactDataServices = "data services"
+const getDataServiceCmdLiteral = "data-services [dataservice-name]"
+
+var getDataServiceCmd = &cobra.Command{
+	Use:     getDataServiceCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactDataServices),
+	Long:    generateGetCmdLongDescForArtifact(artifactDataServices, "dataservice-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactDataServices, getTrimmedCmdLiteral(getDataServiceCmdLiteral), "SampleDataService"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetDataServiceCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getDataServiceCmd)
+	getDataServiceCmd.Flags().StringVarP(&getDataServiceCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getDataServiceCmd.Flags().StringVarP(&getDataServiceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactDataServices))
+	getDataServiceCmd.MarkFlagRequired("environment")
+}
+
+func handleGetDataServiceCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getDataServiceCmdLiteral))
+	credentials.HandleMissingCredentials(getDataServiceCmdEnvironment)
+	if len(args) == 1 {
+		var dataServiceName = args[0]
+		executeShowDataService(dataServiceName)
+	} else {
+		executeListDataServices()
+	}
+}
+
+func executeListDataServices() {
+
+	dataServiceList, err := impl.GetDataServiceList(getDataServiceCmdEnvironment)
+	if err == nil {
+		impl.PrintDataServiceList(dataServiceList, getDataServiceCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactDataServices, err)
+	}
+}
+
+func executeShowDataService(dataserviceName string) {
+	dataservice, err := impl.GetDataService(getDataServiceCmdEnvironment, dataserviceName)
+	if err == nil {
+		impl.PrintDataServiceDetails(dataservice, getDataServiceCmdFormat)
+	} else {
+		printErrorForArtifact(artifactDataServices, dataserviceName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/endpoints.go
+++ b/import-export-cli/cmd/mi/get/endpoints.go
@@ -43,10 +43,8 @@ var getEndpointCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getEndpointCmd)
-	getEndpointCmd.Flags().StringVarP(&getEndpointCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getEndpointCmd.Flags().StringVarP(&getEndpointCmdFormat, "format", "", "", generateFormatFlagUsage(artifactEndpoints))
-	getEndpointCmd.MarkFlagRequired("environment")
+	setEnvFlag(getEndpointCmd, &getEndpointCmdEnvironment)
+	setFormatFlag(getEndpointCmd, &getEndpointCmdFormat)
 }
 
 func handleGetEndpointCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetEndpointCmdArguments(args []string) {
 }
 
 func executeListEndpoints() {
-
 	epList, err := impl.GetEndpointList(getEndpointCmdEnvironment)
 	if err == nil {
 		impl.PrintEndpointList(epList, getEndpointCmdFormat)

--- a/import-export-cli/cmd/mi/get/endpoints.go
+++ b/import-export-cli/cmd/mi/get/endpoints.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getEndpointCmdEnvironment string
+var getEndpointCmdFormat string
+
+const artifactEndpoints = "endpoints"
+const getEndpointCmdLiteral = "endpoints [endpoint-name]"
+
+var getEndpointCmd = &cobra.Command{
+	Use:     getEndpointCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactEndpoints),
+	Long:    generateGetCmdLongDescForArtifact(artifactEndpoints, "endpoint-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactEndpoints, getTrimmedCmdLiteral(getEndpointCmdLiteral), "SampleEndpoint"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetEndpointCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getEndpointCmd)
+	getEndpointCmd.Flags().StringVarP(&getEndpointCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getEndpointCmd.Flags().StringVarP(&getEndpointCmdFormat, "format", "", "", generateFormatFlagUsage(artifactEndpoints))
+	getEndpointCmd.MarkFlagRequired("environment")
+}
+
+func handleGetEndpointCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getEndpointCmdLiteral))
+	credentials.HandleMissingCredentials(getEndpointCmdEnvironment)
+	if len(args) == 1 {
+		var EndpointName = args[0]
+		executeShowEndpoint(EndpointName)
+	} else {
+		executeListEndpoints()
+	}
+}
+
+func executeListEndpoints() {
+
+	epList, err := impl.GetEndpointList(getEndpointCmdEnvironment)
+	if err == nil {
+		impl.PrintEndpointList(epList, getEndpointCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactEndpoints, err)
+	}
+}
+
+func executeShowEndpoint(epName string) {
+	endpoint, err := impl.GetEndpoint(getEndpointCmdEnvironment, epName)
+	if err == nil {
+		impl.PrintEndpointDetails(endpoint, getEndpointCmdFormat)
+	} else {
+		printErrorForArtifact(artifactEndpoints, epName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/get.go
+++ b/import-export-cli/cmd/mi/get/get.go
@@ -16,30 +16,30 @@
 * under the License.
  */
 
-package mi
+package get
 
 import (
 	"github.com/spf13/cobra"
-	miGetCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/get"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const miCmdShortDesc = "Micro Integrator related commands"
+// GetCmdLiteral Get command related usage Info
+const GetCmdLiteral = "get"
+const getCmdShortDesc = "Get information about artifacts deployed in a Micro Integrator instance"
 
-const miCmdLongDesc = `Micro Integrator related commands such as login, logout, get, add, update, delete, activate, deactivate.`
+const getCmdLongDesc = `Get information about artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)`
 
-// MICmd represents the mi command
-var MICmd = &cobra.Command{
-	Use:   utils.MiCmdLiteral,
-	Short: miCmdShortDesc,
-	Long:  miCmdLongDesc,
-	// Example: miCmdExamples,
+const getCmdExamples = utils.ProjectName + ` ` + utils.MiCmdLiteral + ` ` + GetCmdLiteral + ` ` + `apis` + ` -e dev
+` + utils.ProjectName + ` ` + utils.MiCmdLiteral + ` ` + GetCmdLiteral + ` ` + `endpoints` + ` -e dev`
+
+// GetCmd represents the get command
+var GetCmd = &cobra.Command{
+	Use:     GetCmdLiteral,
+	Short:   getCmdShortDesc,
+	Long:    getCmdLongDesc,
+	Example: getCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.Logln(utils.LogPrefixInfo + utils.MiCmdLiteral + " called")
+		utils.Logln(utils.LogPrefixInfo + GetCmdLiteral + " called")
 		cmd.Help()
 	},
-}
-
-func init() {
-	MICmd.AddCommand(miGetCmd.GetCmd)
 }

--- a/import-export-cli/cmd/mi/get/inboundendpoints.go
+++ b/import-export-cli/cmd/mi/get/inboundendpoints.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getInboundEndpointCmdEnvironment string
+var getInboundEndpointCmdFormat string
+
+const artifactInboundEndpoints = "inbound endpoints"
+const getInboundEndpointCmdLiteral = "inbound-endpoints [inbound-name]"
+
+var getInboundEndpointCmd = &cobra.Command{
+	Use:     getInboundEndpointCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactInboundEndpoints),
+	Long:    generateGetCmdLongDescForArtifact(artifactInboundEndpoints, "inbound-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactInboundEndpoints, getTrimmedCmdLiteral(getInboundEndpointCmdLiteral), "SampleInboundEndpoint"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetInboundEndpointCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getInboundEndpointCmd)
+	getInboundEndpointCmd.Flags().StringVarP(&getInboundEndpointCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getInboundEndpointCmd.Flags().StringVarP(&getInboundEndpointCmdFormat, "format", "", "", generateFormatFlagUsage(artifactInboundEndpoints))
+	getInboundEndpointCmd.MarkFlagRequired("environment")
+}
+
+func handleGetInboundEndpointCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getInboundEndpointCmdLiteral))
+	credentials.HandleMissingCredentials(getInboundEndpointCmdEnvironment)
+	if len(args) == 1 {
+		var inboundEndpointName = args[0]
+		executeShowInboundEndpoint(inboundEndpointName)
+	} else {
+		executeListInboundEndpoints()
+	}
+}
+
+func executeListInboundEndpoints() {
+
+	inboundEpList, err := impl.GetInboundEndpointList(getInboundEndpointCmdEnvironment)
+	if err == nil {
+		impl.PrintInboundEndpointList(inboundEpList, getInboundEndpointCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactInboundEndpoints, err)
+	}
+}
+
+func executeShowInboundEndpoint(inboundEpName string) {
+	inboundEndpoint, err := impl.GetInboundEndpoint(getInboundEndpointCmdEnvironment, inboundEpName)
+	if err == nil {
+		impl.PrintInboundEndpointDetails(inboundEndpoint, getInboundEndpointCmdFormat)
+	} else {
+		printErrorForArtifact(artifactInboundEndpoints, inboundEpName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/inboundendpoints.go
+++ b/import-export-cli/cmd/mi/get/inboundendpoints.go
@@ -43,10 +43,8 @@ var getInboundEndpointCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getInboundEndpointCmd)
-	getInboundEndpointCmd.Flags().StringVarP(&getInboundEndpointCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getInboundEndpointCmd.Flags().StringVarP(&getInboundEndpointCmdFormat, "format", "", "", generateFormatFlagUsage(artifactInboundEndpoints))
-	getInboundEndpointCmd.MarkFlagRequired("environment")
+	setEnvFlag(getInboundEndpointCmd, &getInboundEndpointCmdEnvironment)
+	setFormatFlag(getInboundEndpointCmd, &getInboundEndpointCmdFormat)
 }
 
 func handleGetInboundEndpointCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetInboundEndpointCmdArguments(args []string) {
 }
 
 func executeListInboundEndpoints() {
-
 	inboundEpList, err := impl.GetInboundEndpointList(getInboundEndpointCmdEnvironment)
 	if err == nil {
 		impl.PrintInboundEndpointList(inboundEpList, getInboundEndpointCmdFormat)

--- a/import-export-cli/cmd/mi/get/localentries.go
+++ b/import-export-cli/cmd/mi/get/localentries.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getLocalEntryCmdEnvironment string
+var getLocalEntryCmdFormat string
+
+const artifactLocalEntries = "local entries"
+const getLocalEntryCmdLiteral = "local-entries [localentry-name]"
+
+var getLocalEntryCmd = &cobra.Command{
+	Use:     getLocalEntryCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactLocalEntries),
+	Long:    generateGetCmdLongDescForArtifact(artifactLocalEntries, "localentry-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactLocalEntries, getTrimmedCmdLiteral(getLocalEntryCmdLiteral), "SampleLocalEntry"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetLocalEntryCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getLocalEntryCmd)
+	getLocalEntryCmd.Flags().StringVarP(&getLocalEntryCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getLocalEntryCmd.Flags().StringVarP(&getLocalEntryCmdFormat, "format", "", "", generateFormatFlagUsage(artifactLocalEntries))
+	getLocalEntryCmd.MarkFlagRequired("environment")
+}
+
+func handleGetLocalEntryCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLocalEntryCmdLiteral))
+	credentials.HandleMissingCredentials(getLocalEntryCmdEnvironment)
+	if len(args) == 1 {
+		var LocalEntryName = args[0]
+		executeShowLocalEntry(LocalEntryName)
+	} else {
+		executeListLocalEntrys()
+	}
+}
+
+func executeListLocalEntrys() {
+
+	localEntryList, err := impl.GetLocalEntryList(getLocalEntryCmdEnvironment)
+	if err == nil {
+		impl.PrintLocalEntryList(localEntryList, getLocalEntryCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactLocalEntries, err)
+	}
+}
+
+func executeShowLocalEntry(localEntryName string) {
+	localEntry, err := impl.GetLocalEntry(getLocalEntryCmdEnvironment, localEntryName)
+	if err == nil {
+		impl.PrintLocalEntryDetails(localEntry, getLocalEntryCmdFormat)
+	} else {
+		printErrorForArtifact(artifactLocalEntries, localEntryName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/localentries.go
+++ b/import-export-cli/cmd/mi/get/localentries.go
@@ -43,10 +43,8 @@ var getLocalEntryCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getLocalEntryCmd)
-	getLocalEntryCmd.Flags().StringVarP(&getLocalEntryCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getLocalEntryCmd.Flags().StringVarP(&getLocalEntryCmdFormat, "format", "", "", generateFormatFlagUsage(artifactLocalEntries))
-	getLocalEntryCmd.MarkFlagRequired("environment")
+	setEnvFlag(getLocalEntryCmd, &getLocalEntryCmdEnvironment)
+	setFormatFlag(getLocalEntryCmd, &getLocalEntryCmdFormat)
 }
 
 func handleGetLocalEntryCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetLocalEntryCmdArguments(args []string) {
 }
 
 func executeListLocalEntrys() {
-
 	localEntryList, err := impl.GetLocalEntryList(getLocalEntryCmdEnvironment)
 	if err == nil {
 		impl.PrintLocalEntryList(localEntryList, getLocalEntryCmdFormat)

--- a/import-export-cli/cmd/mi/get/logLevels.go
+++ b/import-export-cli/cmd/mi/get/logLevels.go
@@ -1,0 +1,74 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getLogLevelCmdEnvironment string
+var getLogLevelCmdFormat string
+
+const getLogLevelCmdLiteral = "log-levels [logger-name]"
+const getLogLevelCmdShortDesc = "Get information about a Logger configured in a Micro Integrator"
+
+const getLogLevelCmdLongDesc = "Get information about the Logger specified by command line argument [logger-name]\nconfigured in a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getLogLevelCmdExamples = "To get details about a specific logger\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogLevelCmdLiteral) + " org-apache-coyote -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var getLogLevelCmd = &cobra.Command{
+	Use:     getLogLevelCmdLiteral,
+	Short:   getLogLevelCmdShortDesc,
+	Long:    getLogLevelCmdLongDesc,
+	Example: getLogLevelCmdExamples,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetLogLevelCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getLogLevelCmd)
+	getLogLevelCmd.Flags().StringVarP(&getLogLevelCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getLogLevelCmd.Flags().StringVarP(&getLogLevelCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getLogLevelCmdLiteral)))
+	getLogLevelCmd.MarkFlagRequired("environment")
+}
+
+func handleGetLogLevelCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLogLevelCmdLiteral))
+	credentials.HandleMissingCredentials(getLogLevelCmdEnvironment)
+	var loggerName = args[0]
+	executeShowLogLevel(loggerName)
+}
+
+func executeShowLogLevel(loggerName string) {
+
+	LogLevelList, err := impl.GetLoggerInfo(getLogLevelCmdEnvironment, loggerName)
+	if err == nil {
+		impl.PrintLoggerInfo(LogLevelList, getLogLevelCmdFormat)
+	} else {
+		printErrorForArtifact("logger", loggerName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/logLevels.go
+++ b/import-export-cli/cmd/mi/get/logLevels.go
@@ -50,10 +50,8 @@ var getLogLevelCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getLogLevelCmd)
-	getLogLevelCmd.Flags().StringVarP(&getLogLevelCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getLogLevelCmd.Flags().StringVarP(&getLogLevelCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getLogLevelCmdLiteral)))
-	getLogLevelCmd.MarkFlagRequired("environment")
+	setEnvFlag(getLogLevelCmd, &getLogLevelCmdEnvironment)
+	setFormatFlag(getLogLevelCmd, &getLogLevelCmdFormat)
 }
 
 func handleGetLogLevelCmdArguments(args []string) {
@@ -64,7 +62,6 @@ func handleGetLogLevelCmdArguments(args []string) {
 }
 
 func executeShowLogLevel(loggerName string) {
-
 	LogLevelList, err := impl.GetLoggerInfo(getLogLevelCmdEnvironment, loggerName)
 	if err == nil {
 		impl.PrintLoggerInfo(LogLevelList, getLogLevelCmdFormat)

--- a/import-export-cli/cmd/mi/get/logs.go
+++ b/import-export-cli/cmd/mi/get/logs.go
@@ -57,11 +57,9 @@ var getLogCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getLogCmd)
-	getLogCmd.Flags().StringVarP(&getLogCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getLogCmd.Flags().StringVarP(&getLogCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getLogCmdLiteral)))
+	setEnvFlag(getLogCmd, &getLogCmdEnvironment)
+	setFormatFlag(getLogCmd, &getLogCmdFormat)
 	getLogCmd.Flags().StringVarP(&logFileDownloadPath, "path", "p", "", "Path the file should be downloaded")
-	getLogCmd.MarkFlagRequired("environment")
 }
 
 func handleGetLogCmdArguments(args []string) {

--- a/import-export-cli/cmd/mi/get/logs.go
+++ b/import-export-cli/cmd/mi/get/logs.go
@@ -1,0 +1,98 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getLogCmdEnvironment string
+var getLogCmdFormat string
+var logFileDownloadPath string
+
+const getLogCmdLiteral = "logs [file-name]"
+
+const getLogCmdShortDesc = "List all the available log files"
+const getLogCmdLongDesc = "Download a log file by providing the file name and download location,\n" +
+	"if not provided, list all the log files of the Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getLogCmdExamples = "Example:\n" +
+	"To list all the log files\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogCmdLiteral) + " -e dev\n" +
+	"To download a selected log file\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogCmdLiteral) + " [file-name] -p [download-location] -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var getLogCmd = &cobra.Command{
+	Use:     getLogCmdLiteral,
+	Short:   getLogCmdShortDesc,
+	Long:    getLogCmdLongDesc,
+	Example: getLogCmdExamples,
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetLogCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getLogCmd)
+	getLogCmd.Flags().StringVarP(&getLogCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getLogCmd.Flags().StringVarP(&getLogCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getLogCmdLiteral)))
+	getLogCmd.Flags().StringVarP(&logFileDownloadPath, "path", "p", "", "Path the file should be downloaded")
+	getLogCmd.MarkFlagRequired("environment")
+}
+
+func handleGetLogCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLogCmdLiteral))
+	credentials.HandleMissingCredentials(getLogCmdEnvironment)
+	if len(args) == 1 {
+		var logFileName = args[0]
+		if isEmptyOrCurrentDir(logFileDownloadPath) {
+			logFileDownloadPath, _ = os.Getwd()
+		}
+		executeDownloadLogFile(logFileDownloadPath, logFileName)
+	} else {
+		executeListLogFiles()
+	}
+}
+
+func executeListLogFiles() {
+	fileList, err := impl.GetLogFileList(getLogCmdEnvironment)
+	if err == nil {
+		logFileList := impl.FilterOnlyLogFiles(fileList)
+		impl.PrintLogFileList(logFileList, getLogCmdFormat)
+	} else {
+		printErrorForArtifactList("log files", err)
+	}
+}
+
+func executeDownloadLogFile(targetDirectory, logFileName string) {
+	logFile, err := impl.GetLogFile(getLogCmdEnvironment, logFileName)
+	if err == nil {
+		impl.WriteLogFile(logFile, targetDirectory+"/"+logFileName)
+	} else {
+		printErrorForArtifact("log file", logFileName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/messageprocessors.go
+++ b/import-export-cli/cmd/mi/get/messageprocessors.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getMessageProcessorCmdEnvironment string
+var getMessageProcessorCmdFormat string
+
+const artifactMessageProcessors = "message processors"
+const getMessageProcessorCmdLiteral = "message-processors [messageprocessor-name]"
+
+var getMessageProcessorCmd = &cobra.Command{
+	Use:     getMessageProcessorCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactMessageProcessors),
+	Long:    generateGetCmdLongDescForArtifact(artifactMessageProcessors, "messageprocessor-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactMessageProcessors, getTrimmedCmdLiteral(getMessageProcessorCmdLiteral), "TestMessageProcessor"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetMessageProcessorCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getMessageProcessorCmd)
+	getMessageProcessorCmd.Flags().StringVarP(&getMessageProcessorCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getMessageProcessorCmd.Flags().StringVarP(&getMessageProcessorCmdFormat, "format", "", "", generateFormatFlagUsage(artifactMessageProcessors))
+	getMessageProcessorCmd.MarkFlagRequired("environment")
+}
+
+func handleGetMessageProcessorCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getMessageProcessorCmdLiteral))
+	credentials.HandleMissingCredentials(getMessageProcessorCmdEnvironment)
+	if len(args) == 1 {
+		var messageProcessorName = args[0]
+		executeShowMessageProcessor(messageProcessorName)
+	} else {
+		executeListMessageProcessors()
+	}
+}
+
+func executeListMessageProcessors() {
+
+	msgProcessorList, err := impl.GetMessageProcessorList(getMessageProcessorCmdEnvironment)
+	if err == nil {
+		impl.PrintMessageProcessorList(msgProcessorList, getMessageProcessorCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactMessageProcessors, err)
+	}
+}
+
+func executeShowMessageProcessor(msgProcessorName string) {
+	msgProcessor, err := impl.GetMessageProcessor(getMessageProcessorCmdEnvironment, msgProcessorName)
+	if err == nil {
+		impl.PrintMessageProcessorDetails(msgProcessor, getMessageProcessorCmdFormat)
+	} else {
+		printErrorForArtifact(artifactMessageProcessors, msgProcessorName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/messageprocessors.go
+++ b/import-export-cli/cmd/mi/get/messageprocessors.go
@@ -43,10 +43,8 @@ var getMessageProcessorCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getMessageProcessorCmd)
-	getMessageProcessorCmd.Flags().StringVarP(&getMessageProcessorCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getMessageProcessorCmd.Flags().StringVarP(&getMessageProcessorCmdFormat, "format", "", "", generateFormatFlagUsage(artifactMessageProcessors))
-	getMessageProcessorCmd.MarkFlagRequired("environment")
+	setEnvFlag(getMessageProcessorCmd, &getMessageProcessorCmdEnvironment)
+	setFormatFlag(getMessageProcessorCmd, &getMessageProcessorCmdFormat)
 }
 
 func handleGetMessageProcessorCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetMessageProcessorCmdArguments(args []string) {
 }
 
 func executeListMessageProcessors() {
-
 	msgProcessorList, err := impl.GetMessageProcessorList(getMessageProcessorCmdEnvironment)
 	if err == nil {
 		impl.PrintMessageProcessorList(msgProcessorList, getMessageProcessorCmdFormat)

--- a/import-export-cli/cmd/mi/get/messagestores.go
+++ b/import-export-cli/cmd/mi/get/messagestores.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getMessageStoreCmdEnvironment string
+var getMessageStoreCmdFormat string
+
+const artifactMessageStores = "message stores"
+const getMessageStoreCmdLiteral = "message-stores [messagestore-name]"
+
+var getMessageStoreCmd = &cobra.Command{
+	Use:     getMessageStoreCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactMessageStores),
+	Long:    generateGetCmdLongDescForArtifact(artifactMessageStores, "messagestore-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactMessageStores, getTrimmedCmdLiteral(getMessageStoreCmdLiteral), "TestMessageStore"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetMessageStoreCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getMessageStoreCmd)
+	getMessageStoreCmd.Flags().StringVarP(&getMessageStoreCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getMessageStoreCmd.Flags().StringVarP(&getMessageStoreCmdFormat, "format", "", "", generateFormatFlagUsage(artifactMessageStores))
+	getMessageStoreCmd.MarkFlagRequired("environment")
+}
+
+func handleGetMessageStoreCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getMessageStoreCmdLiteral))
+	credentials.HandleMissingCredentials(getMessageStoreCmdEnvironment)
+	if len(args) == 1 {
+		var messageStoreName = args[0]
+		executeShowMessageStore(messageStoreName)
+	} else {
+		executeListMessageStores()
+	}
+}
+
+func executeListMessageStores() {
+
+	messageStoreList, err := impl.GetMessageStoreList(getMessageStoreCmdEnvironment)
+	if err == nil {
+		impl.PrintMessageStoreList(messageStoreList, getMessageStoreCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactMessageStores, err)
+	}
+}
+
+func executeShowMessageStore(messageStoreName string) {
+	messageStore, err := impl.GetMessageStore(getMessageStoreCmdEnvironment, messageStoreName)
+	if err == nil {
+		impl.PrintMessageStoreDetails(messageStore, getMessageStoreCmdFormat)
+	} else {
+		printErrorForArtifact(artifactMessageStores, messageStoreName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/messagestores.go
+++ b/import-export-cli/cmd/mi/get/messagestores.go
@@ -43,10 +43,8 @@ var getMessageStoreCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getMessageStoreCmd)
-	getMessageStoreCmd.Flags().StringVarP(&getMessageStoreCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getMessageStoreCmd.Flags().StringVarP(&getMessageStoreCmdFormat, "format", "", "", generateFormatFlagUsage(artifactMessageStores))
-	getMessageStoreCmd.MarkFlagRequired("environment")
+	setEnvFlag(getMessageStoreCmd, &getMessageStoreCmdEnvironment)
+	setFormatFlag(getMessageStoreCmd, &getMessageStoreCmdFormat)
 }
 
 func handleGetMessageStoreCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetMessageStoreCmdArguments(args []string) {
 }
 
 func executeListMessageStores() {
-
 	messageStoreList, err := impl.GetMessageStoreList(getMessageStoreCmdEnvironment)
 	if err == nil {
 		impl.PrintMessageStoreList(messageStoreList, getMessageStoreCmdFormat)

--- a/import-export-cli/cmd/mi/get/proxyservices.go
+++ b/import-export-cli/cmd/mi/get/proxyservices.go
@@ -43,10 +43,8 @@ var getProxyServiceCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getProxyServiceCmd)
-	getProxyServiceCmd.Flags().StringVarP(&getProxyServiceCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getProxyServiceCmd.Flags().StringVarP(&getProxyServiceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactProxyServices))
-	getProxyServiceCmd.MarkFlagRequired("environment")
+	setEnvFlag(getProxyServiceCmd, &getProxyServiceCmdEnvironment)
+	setFormatFlag(getProxyServiceCmd, &getProxyServiceCmdFormat)
 }
 
 func handleGetProxyServiceCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetProxyServiceCmdArguments(args []string) {
 }
 
 func executeListProxyServices() {
-
 	proxyList, err := impl.GetProxyServiceList(getProxyServiceCmdEnvironment)
 	if err == nil {
 		impl.PrintProxyServiceList(proxyList, getProxyServiceCmdFormat)

--- a/import-export-cli/cmd/mi/get/proxyservices.go
+++ b/import-export-cli/cmd/mi/get/proxyservices.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getProxyServiceCmdEnvironment string
+var getProxyServiceCmdFormat string
+
+const artifactProxyServices = "proxy services"
+const getProxyServiceCmdLiteral = "proxy-services [proxy-name]"
+
+var getProxyServiceCmd = &cobra.Command{
+	Use:     getProxyServiceCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactProxyServices),
+	Long:    generateGetCmdLongDescForArtifact(artifactProxyServices, "proxy-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactProxyServices, getTrimmedCmdLiteral(getProxyServiceCmdLiteral), "SampleProxy"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetProxyServiceCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getProxyServiceCmd)
+	getProxyServiceCmd.Flags().StringVarP(&getProxyServiceCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getProxyServiceCmd.Flags().StringVarP(&getProxyServiceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactProxyServices))
+	getProxyServiceCmd.MarkFlagRequired("environment")
+}
+
+func handleGetProxyServiceCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getProxyServiceCmdLiteral))
+	credentials.HandleMissingCredentials(getProxyServiceCmdEnvironment)
+	if len(args) == 1 {
+		var proxyServiceName = args[0]
+		executeShowProxyService(proxyServiceName)
+	} else {
+		executeListProxyServices()
+	}
+}
+
+func executeListProxyServices() {
+
+	proxyList, err := impl.GetProxyServiceList(getProxyServiceCmdEnvironment)
+	if err == nil {
+		impl.PrintProxyServiceList(proxyList, getProxyServiceCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactProxyServices, err)
+	}
+}
+
+func executeShowProxyService(proxyName string) {
+	proxyService, err := impl.GetProxyService(getProxyServiceCmdEnvironment, proxyName)
+	if err == nil {
+		impl.PrintProxyServiceDetails(proxyService, getProxyServiceCmdFormat)
+	} else {
+		printErrorForArtifact(artifactProxyServices, proxyName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/sequences.go
+++ b/import-export-cli/cmd/mi/get/sequences.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getSequenceCmdEnvironment string
+var getSequenceCmdFormat string
+
+const artifactSequences = "sequences"
+const getSequenceCmdLiteral = "sequences [sequence-name]"
+
+var getSequenceCmd = &cobra.Command{
+	Use:     getSequenceCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactSequences),
+	Long:    generateGetCmdLongDescForArtifact(artifactSequences, "sequence-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactSequences, getTrimmedCmdLiteral(getSequenceCmdLiteral), "SampleSequence"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetSequenceCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getSequenceCmd)
+	getSequenceCmd.Flags().StringVarP(&getSequenceCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getSequenceCmd.Flags().StringVarP(&getSequenceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactSequences))
+	getSequenceCmd.MarkFlagRequired("environment")
+}
+
+func handleGetSequenceCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getSequenceCmdLiteral))
+	credentials.HandleMissingCredentials(getSequenceCmdEnvironment)
+	if len(args) == 1 {
+		var sequenceName = args[0]
+		executeShowSequence(sequenceName)
+	} else {
+		executeListSequences()
+	}
+}
+
+func executeListSequences() {
+
+	sequenceList, err := impl.GetSequenceList(getSequenceCmdEnvironment)
+	if err == nil {
+		impl.PrintSequenceList(sequenceList, getSequenceCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactSequences, err)
+	}
+}
+
+func executeShowSequence(sequenceName string) {
+	sequence, err := impl.GetSequence(getSequenceCmdEnvironment, sequenceName)
+	if err == nil {
+		impl.PrintSequenceDetails(sequence, getSequenceCmdFormat)
+	} else {
+		printErrorForArtifact(artifactSequences, sequenceName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/sequences.go
+++ b/import-export-cli/cmd/mi/get/sequences.go
@@ -43,10 +43,8 @@ var getSequenceCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getSequenceCmd)
-	getSequenceCmd.Flags().StringVarP(&getSequenceCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getSequenceCmd.Flags().StringVarP(&getSequenceCmdFormat, "format", "", "", generateFormatFlagUsage(artifactSequences))
-	getSequenceCmd.MarkFlagRequired("environment")
+	setEnvFlag(getSequenceCmd, &getSequenceCmdEnvironment)
+	setFormatFlag(getSequenceCmd, &getSequenceCmdFormat)
 }
 
 func handleGetSequenceCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetSequenceCmdArguments(args []string) {
 }
 
 func executeListSequences() {
-
 	sequenceList, err := impl.GetSequenceList(getSequenceCmdEnvironment)
 	if err == nil {
 		impl.PrintSequenceList(sequenceList, getSequenceCmdFormat)

--- a/import-export-cli/cmd/mi/get/tasks.go
+++ b/import-export-cli/cmd/mi/get/tasks.go
@@ -1,0 +1,80 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+)
+
+var getTaskCmdEnvironment string
+var getTaskCmdFormat string
+
+const artifactTasks = "tasks"
+const getTaskCmdLiteral = "tasks [task-name]"
+
+var getTasksCmd = &cobra.Command{
+	Use:     getTaskCmdLiteral,
+	Short:   generateGetCmdShortDescForArtifact(artifactTasks),
+	Long:    generateGetCmdLongDescForArtifact(artifactTasks, "task-name"),
+	Example: generateGetCmdExamplesForArtifact(artifactTasks, getTrimmedCmdLiteral(getTaskCmdLiteral), "SampleTask"),
+	Args:    cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetTaskCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getTasksCmd)
+	getTasksCmd.Flags().StringVarP(&getTaskCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getTasksCmd.Flags().StringVarP(&getTaskCmdFormat, "format", "", "", generateFormatFlagUsage(artifactTasks))
+	getTasksCmd.MarkFlagRequired("environment")
+}
+
+func handleGetTaskCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTaskCmdLiteral))
+	credentials.HandleMissingCredentials(getTaskCmdEnvironment)
+	if len(args) == 1 {
+		var taskName = args[0]
+		executeShowTask(taskName)
+	} else {
+		executeListTasks()
+	}
+}
+
+func executeListTasks() {
+
+	taskList, err := impl.GetTaskList(getTaskCmdEnvironment)
+	if err == nil {
+		impl.PrintTaskList(taskList, getTaskCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactTasks, err)
+	}
+}
+
+func executeShowTask(taskName string) {
+	task, err := impl.GetTask(getTaskCmdEnvironment, taskName)
+	if err == nil {
+		impl.PrintTaskDetails(task, getTaskCmdFormat)
+	} else {
+		printErrorForArtifact(artifactTasks, taskName, err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/tasks.go
+++ b/import-export-cli/cmd/mi/get/tasks.go
@@ -43,10 +43,8 @@ var getTasksCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getTasksCmd)
-	getTasksCmd.Flags().StringVarP(&getTaskCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getTasksCmd.Flags().StringVarP(&getTaskCmdFormat, "format", "", "", generateFormatFlagUsage(artifactTasks))
-	getTasksCmd.MarkFlagRequired("environment")
+	setEnvFlag(getTasksCmd, &getTaskCmdEnvironment)
+	setFormatFlag(getTasksCmd, &getTaskCmdFormat)
 }
 
 func handleGetTaskCmdArguments(args []string) {
@@ -61,7 +59,6 @@ func handleGetTaskCmdArguments(args []string) {
 }
 
 func executeListTasks() {
-
 	taskList, err := impl.GetTaskList(getTaskCmdEnvironment)
 	if err == nil {
 		impl.PrintTaskList(taskList, getTaskCmdFormat)

--- a/import-export-cli/cmd/mi/get/templates.go
+++ b/import-export-cli/cmd/mi/get/templates.go
@@ -1,0 +1,143 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getTemplateCmdEnvironment string
+var getTemplateCmdFormat string
+
+const artifactTemplates = "templates"
+const getTemplateCmdLiteral = "templates [template-type] [template-name]"
+
+const getTemplateCmdShortDesc = "Get information about templates deployed in a Micro Integrator"
+
+const getTemplateCmdLongDesc = "Get information about the template specified by command line arguments [template-type] and [template-name]\n" +
+	"If not specified, list all the templates in the environment specified by the flag --environment, -e"
+
+var getTemplateCmdExamples = "To list all the " + artifactTemplates + "\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " -e dev\n" +
+	"To get details about a specific template type\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType\n" +
+	"To get details about a specific template\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType TemplateName -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+const endpointKey string = "endpoint"
+const sequenceKey string = "sequence"
+
+var getTemplateCmd = &cobra.Command{
+	Use:     getTemplateCmdLiteral,
+	Short:   getTemplateCmdShortDesc,
+	Long:    getTemplateCmdLongDesc,
+	Example: getTemplateCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 2 {
+			var errMessage = "accepts at most 2 arg(s), received " + fmt.Sprint(len(args))
+			return errors.New(errMessage)
+		} else if len(args) > 0 {
+			if !isValidTemplateType(args[0]) {
+				var errMessage = "accepts " + endpointKey + " or " + sequenceKey + " as template-type, invalid template type " + args[0]
+				return errors.New(errMessage)
+			}
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetTemplateCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getTemplateCmd)
+	getTemplateCmd.Flags().StringVarP(&getTemplateCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getTemplateCmd.Flags().StringVarP(&getTemplateCmdFormat, "format", "", "", generateFormatFlagUsage(artifactTemplates))
+	getTemplateCmd.MarkFlagRequired("environment")
+}
+
+func handleGetTemplateCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTemplateCmdLiteral))
+	credentials.HandleMissingCredentials(getTemplateCmdEnvironment)
+	if len(args) == 2 {
+		var templateType = args[0]
+		var templateName = args[1]
+		executeGetTemplateByNameCmd(templateType, templateName)
+	} else if len(args) == 1 {
+		var templateType = args[0]
+		executeGetTemplateByTypeCmd(templateType)
+	} else {
+		executeListTemplates()
+	}
+}
+
+func executeListTemplates() {
+
+	templateList, err := impl.GetTemplateList(getTemplateCmdEnvironment)
+	if err == nil {
+		impl.PrintTemplateList(templateList, getTemplateCmdFormat)
+	} else {
+		printErrorForArtifactList(artifactTemplates, err)
+	}
+}
+
+func executeGetTemplateByTypeCmd(templateType string) {
+
+	templateList, err := impl.GetTemplatesByType(getTemplateCmdEnvironment, templateType)
+	if err == nil {
+		impl.PrintTemplatesByType(templateList, getTemplateCmdFormat)
+	} else {
+		printErrorForArtifact(artifactTemplates, templateType, err)
+	}
+}
+
+func executeGetTemplateByNameCmd(templateType, templateName string) {
+
+	if templateType == sequenceKey {
+		sequenceTemplate, err := impl.GetSequenceTemplate(getTemplateCmdEnvironment, templateName)
+		if err == nil {
+			impl.PrintSequenceTemplateDetails(sequenceTemplate, getTemplateCmdFormat)
+		} else {
+			printErrorForArtifact(artifactTemplates, templateName, err)
+		}
+	}
+
+	if templateType == endpointKey {
+		endpointTemplate, err := impl.GetEndpointTemplate(getTemplateCmdEnvironment, templateName)
+		if err == nil {
+			impl.PrintEndpointTemplateDetails(endpointTemplate, getTemplateCmdFormat)
+		} else {
+			printErrorForArtifact(artifactTemplates, templateName, err)
+		}
+	}
+}
+
+func isValidTemplateType(templateType string) bool {
+	templateType = strings.ToLower(templateType)
+	return templateType == endpointKey || templateType == sequenceKey
+}

--- a/import-export-cli/cmd/mi/get/templates.go
+++ b/import-export-cli/cmd/mi/get/templates.go
@@ -75,10 +75,8 @@ var getTemplateCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getTemplateCmd)
-	getTemplateCmd.Flags().StringVarP(&getTemplateCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getTemplateCmd.Flags().StringVarP(&getTemplateCmdFormat, "format", "", "", generateFormatFlagUsage(artifactTemplates))
-	getTemplateCmd.MarkFlagRequired("environment")
+	setEnvFlag(getTemplateCmd, &getTemplateCmdEnvironment)
+	setFormatFlag(getTemplateCmd, &getTemplateCmdFormat)
 }
 
 func handleGetTemplateCmdArguments(args []string) {
@@ -97,7 +95,6 @@ func handleGetTemplateCmdArguments(args []string) {
 }
 
 func executeListTemplates() {
-
 	templateList, err := impl.GetTemplateList(getTemplateCmdEnvironment)
 	if err == nil {
 		impl.PrintTemplateList(templateList, getTemplateCmdFormat)
@@ -107,7 +104,6 @@ func executeListTemplates() {
 }
 
 func executeGetTemplateByTypeCmd(templateType string) {
-
 	templateList, err := impl.GetTemplatesByType(getTemplateCmdEnvironment, templateType)
 	if err == nil {
 		impl.PrintTemplatesByType(templateList, getTemplateCmdFormat)
@@ -117,7 +113,6 @@ func executeGetTemplateByTypeCmd(templateType string) {
 }
 
 func executeGetTemplateByNameCmd(templateType, templateName string) {
-
 	if templateType == sequenceKey {
 		sequenceTemplate, err := impl.GetSequenceTemplate(getTemplateCmdEnvironment, templateName)
 		if err == nil {
@@ -126,7 +121,6 @@ func executeGetTemplateByNameCmd(templateType, templateName string) {
 			printErrorForArtifact(artifactTemplates, templateName, err)
 		}
 	}
-
 	if templateType == endpointKey {
 		endpointTemplate, err := impl.GetEndpointTemplate(getTemplateCmdEnvironment, templateName)
 		if err == nil {

--- a/import-export-cli/cmd/mi/get/transactionCount.go
+++ b/import-export-cli/cmd/mi/get/transactionCount.go
@@ -62,10 +62,8 @@ var getTransactionCountCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getTransactionCountCmd)
-	getTransactionCountCmd.Flags().StringVarP(&getTransactionCountCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getTransactionCountCmd.Flags().StringVarP(&getTransactionCountCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getTransactionCountCmdLiteral)))
-	getTransactionCountCmd.MarkFlagRequired("environment")
+	setEnvFlag(getTransactionCountCmd, &getTransactionCountCmdEnvironment)
+	setFormatFlag(getTransactionCountCmd, &getTransactionCountCmdFormat)
 }
 
 func handleGetTransactionCountCmdArguments(args []string) {
@@ -81,7 +79,6 @@ func handleGetTransactionCountCmdArguments(args []string) {
 }
 
 func executeGetTransactionCountForMonth(period ...string) {
-
 	transactionCount, err := impl.GetTransactionCount(getTransactionCountCmdEnvironment, period)
 	if err == nil {
 		impl.PrintTransactionCount(transactionCount, getTransactionCountCmdFormat)

--- a/import-export-cli/cmd/mi/get/transactionCount.go
+++ b/import-export-cli/cmd/mi/get/transactionCount.go
@@ -1,0 +1,91 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getTransactionCountCmdEnvironment string
+var getTransactionCountCmdFormat string
+
+const getTransactionCountCmdLiteral = "transaction-counts [year] [month]"
+
+const getTransactionCountCmdShortDesc = "Retrieve transaction count"
+const getTransactionCountCmdLongDesc = "Retrieve transaction count based on the given year and month.\n" +
+	"If year and month not provided, retrieve the count for the current year and month of Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getTransactionCountCmdExamples = "To get the transaction count for the current month\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " -e dev\n" +
+	"To get the transaction count for a specific month\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " 2020 06 -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var getTransactionCountCmd = &cobra.Command{
+	Use:     getTransactionCountCmdLiteral,
+	Short:   getTransactionCountCmdShortDesc,
+	Long:    getTransactionCountCmdLongDesc,
+	Example: getTransactionCountCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 || len(args) == 2 {
+			return nil
+		}
+		var errMessage = "accepts exactly 0 or 2 arg(s), received " + fmt.Sprint(len(args))
+		return errors.New(errMessage)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetTransactionCountCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getTransactionCountCmd)
+	getTransactionCountCmd.Flags().StringVarP(&getTransactionCountCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getTransactionCountCmd.Flags().StringVarP(&getTransactionCountCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getTransactionCountCmdLiteral)))
+	getTransactionCountCmd.MarkFlagRequired("environment")
+}
+
+func handleGetTransactionCountCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTransactionCountCmdLiteral))
+	credentials.HandleMissingCredentials(getTransactionCountCmdEnvironment)
+	if len(args) == 2 {
+		var year = args[0]
+		var month = args[1]
+		executeGetTransactionCountForMonth(year, month)
+	} else {
+		executeGetTransactionCountForMonth()
+	}
+}
+
+func executeGetTransactionCountForMonth(period ...string) {
+
+	transactionCount, err := impl.GetTransactionCount(getTransactionCountCmdEnvironment, period)
+	if err == nil {
+		impl.PrintTransactionCount(transactionCount, getTransactionCountCmdFormat)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Retrieving transactions count.", err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/transactionReports.go
+++ b/import-export-cli/cmd/mi/get/transactionReports.go
@@ -29,7 +29,6 @@ import (
 )
 
 var getTransactionReportCmdEnvironment string
-var getTransactionReportCmdFormat string
 var transactionReportPath string
 
 const getTransactionReportCmdLiteral = "transaction-reports [start] [end]"
@@ -61,10 +60,8 @@ var getTransactionReportCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getTransactionReportCmd)
-	getTransactionReportCmd.Flags().StringVarP(&getTransactionReportCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
+	setEnvFlag(getTransactionReportCmd, &getTransactionReportCmdEnvironment)
 	getTransactionReportCmd.Flags().StringVarP(&transactionReportPath, "path", "p", "", "destination file location")
-	getTransactionReportCmd.MarkFlagRequired("environment")
 }
 
 func handleGetTransactionReportCmdArguments(args []string) {

--- a/import-export-cli/cmd/mi/get/transactionReports.go
+++ b/import-export-cli/cmd/mi/get/transactionReports.go
@@ -1,0 +1,91 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getTransactionReportCmdEnvironment string
+var getTransactionReportCmdFormat string
+var transactionReportPath string
+
+const getTransactionReportCmdLiteral = "transaction-reports [start] [end]"
+
+const getTransactionReportCmdShortDesc = "Generate transaction count summary report"
+const getTransactionReportCmdLongDesc = "Generate the transaction count summary report at the given location for the " +
+	"given period of time.\nIf a location not provided, generate the report in current directory.\nIf an end date " +
+	"not provided, generate the report with values upto current date of the Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getTransactionReportCmdExamples = "Example:\n" +
+	"To generate transaction count report consisting data within a specified time period at a specified location\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-05 2020-06 --path </dir_path> -e dev\n" +
+	"To generate transaction count report with data from a given month upto the current month at a specified location\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 -p </dir_path> -e dev\n" +
+	"To generate transaction count report at the current location with data between 2020-01 and 2020-05\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 2020-05 -e dev\n" +
+	"NOTE: The [start] argument and the flag (--environment (-e)) is mandatory"
+
+var getTransactionReportCmd = &cobra.Command{
+	Use:     getTransactionReportCmdLiteral,
+	Short:   getTransactionReportCmdShortDesc,
+	Long:    getTransactionReportCmdLongDesc,
+	Example: getTransactionReportCmdExamples,
+	Args:    cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetTransactionReportCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getTransactionReportCmd)
+	getTransactionReportCmd.Flags().StringVarP(&getTransactionReportCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getTransactionReportCmd.Flags().StringVarP(&transactionReportPath, "path", "p", "", "destination file location")
+	getTransactionReportCmd.MarkFlagRequired("environment")
+}
+
+func handleGetTransactionReportCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTransactionReportCmdLiteral))
+	credentials.HandleMissingCredentials(getTransactionReportCmdEnvironment)
+	var start = args[0]
+	var end = ""
+	if len(args) == 2 {
+		end = args[1]
+	}
+	if isEmptyOrCurrentDir(transactionReportPath) {
+		transactionReportPath, _ = os.Getwd()
+	}
+	executeGetTransactionReport(transactionReportPath, start, end)
+}
+
+func executeGetTransactionReport(targetDirectory string, period ...string) {
+	transactionReport, err := impl.GetTransactionReport(getTransactionReportCmdEnvironment, period)
+	if err == nil {
+		impl.WriteTransactionReportAsCSV(transactionReport, targetDirectory)
+	} else {
+		fmt.Println(utils.LogPrefixError+"Retrieving Transaction Reports.", err)
+	}
+}

--- a/import-export-cli/cmd/mi/get/users.go
+++ b/import-export-cli/cmd/mi/get/users.go
@@ -1,0 +1,116 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getUserCmdEnvironment string
+var getUserCmdFormat string
+var getUserCmdPattern string
+var getUserCmdRole string
+
+const getUserCmdLiteral = "users [user-name]"
+
+const getUserCmdShortDesc = "Get information about users"
+const getUserCmdLongDesc = "Get information about the users filtered by username pattern and role.\n" +
+	"If not provided list all users of the Micro Integrator in the environment specified by the flag --environment, -e"
+
+var getUserCmdExamples = "Example:\n" +
+	"To list all the users\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -e dev\n" +
+	"To get the list of users with specific role\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -r [role-name] -e dev\n" +
+	"To get the list of users with a username matching with the wild card Ex: \"*mi*\" matches with \"admin\"\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -p [pattern] -e dev\n" +
+	"To get details about a user by providing the user-id\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " [user-id] -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var getUserCmd = &cobra.Command{
+	Use:     getUserCmdLiteral,
+	Short:   getUserCmdShortDesc,
+	Long:    getUserCmdLongDesc,
+	Example: getUserCmdExamples,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			var errMessage = "accepts at most 1 arg(s), received " + fmt.Sprint(len(args))
+			return errors.New(errMessage)
+		} else if len(args) == 1 {
+			if isInvalidFlagArgCombination(args[0], getUserCmdPattern, getUserCmdRole) {
+				var errMessage = "[user-id] arg cannot be used with -p or -r flags"
+				return errors.New(errMessage)
+			}
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		handleGetUserCmdArguments(args)
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(getUserCmd)
+	getUserCmd.Flags().StringVarP(&getUserCmdEnvironment, "environment", "e",
+		"", "Environment to be searched")
+	getUserCmd.Flags().StringVarP(&getUserCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getUserCmdLiteral)))
+	getUserCmd.Flags().StringVarP(&getUserCmdRole, "role", "r", "", "Filter users by role")
+	getUserCmd.Flags().StringVarP(&getUserCmdPattern, "pattern", "p", "", "Filter users by regex")
+	getUserCmd.MarkFlagRequired("environment")
+}
+
+func handleGetUserCmdArguments(args []string) {
+	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getUserCmdLiteral))
+	credentials.HandleMissingCredentials(getUserCmdEnvironment)
+	if len(args) == 1 {
+		var userID = args[0]
+		executeShowUser(userID)
+	} else {
+		executeListUsers()
+	}
+}
+
+func executeShowUser(userID string) {
+	userInfo, err := impl.GetUserInfo(getUserCmdEnvironment, userID)
+	if err == nil {
+		impl.PrintUserDetails(userInfo, getUserCmdFormat)
+	} else {
+		printErrorForArtifact("users", userID, err)
+	}
+}
+
+func executeListUsers() {
+	userList, err := impl.GetUserList(getUserCmdEnvironment, getUserCmdRole, getUserCmdPattern)
+	if err == nil {
+		impl.PrintUserList(userList, getUserCmdFormat)
+	} else {
+		printErrorForArtifactList("users", err)
+	}
+}
+
+func isInvalidFlagArgCombination(userIDArg, patternFlag, roleFlag string) bool {
+	return userIDArg != "" && (getUserCmdPattern != "" || getUserCmdRole != "")
+}

--- a/import-export-cli/cmd/mi/get/users.go
+++ b/import-export-cli/cmd/mi/get/users.go
@@ -74,12 +74,10 @@ var getUserCmd = &cobra.Command{
 
 func init() {
 	GetCmd.AddCommand(getUserCmd)
-	getUserCmd.Flags().StringVarP(&getUserCmdEnvironment, "environment", "e",
-		"", "Environment to be searched")
-	getUserCmd.Flags().StringVarP(&getUserCmdFormat, "format", "", "", generateFormatFlagUsage(getTrimmedCmdLiteral(getUserCmdLiteral)))
+	setEnvFlag(getUserCmd, &getUserCmdEnvironment)
+	setFormatFlag(getUserCmd, &getUserCmdFormat)
 	getUserCmd.Flags().StringVarP(&getUserCmdRole, "role", "r", "", "Filter users by role")
 	getUserCmd.Flags().StringVarP(&getUserCmdPattern, "pattern", "p", "", "Filter users by regex")
-	getUserCmd.MarkFlagRequired("environment")
 }
 
 func handleGetUserCmdArguments(args []string) {

--- a/import-export-cli/cmd/mi/get/utils.go
+++ b/import-export-cli/cmd/mi/get/utils.go
@@ -1,0 +1,67 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package get
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+func generateGetCmdShortDescForArtifact(artifact string) string {
+	return "Get information about " + artifact + " deployed in a Micro Integrator"
+}
+
+func generateGetCmdLongDescForArtifact(artifact, argument string) string {
+	return "Get information about the " + artifact + " specified by command line argument [" + argument + "]\nIf not specified, list all the " + artifact + " deployed in a Micro Integrator in the environment specified by the flag --environment, -e"
+}
+
+func generateGetCmdExamplesForArtifact(resourceType, cmdLiteral, sampleResourceName string) string {
+	return "To list all the " + resourceType + "\n" +
+		"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + cmdLiteral + " -e dev\n" +
+		"To get details about a specific " + resourceType + "\n" +
+		"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + cmdLiteral + " " + sampleResourceName + " -e dev\n" +
+		"NOTE: The flag (--environment (-e)) is mandatory"
+}
+
+func getTrimmedCmdLiteral(cmd string) string {
+	cmdParts := strings.Fields(cmd)
+	return cmdParts[0]
+}
+
+func generateFormatFlagUsage(resource string) string {
+	return "Pretty-print " + resource + " using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields"
+}
+
+func printErrorForArtifact(artifactType, artifactName string, err error) {
+	fmt.Println(utils.LogPrefixError+"Getting Information of "+artifactType+" [ "+artifactName+" ] ", err)
+}
+
+func printErrorForArtifactList(artifactType string, err error) {
+	fmt.Println(utils.LogPrefixError+"Getting List of "+artifactType, err)
+}
+
+func printGetCmdVerboseLogForArtifact(artifactType string) {
+	utils.Logln(utils.LogPrefixInfo + GetCmdLiteral + " " + artifactType + " called")
+}
+
+func isEmptyOrCurrentDir(path string) bool {
+	return path == "" || path == "."
+}

--- a/import-export-cli/cmd/mi/get/utils.go
+++ b/import-export-cli/cmd/mi/get/utils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -46,10 +47,6 @@ func getTrimmedCmdLiteral(cmd string) string {
 	return cmdParts[0]
 }
 
-func generateFormatFlagUsage(resource string) string {
-	return "Pretty-print " + resource + " using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields"
-}
-
 func printErrorForArtifact(artifactType, artifactName string, err error) {
 	fmt.Println(utils.LogPrefixError+"Getting Information of "+artifactType+" [ "+artifactName+" ] ", err)
 }
@@ -64,4 +61,14 @@ func printGetCmdVerboseLogForArtifact(artifactType string) {
 
 func isEmptyOrCurrentDir(path string) bool {
 	return path == "" || path == "."
+}
+
+func setEnvFlag(cmd *cobra.Command, param *string) {
+	cmd.Flags().StringVarP(param, "environment", "e", "", "Environment to be searched")
+	cmd.MarkFlagRequired("environment")
+}
+
+func setFormatFlag(cmd *cobra.Command, param *string) {
+	cmd.Flags().StringVarP(param, "format", "", "",
+		"Pretty-print using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
 }

--- a/import-export-cli/credentials/miCredentials.go
+++ b/import-export-cli/credentials/miCredentials.go
@@ -190,3 +190,11 @@ func RunMILogout(environment string) error {
 	fmt.Println("Logged out from MI in", environment, "environment")
 	return store.EraseMI(environment)
 }
+
+// HandleMissingCredentials check for missing credentials and prompt to enter credentials or print error and exit
+func HandleMissingCredentials(env string) {
+	_, err := GetMICredentials(env)
+	if err != nil {
+		utils.HandleErrorAndExit("Error getting credentials", err)
+	}
+}

--- a/import-export-cli/docs/apictl_mi.md
+++ b/import-export-cli/docs/apictl_mi.md
@@ -26,6 +26,7 @@ apictl mi [flags]
 ### SEE ALSO
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
 * [apictl mi login](apictl_mi_login.md)	 - Login to a Micro Integrator
 * [apictl mi logout](apictl_mi_logout.md)	 - Logout from a Micro Integrator
 

--- a/import-export-cli/docs/apictl_mi_get.md
+++ b/import-export-cli/docs/apictl_mi_get.md
@@ -1,0 +1,54 @@
+## apictl mi get
+
+Get information about artifacts deployed in a Micro Integrator instance
+
+### Synopsis
+
+Get information about artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi get [flags]
+```
+
+### Examples
+
+```
+apictl mi get apis -e dev
+apictl mi get endpoints -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi get apis](apictl_mi_get_apis.md)	 - Get information about apis deployed in a Micro Integrator
+* [apictl mi get composite-apps](apictl_mi_get_composite-apps.md)	 - Get information about composite apps deployed in a Micro Integrator
+* [apictl mi get connectors](apictl_mi_get_connectors.md)	 - Get information about connectors deployed in a Micro Integrator
+* [apictl mi get data-services](apictl_mi_get_data-services.md)	 - Get information about data services deployed in a Micro Integrator
+* [apictl mi get endpoints](apictl_mi_get_endpoints.md)	 - Get information about endpoints deployed in a Micro Integrator
+* [apictl mi get inbound-endpoints](apictl_mi_get_inbound-endpoints.md)	 - Get information about inbound endpoints deployed in a Micro Integrator
+* [apictl mi get local-entries](apictl_mi_get_local-entries.md)	 - Get information about local entries deployed in a Micro Integrator
+* [apictl mi get log-levels](apictl_mi_get_log-levels.md)	 - Get information about a Logger configured in a Micro Integrator
+* [apictl mi get logs](apictl_mi_get_logs.md)	 - List all the available log files
+* [apictl mi get message-processors](apictl_mi_get_message-processors.md)	 - Get information about message processors deployed in a Micro Integrator
+* [apictl mi get message-stores](apictl_mi_get_message-stores.md)	 - Get information about message stores deployed in a Micro Integrator
+* [apictl mi get proxy-services](apictl_mi_get_proxy-services.md)	 - Get information about proxy services deployed in a Micro Integrator
+* [apictl mi get sequences](apictl_mi_get_sequences.md)	 - Get information about sequences deployed in a Micro Integrator
+* [apictl mi get tasks](apictl_mi_get_tasks.md)	 - Get information about tasks deployed in a Micro Integrator
+* [apictl mi get templates](apictl_mi_get_templates.md)	 - Get information about templates deployed in a Micro Integrator
+* [apictl mi get transaction-counts](apictl_mi_get_transaction-counts.md)	 - Retrieve transaction count
+* [apictl mi get transaction-reports](apictl_mi_get_transaction-reports.md)	 - Generate transaction count summary report
+* [apictl mi get users](apictl_mi_get_users.md)	 - Get information about users
+

--- a/import-export-cli/docs/apictl_mi_get_apis.md
+++ b/import-export-cli/docs/apictl_mi_get_apis.md
@@ -1,0 +1,42 @@
+## apictl mi get apis
+
+Get information about apis deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the apis specified by command line argument [api-name]
+If not specified, list all the apis deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get apis [api-name] [flags]
+```
+
+### Examples
+
+```
+To list all the apis
+  apictl mi get apis -e dev
+To get details about a specific apis
+  apictl mi get apis SampleIntegrationAPI -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for apis
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_composite-apps.md
+++ b/import-export-cli/docs/apictl_mi_get_composite-apps.md
@@ -1,0 +1,42 @@
+## apictl mi get composite-apps
+
+Get information about composite apps deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the composite apps specified by command line argument [app-name]
+If not specified, list all the composite apps deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get composite-apps [app-name] [flags]
+```
+
+### Examples
+
+```
+To list all the composite apps
+  apictl mi get composite-apps -e dev
+To get details about a specific composite apps
+  apictl mi get composite-apps SampleApp -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print composite apps using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for composite-apps
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_connectors.md
+++ b/import-export-cli/docs/apictl_mi_get_connectors.md
@@ -1,0 +1,39 @@
+## apictl mi get connectors
+
+Get information about connectors deployed in a Micro Integrator
+
+### Synopsis
+
+List all the connectors deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get connectors [flags]
+```
+
+### Examples
+
+```
+To list all the connectors
+  apictl mi get connectors -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print connectors using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for connectors
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_data-services.md
+++ b/import-export-cli/docs/apictl_mi_get_data-services.md
@@ -1,0 +1,42 @@
+## apictl mi get data-services
+
+Get information about data services deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the data services specified by command line argument [dataservice-name]
+If not specified, list all the data services deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get data-services [dataservice-name] [flags]
+```
+
+### Examples
+
+```
+To list all the data services
+  apictl mi get data-services -e dev
+To get details about a specific data services
+  apictl mi get data-services SampleDataService -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print data services using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for data-services
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_endpoints.md
+++ b/import-export-cli/docs/apictl_mi_get_endpoints.md
@@ -1,0 +1,42 @@
+## apictl mi get endpoints
+
+Get information about endpoints deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the endpoints specified by command line argument [endpoint-name]
+If not specified, list all the endpoints deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get endpoints [endpoint-name] [flags]
+```
+
+### Examples
+
+```
+To list all the endpoints
+  apictl mi get endpoints -e dev
+To get details about a specific endpoints
+  apictl mi get endpoints SampleEndpoint -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print endpoints using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for endpoints
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_inbound-endpoints.md
+++ b/import-export-cli/docs/apictl_mi_get_inbound-endpoints.md
@@ -1,0 +1,42 @@
+## apictl mi get inbound-endpoints
+
+Get information about inbound endpoints deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the inbound endpoints specified by command line argument [inbound-name]
+If not specified, list all the inbound endpoints deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get inbound-endpoints [inbound-name] [flags]
+```
+
+### Examples
+
+```
+To list all the inbound endpoints
+  apictl mi get inbound-endpoints -e dev
+To get details about a specific inbound endpoints
+  apictl mi get inbound-endpoints SampleInboundEndpoint -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print inbound endpoints using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for inbound-endpoints
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_local-entries.md
+++ b/import-export-cli/docs/apictl_mi_get_local-entries.md
@@ -1,0 +1,42 @@
+## apictl mi get local-entries
+
+Get information about local entries deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the local entries specified by command line argument [localentry-name]
+If not specified, list all the local entries deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get local-entries [localentry-name] [flags]
+```
+
+### Examples
+
+```
+To list all the local entries
+  apictl mi get local-entries -e dev
+To get details about a specific local entries
+  apictl mi get local-entries SampleLocalEntry -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print local entries using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for local-entries
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_log-levels.md
+++ b/import-export-cli/docs/apictl_mi_get_log-levels.md
@@ -1,0 +1,40 @@
+## apictl mi get log-levels
+
+Get information about a Logger configured in a Micro Integrator
+
+### Synopsis
+
+Get information about the Logger specified by command line argument [logger-name]
+configured in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get log-levels [logger-name] [flags]
+```
+
+### Examples
+
+```
+To get details about a specific logger
+  apictl mi get log-levels org-apache-coyote -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print log-levels using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for log-levels
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_logs.md
+++ b/import-export-cli/docs/apictl_mi_get_logs.md
@@ -1,0 +1,44 @@
+## apictl mi get logs
+
+List all the available log files
+
+### Synopsis
+
+Download a log file by providing the file name and download location,
+if not provided, list all the log files of the Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get logs [file-name] [flags]
+```
+
+### Examples
+
+```
+Example:
+To list all the log files
+  apictl mi get logs -e dev
+To download a selected log file
+  apictl mi get logs [file-name] -p [download-location] -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print logs using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for logs
+  -p, --path string          Path the file should be downloaded
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_message-processors.md
+++ b/import-export-cli/docs/apictl_mi_get_message-processors.md
@@ -1,0 +1,42 @@
+## apictl mi get message-processors
+
+Get information about message processors deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the message processors specified by command line argument [messageprocessor-name]
+If not specified, list all the message processors deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get message-processors [messageprocessor-name] [flags]
+```
+
+### Examples
+
+```
+To list all the message processors
+  apictl mi get message-processors -e dev
+To get details about a specific message processors
+  apictl mi get message-processors TestMessageProcessor -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print message processors using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for message-processors
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_message-stores.md
+++ b/import-export-cli/docs/apictl_mi_get_message-stores.md
@@ -1,0 +1,42 @@
+## apictl mi get message-stores
+
+Get information about message stores deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the message stores specified by command line argument [messagestore-name]
+If not specified, list all the message stores deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get message-stores [messagestore-name] [flags]
+```
+
+### Examples
+
+```
+To list all the message stores
+  apictl mi get message-stores -e dev
+To get details about a specific message stores
+  apictl mi get message-stores TestMessageStore -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print message stores using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for message-stores
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_proxy-services.md
+++ b/import-export-cli/docs/apictl_mi_get_proxy-services.md
@@ -1,0 +1,42 @@
+## apictl mi get proxy-services
+
+Get information about proxy services deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the proxy services specified by command line argument [proxy-name]
+If not specified, list all the proxy services deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get proxy-services [proxy-name] [flags]
+```
+
+### Examples
+
+```
+To list all the proxy services
+  apictl mi get proxy-services -e dev
+To get details about a specific proxy services
+  apictl mi get proxy-services SampleProxy -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print proxy services using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for proxy-services
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_sequences.md
+++ b/import-export-cli/docs/apictl_mi_get_sequences.md
@@ -1,0 +1,42 @@
+## apictl mi get sequences
+
+Get information about sequences deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the sequences specified by command line argument [sequence-name]
+If not specified, list all the sequences deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get sequences [sequence-name] [flags]
+```
+
+### Examples
+
+```
+To list all the sequences
+  apictl mi get sequences -e dev
+To get details about a specific sequences
+  apictl mi get sequences SampleSequence -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print sequences using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for sequences
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_tasks.md
+++ b/import-export-cli/docs/apictl_mi_get_tasks.md
@@ -1,0 +1,42 @@
+## apictl mi get tasks
+
+Get information about tasks deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the tasks specified by command line argument [task-name]
+If not specified, list all the tasks deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get tasks [task-name] [flags]
+```
+
+### Examples
+
+```
+To list all the tasks
+  apictl mi get tasks -e dev
+To get details about a specific tasks
+  apictl mi get tasks SampleTask -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print tasks using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for tasks
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_templates.md
+++ b/import-export-cli/docs/apictl_mi_get_templates.md
@@ -1,0 +1,44 @@
+## apictl mi get templates
+
+Get information about templates deployed in a Micro Integrator
+
+### Synopsis
+
+Get information about the template specified by command line arguments [template-type] and [template-name]
+If not specified, list all the templates in the environment specified by the flag --environment, -e
+
+```
+apictl mi get templates [template-type] [template-name] [flags]
+```
+
+### Examples
+
+```
+To list all the templates
+apictl mi get templates -e dev
+To get details about a specific template type
+apictl mi get templates TemplateType
+To get details about a specific template
+apictl mi get templates TemplateType TemplateName -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print templates using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for templates
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_transaction-counts.md
+++ b/import-export-cli/docs/apictl_mi_get_transaction-counts.md
@@ -1,0 +1,42 @@
+## apictl mi get transaction-counts
+
+Retrieve transaction count
+
+### Synopsis
+
+Retrieve transaction count based on the given year and month.
+If year and month not provided, retrieve the count for the current year and month of Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get transaction-counts [year] [month] [flags]
+```
+
+### Examples
+
+```
+To get the transaction count for the current month
+  apictl mi get transaction-counts -e dev
+To get the transaction count for a specific month
+  apictl mi get transaction-counts 2020 06 -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print transaction-counts using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for transaction-counts
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_transaction-reports.md
+++ b/import-export-cli/docs/apictl_mi_get_transaction-reports.md
@@ -1,0 +1,46 @@
+## apictl mi get transaction-reports
+
+Generate transaction count summary report
+
+### Synopsis
+
+Generate the transaction count summary report at the given location for the given period of time.
+If a location not provided, generate the report in current directory.
+If an end date not provided, generate the report with values upto current date of the Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get transaction-reports [start] [end] [flags]
+```
+
+### Examples
+
+```
+Example:
+To generate transaction count report consisting data within a specified time period at a specified location
+  apictl mi get transaction-reports 2020-05 2020-06 --path </dir_path> -e dev
+To generate transaction count report with data from a given month upto the current month at a specified location
+  apictl mi get transaction-reports 2020-01 -p </dir_path> -e dev
+To generate transaction count report at the current location with data between 2020-01 and 2020-05
+  apictl mi get transaction-reports 2020-01 2020-05 -e dev
+NOTE: The [start] argument and the flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+  -h, --help                 help for transaction-reports
+  -p, --path string          destination file location
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_users.md
+++ b/import-export-cli/docs/apictl_mi_get_users.md
@@ -1,0 +1,49 @@
+## apictl mi get users
+
+Get information about users
+
+### Synopsis
+
+Get information about the users filtered by username pattern and role.
+If not provided list all users of the Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi get users [user-name] [flags]
+```
+
+### Examples
+
+```
+Example:
+To list all the users
+  apictl mi get users -e dev
+To get the list of users with specific role
+  apictl mi get users -r [role-name] -e dev
+To get the list of users with a username matching with the wild card Ex: "*mi*" matches with "admin"
+  apictl mi get users -p [pattern] -e dev
+To get details about a user by providing the user-id
+  apictl mi get users [user-id] -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+      --format string        Pretty-print users using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for users
+  -p, --pattern string       Filter users by regex
+  -r, --role string          Filter users by role
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/mi/impl/common.go
+++ b/import-export-cli/mi/impl/common.go
@@ -44,7 +44,6 @@ const miHTTPRetryCount = 2
 // @return struct object
 // @return error
 func unmarshalData(url string, params map[string]string, env string, model interface{}) (interface{}, error) {
-
 	resp, err := invokeGETRequestWithRetry(url, params, env)
 
 	if err != nil {
@@ -74,7 +73,6 @@ func unmarshalData(url string, params map[string]string, env string, model inter
 }
 
 func downloadLogFileData(url string, params map[string]string, env string) ([]byte, error) {
-
 	resp, err := invokeGETRequestWithRetry(url, params, env)
 
 	if err != nil {
@@ -110,7 +108,6 @@ func retryHTTPCall(attempts int, env string, f func(string) (*resty.Response, er
 }
 
 func invokeGETRequestWithRetry(url string, params map[string]string, env string) (*resty.Response, error) {
-
 	return retryHTTPCall(miHTTPRetryCount, env, func(accessToken string) (*resty.Response, error) {
 		headers := make(map[string]string)
 		headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
@@ -148,7 +145,6 @@ func getRenderer(data interface{}, newLine bool) func(w io.Writer, t *template.T
 }
 
 func getArtifactInfo(resource, artifactKey, artifactName, env string, model interface{}) (interface{}, error) {
-
 	params := make(map[string]string)
 	params[artifactKey] = artifactName
 
@@ -156,12 +152,10 @@ func getArtifactInfo(resource, artifactKey, artifactName, env string, model inte
 }
 
 func getArtifactList(resource, env string, model interface{}) (interface{}, error) {
-
 	return callMIManagementEndpointOfResource(resource, nil, env, model)
 }
 
 func callMIManagementEndpointOfResource(resource string, params map[string]string, env string, model interface{}) (interface{}, error) {
-
 	url := utils.GetMIManagementEndpointOfResource(resource, env, utils.MainConfigFilePath)
 
 	resp, err := unmarshalData(url, params, env, model)
@@ -178,7 +172,6 @@ func callMIManagementEndpointOfResource(resource string, params map[string]strin
 }
 
 func getContextWithFormat(format, defaultformat string) *formatter.Context {
-
 	if format == "" {
 		format = defaultformat
 	}

--- a/import-export-cli/mi/impl/common.go
+++ b/import-export-cli/mi/impl/common.go
@@ -1,0 +1,192 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/template"
+
+	"github.com/go-resty/resty"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// miHTTPRetryCount default retry count for HTTP calls
+const miHTTPRetryCount = 2
+
+// unmarshalData unmarshal data from the response to the respective struct
+// @param url: url of rest api
+// @param params: parameters for the HTTP call
+// @param env: environment of the micro integrator instance
+// @param model: struct object
+// @return struct object
+// @return error
+func unmarshalData(url string, params map[string]string, env string, model interface{}) (interface{}, error) {
+
+	resp, err := invokeGETRequestWithRetry(url, params, env)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+url, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		response := model
+		unmarshalError := json.Unmarshal(resp.Body(), &response)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+		}
+		return response, nil
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		fmt.Println("Invalid credentials. Please login to the current Micro Integrator instance")
+		utils.HandleErrorAndExit("Execute 'apictl mi login --help' for more information", nil)
+	}
+	if len(resp.Body()) == 0 {
+		return nil, errors.New(resp.Status())
+	}
+	data := unmarshalJSONToStringMap(resp.Body())
+	return data["Error"], errors.New(resp.Status())
+}
+
+func downloadLogFileData(url string, params map[string]string, env string) ([]byte, error) {
+
+	resp, err := invokeGETRequestWithRetry(url, params, env)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+url, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"Response:", resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		return resp.Body(), nil
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		fmt.Println("Invalid credentials. Please login to the current Micro Integrator instance")
+		utils.HandleErrorAndExit("Execute 'apictl mi login --help' for more information", nil)
+	}
+	return nil, errors.New(resp.Status())
+}
+
+func retryHTTPCall(attempts int, env string, f func(string) (*resty.Response, error)) (*resty.Response, error) {
+	cred, err := credentials.GetMICredentials(env)
+	resp, err := f(cred.AccessToken)
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if attempts--; attempts > 0 {
+			token, err := credentials.GetOAuthAccessTokenForMI(cred.Username, cred.Password, env)
+			if err != nil {
+				return nil, err
+			}
+			credentials.UpdateMIAccessToken(env, token)
+			return retryHTTPCall(attempts, env, f)
+		}
+	}
+	return resp, err
+}
+
+func invokeGETRequestWithRetry(url string, params map[string]string, env string) (*resty.Response, error) {
+
+	return retryHTTPCall(miHTTPRetryCount, env, func(accessToken string) (*resty.Response, error) {
+		headers := make(map[string]string)
+		headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+		return utils.InvokeGETRequestWithMultipleQueryParams(params, url, headers)
+	})
+}
+
+func unmarshalJSONToStringMap(body []byte) map[string]string {
+	var data map[string]string
+	unmarshalError := json.Unmarshal(body, &data)
+	if unmarshalError != nil {
+		utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
+	}
+	return data
+}
+
+func getItemRenderer(data interface{}) func(w io.Writer, t *template.Template) error {
+	return getRenderer(data, false)
+}
+
+func getItemRendererEndsWithNewLine(data interface{}) func(w io.Writer, t *template.Template) error {
+	return getRenderer(data, true)
+}
+
+func getRenderer(data interface{}, newLine bool) func(w io.Writer, t *template.Template) error {
+	return func(w io.Writer, t *template.Template) error {
+		if err := t.Execute(w, data); err != nil {
+			return err
+		}
+		if newLine {
+			_, _ = w.Write([]byte{'\n'})
+		}
+		return nil
+	}
+}
+
+func getArtifactInfo(resource, artifactKey, artifactName, env string, model interface{}) (interface{}, error) {
+
+	params := make(map[string]string)
+	params[artifactKey] = artifactName
+
+	return callMIManagementEndpointOfResource(resource, params, env, model)
+}
+
+func getArtifactList(resource, env string, model interface{}) (interface{}, error) {
+
+	return callMIManagementEndpointOfResource(resource, nil, env, model)
+}
+
+func callMIManagementEndpointOfResource(resource string, params map[string]string, env string, model interface{}) (interface{}, error) {
+
+	url := utils.GetMIManagementEndpointOfResource(resource, env, utils.MainConfigFilePath)
+
+	resp, err := unmarshalData(url, params, env, model)
+	if err != nil {
+		if resp != nil {
+			errBody := resp.(string)
+			if len(errBody) > 0 {
+				return nil, errors.New(errBody)
+			}
+		}
+		return nil, err
+	}
+	return resp, nil
+}
+
+func getContextWithFormat(format, defaultformat string) *formatter.Context {
+
+	if format == "" {
+		format = defaultformat
+	}
+	return formatter.NewContext(os.Stdout, format)
+}
+
+func putNonEmptyValueToMap(dataMap map[string]string, key, value string) {
+	if value != "" {
+		dataMap[key] = value
+	}
+}

--- a/import-export-cli/mi/impl/constants.go
+++ b/import-export-cli/mi/impl/constants.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+// Headers used in the table views
+const nameHeader = "NAME"
+const versionHeader = "VERSION"
+const statusHeader = "STATUS"
+const packageHeader = "PACKAGE"
+const descriptionHeader = "DESCRIPTION"
+const wsdl11Header = "WSDL 1.1"
+const wsdl20Header = "WSDL 2.0"
+const typeHeader = "TYPE"
+const activeHeader = "ACTIVE"
+const urlHeader = "URL"
+const loglevelHeader = "LOG LEVEL"
+const componentHeader = "COMPONENT"
+const statsHeader = "STATS"
+const tracingHeader = "TRACING"
+const countHeader = "COUNT"
+const intervalHeader = "INTERVAL"
+const cronExpressionHeader = "CRON EXPRESSION"
+const sizeHeader = "SIZE"
+const monthHeader = "MONTH"
+const yearHeader = "YEAR"
+const transactionCountHeader = "TRANSACTION COUNT"
+const userIDHeader = "USER ID"

--- a/import-export-cli/mi/impl/getCompositeApps.go
+++ b/import-export-cli/mi/impl/getCompositeApps.go
@@ -41,7 +41,6 @@ const (
 
 // GetCompositeAppList returns a list of composite apps deployed in the micro integrator in a given environment
 func GetCompositeAppList(env string) (*artifactutils.CompositeAppList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementCarbonAppResource, env, &artifactutils.CompositeAppList{})
 	if err != nil {
 		return nil, err
@@ -51,11 +50,8 @@ func GetCompositeAppList(env string) (*artifactutils.CompositeAppList, error) {
 
 // PrintCompositeAppList print a list of composite apps according to the given format
 func PrintCompositeAppList(appList *artifactutils.CompositeAppList, format string) {
-
 	if appList.Count > 0 {
-
 		apps := appList.CompositeApps
-
 		appListContext := getContextWithFormat(format, defaultCompositeAppListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -67,12 +63,10 @@ func PrintCompositeAppList(appList *artifactutils.CompositeAppList, format strin
 			}
 			return nil
 		}
-
 		appListTableHeaders := map[string]string{
 			"Name":    nameHeader,
 			"Version": versionHeader,
 		}
-
 		if err := appListContext.Write(renderer, appListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -83,7 +77,6 @@ func PrintCompositeAppList(appList *artifactutils.CompositeAppList, format strin
 
 // GetCompositeApp returns a information about a specific composite app deployed in the micro integrator in a given environment
 func GetCompositeApp(env, appname string) (*artifactutils.CompositeApp, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementCarbonAppResource, "carbonAppName", appname, env, &artifactutils.CompositeApp{})
 	if err != nil {
 		return nil, err
@@ -93,7 +86,6 @@ func GetCompositeApp(env, appname string) (*artifactutils.CompositeApp, error) {
 
 // PrintCompositeAppDetails prints details about a composite app according to the given format
 func PrintCompositeAppDetails(app *artifactutils.CompositeApp, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultCompositeAppDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getCompositeApps.go
+++ b/import-export-cli/mi/impl/getCompositeApps.go
@@ -1,0 +1,107 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultCompositeAppListTableFormat = "table {{.Name}}\t{{.Version}}"
+	defaultCompositeAppDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Version - {{.Version}}\n" +
+		"Artifacts :\n" +
+		"NAME\tTYPE\n" +
+		"{{range .Artifacts}}{{.Name}}\t{{.Type}}\n{{end}}"
+)
+
+// GetCompositeAppList returns a list of composite apps deployed in the micro integrator in a given environment
+func GetCompositeAppList(env string) (*artifactutils.CompositeAppList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementCarbonAppResource, env, &artifactutils.CompositeAppList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.CompositeAppList), nil
+}
+
+// PrintCompositeAppList print a list of composite apps according to the given format
+func PrintCompositeAppList(appList *artifactutils.CompositeAppList, format string) {
+
+	if appList.Count > 0 {
+
+		apps := appList.CompositeApps
+
+		appListContext := getContextWithFormat(format, defaultCompositeAppListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, app := range apps {
+				if err := t.Execute(w, app); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		appListTableHeaders := map[string]string{
+			"Name":    nameHeader,
+			"Version": versionHeader,
+		}
+
+		if err := appListContext.Write(renderer, appListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Composite Apps found")
+	}
+}
+
+// GetCompositeApp returns a information about a specific composite app deployed in the micro integrator in a given environment
+func GetCompositeApp(env, appname string) (*artifactutils.CompositeApp, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementCarbonAppResource, "carbonAppName", appname, env, &artifactutils.CompositeApp{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.CompositeApp), nil
+}
+
+// PrintCompositeAppDetails prints details about a composite app according to the given format
+func PrintCompositeAppDetails(app *artifactutils.CompositeApp, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultCompositeAppDetailedFormat
+	}
+
+	appContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(app)
+
+	if err := appContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getConnectors.go
+++ b/import-export-cli/mi/impl/getConnectors.go
@@ -31,7 +31,6 @@ const defaultConnectorListTableFormat = "table {{.Name}}\t{{.Status}}\t{{.Packag
 
 // GetConnectorList returns a list of connector artifacts deployed in the micro integrator in a given environment
 func GetConnectorList(env string) (*artifactutils.ConnectorList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementConnectorResource, env, &artifactutils.ConnectorList{})
 	if err != nil {
 		return nil, err
@@ -41,11 +40,8 @@ func GetConnectorList(env string) (*artifactutils.ConnectorList, error) {
 
 // PrintConnectorList print a list of connectors according to the given format
 func PrintConnectorList(connectorList *artifactutils.ConnectorList, format string) {
-
 	if connectorList.Count > 0 {
-
 		connectors := connectorList.Connectors
-
 		connectorListContext := getContextWithFormat(format, defaultConnectorListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -57,14 +53,12 @@ func PrintConnectorList(connectorList *artifactutils.ConnectorList, format strin
 			}
 			return nil
 		}
-
 		connectorListTableHeaders := map[string]string{
 			"Name":        nameHeader,
 			"Status":      statsHeader,
 			"Package":     packageHeader,
 			"Description": descriptionHeader,
 		}
-
 		if err := connectorListContext.Write(renderer, connectorListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}

--- a/import-export-cli/mi/impl/getConnectors.go
+++ b/import-export-cli/mi/impl/getConnectors.go
@@ -1,0 +1,74 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const defaultConnectorListTableFormat = "table {{.Name}}\t{{.Status}}\t{{.Package}}\t{{.Description}}"
+
+// GetConnectorList returns a list of connector artifacts deployed in the micro integrator in a given environment
+func GetConnectorList(env string) (*artifactutils.ConnectorList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementConnectorResource, env, &artifactutils.ConnectorList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.ConnectorList), nil
+}
+
+// PrintConnectorList print a list of connectors according to the given format
+func PrintConnectorList(connectorList *artifactutils.ConnectorList, format string) {
+
+	if connectorList.Count > 0 {
+
+		connectors := connectorList.Connectors
+
+		connectorListContext := getContextWithFormat(format, defaultConnectorListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, connector := range connectors {
+				if err := t.Execute(w, connector); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		connectorListTableHeaders := map[string]string{
+			"Name":        nameHeader,
+			"Status":      statsHeader,
+			"Package":     packageHeader,
+			"Description": descriptionHeader,
+		}
+
+		if err := connectorListContext.Write(renderer, connectorListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Connectors found")
+	}
+}

--- a/import-export-cli/mi/impl/getDataServices.go
+++ b/import-export-cli/mi/impl/getDataServices.go
@@ -1,0 +1,115 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultdataServiceListTableFormat = "table {{.ServiceName}}\t{{.Wsdl11}}\t{{.Wsdl20}}"
+	defaultdataServiceDetailedFormat  = "detail Name - {{.ServiceName}}\n" +
+		"Group Name - {{.ServiceGroupName}}\n" +
+		"Description - {{.ServiceDescription}}\n" +
+		"WSDL 1.1 - {{.Wsdl11}}\n" +
+		"WSDL 2.0 - {{.Wsdl20}}\n" +
+		"Queries :\n" +
+		"ID\tNAMESPACE\n" +
+		"{{range .Queries}}{{.Id}}\t{{.Namespace}}\n{{end}}"
+)
+
+// GetDataServiceList returns a list of data services deployed in the micro integrator in a given environment
+func GetDataServiceList(env string) (*artifactutils.DataServicesList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementDataServiceResource, env, &artifactutils.DataServicesList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.DataServicesList), nil
+}
+
+// PrintDataServiceList print a list of data services according to the given format
+func PrintDataServiceList(dataServiceList *artifactutils.DataServicesList, format string) {
+
+	if dataServiceList.Count > 0 {
+
+		dataServices := dataServiceList.List
+
+		dataserviceListContext := getContextWithFormat(format, defaultdataServiceListTableFormat)
+
+		// create a new renderer function which iterate collection
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, dataservice := range dataServices {
+				if err := t.Execute(w, dataservice); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		// headers for table
+		dataserviceListTableHeaders := map[string]string{
+			"Name":   nameHeader,
+			"Wsdl11": wsdl11Header,
+			"Wsdl20": wsdl20Header,
+		}
+
+		// execute context
+		if err := dataserviceListContext.Write(renderer, dataserviceListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Data Services found")
+	}
+}
+
+// GetDataService returns information about a specific data service deployed in the micro integrator in a given environment
+func GetDataService(env, dataserviceName string) (*artifactutils.DataServiceInfo, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementDataServiceResource, "dataServiceName", dataserviceName, env, &artifactutils.DataServiceInfo{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.DataServiceInfo), nil
+}
+
+// PrintDataServiceDetails prints details about a data service according to the given format
+func PrintDataServiceDetails(ds *artifactutils.DataServiceInfo, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultdataServiceDetailedFormat
+	}
+
+	dataserviceContext := formatter.NewContext(os.Stdout, format)
+
+	renderer := getItemRenderer(ds)
+
+	if err := dataserviceContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getDataServices.go
+++ b/import-export-cli/mi/impl/getDataServices.go
@@ -44,7 +44,6 @@ const (
 
 // GetDataServiceList returns a list of data services deployed in the micro integrator in a given environment
 func GetDataServiceList(env string) (*artifactutils.DataServicesList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementDataServiceResource, env, &artifactutils.DataServicesList{})
 	if err != nil {
 		return nil, err
@@ -54,14 +53,10 @@ func GetDataServiceList(env string) (*artifactutils.DataServicesList, error) {
 
 // PrintDataServiceList print a list of data services according to the given format
 func PrintDataServiceList(dataServiceList *artifactutils.DataServicesList, format string) {
-
 	if dataServiceList.Count > 0 {
-
 		dataServices := dataServiceList.List
-
 		dataserviceListContext := getContextWithFormat(format, defaultdataServiceListTableFormat)
 
-		// create a new renderer function which iterate collection
 		renderer := func(w io.Writer, t *template.Template) error {
 			for _, dataservice := range dataServices {
 				if err := t.Execute(w, dataservice); err != nil {
@@ -71,15 +66,11 @@ func PrintDataServiceList(dataServiceList *artifactutils.DataServicesList, forma
 			}
 			return nil
 		}
-
-		// headers for table
 		dataserviceListTableHeaders := map[string]string{
 			"Name":   nameHeader,
 			"Wsdl11": wsdl11Header,
 			"Wsdl20": wsdl20Header,
 		}
-
-		// execute context
 		if err := dataserviceListContext.Write(renderer, dataserviceListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -90,7 +81,6 @@ func PrintDataServiceList(dataServiceList *artifactutils.DataServicesList, forma
 
 // GetDataService returns information about a specific data service deployed in the micro integrator in a given environment
 func GetDataService(env, dataserviceName string) (*artifactutils.DataServiceInfo, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementDataServiceResource, "dataServiceName", dataserviceName, env, &artifactutils.DataServiceInfo{})
 	if err != nil {
 		return nil, err
@@ -100,13 +90,11 @@ func GetDataService(env, dataserviceName string) (*artifactutils.DataServiceInfo
 
 // PrintDataServiceDetails prints details about a data service according to the given format
 func PrintDataServiceDetails(ds *artifactutils.DataServiceInfo, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultdataServiceDetailedFormat
 	}
 
 	dataserviceContext := formatter.NewContext(os.Stdout, format)
-
 	renderer := getItemRenderer(ds)
 
 	if err := dataserviceContext.Write(renderer, nil); err != nil {

--- a/import-export-cli/mi/impl/getEndpoints.go
+++ b/import-export-cli/mi/impl/getEndpoints.go
@@ -1,0 +1,113 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultEndpointListTableFormat = "table {{.Name}}\t{{.Type}}\t{{.Active}}"
+	defaultEndpointDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"{{if .Type}}Type - {{.Type}}\n{{ end }}" +
+		"{{if .Active}}Active - {{.Active}}\n{{ end }}" +
+		"{{if .Method}}Method - {{.Method}}\n{{ end }}" +
+		"{{if .Address}}Address - {{.Address}}\n{{ end }}" +
+		"{{if .URITemplate}}URI Template - {{.URITemplate}}\n{{ end }}" +
+		"{{if .ServiceName}}Service Name - {{.ServiceName}}\n{{ end }}" +
+		"{{if .PortName}}Port Name - {{.PortName}}\n{{ end }}" +
+		"{{if .WsdlURI}}WSDL URI - {{.WsdlURI}}\n{{ end }}"
+)
+
+// GetEndpointList returns a list of endpoints
+func GetEndpointList(env string) (*artifactutils.EndpointList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementEndpointResource, env, &artifactutils.EndpointList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.EndpointList), nil
+}
+
+// PrintEndpointList print a list of endpoints
+func PrintEndpointList(endpointList *artifactutils.EndpointList, format string) {
+
+	if endpointList.Count > 0 {
+
+		endpoints := endpointList.Endpoints
+
+		endpointListContext := getContextWithFormat(format, defaultEndpointListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, endpoint := range endpoints {
+				if err := t.Execute(w, endpoint); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		endpointListTableHeaders := map[string]string{
+			"Name":   nameHeader,
+			"Type":   typeHeader,
+			"Active": activeHeader,
+		}
+
+		// execute context
+		if err := endpointListContext.Write(renderer, endpointListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Endpoints found")
+	}
+}
+
+// GetEndpoint returns information about a specific endpoint
+func GetEndpoint(env, endpointName string) (*artifactutils.Endpoint, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementEndpointResource, "endpointName", endpointName, env, &artifactutils.Endpoint{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.Endpoint), nil
+}
+
+// PrintEndpointDetails prints details about an endpoint
+func PrintEndpointDetails(endpoint *artifactutils.Endpoint, format string) {
+
+	if format == "" {
+		format = defaultEndpointDetailedFormat
+	}
+
+	endpointContext := formatter.NewContext(os.Stdout, format)
+
+	renderer := getItemRenderer(endpoint)
+
+	if err := endpointContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getEndpoints.go
+++ b/import-export-cli/mi/impl/getEndpoints.go
@@ -44,7 +44,6 @@ const (
 
 // GetEndpointList returns a list of endpoints
 func GetEndpointList(env string) (*artifactutils.EndpointList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementEndpointResource, env, &artifactutils.EndpointList{})
 	if err != nil {
 		return nil, err
@@ -54,11 +53,8 @@ func GetEndpointList(env string) (*artifactutils.EndpointList, error) {
 
 // PrintEndpointList print a list of endpoints
 func PrintEndpointList(endpointList *artifactutils.EndpointList, format string) {
-
 	if endpointList.Count > 0 {
-
 		endpoints := endpointList.Endpoints
-
 		endpointListContext := getContextWithFormat(format, defaultEndpointListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -70,14 +66,11 @@ func PrintEndpointList(endpointList *artifactutils.EndpointList, format string) 
 			}
 			return nil
 		}
-
 		endpointListTableHeaders := map[string]string{
 			"Name":   nameHeader,
 			"Type":   typeHeader,
 			"Active": activeHeader,
 		}
-
-		// execute context
 		if err := endpointListContext.Write(renderer, endpointListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -88,7 +81,6 @@ func PrintEndpointList(endpointList *artifactutils.EndpointList, format string) 
 
 // GetEndpoint returns information about a specific endpoint
 func GetEndpoint(env, endpointName string) (*artifactutils.Endpoint, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementEndpointResource, "endpointName", endpointName, env, &artifactutils.Endpoint{})
 	if err != nil {
 		return nil, err
@@ -98,13 +90,11 @@ func GetEndpoint(env, endpointName string) (*artifactutils.Endpoint, error) {
 
 // PrintEndpointDetails prints details about an endpoint
 func PrintEndpointDetails(endpoint *artifactutils.Endpoint, format string) {
-
 	if format == "" {
 		format = defaultEndpointDetailedFormat
 	}
 
 	endpointContext := formatter.NewContext(os.Stdout, format)
-
 	renderer := getItemRenderer(endpoint)
 
 	if err := endpointContext.Write(renderer, nil); err != nil {

--- a/import-export-cli/mi/impl/getInboundEndpoints.go
+++ b/import-export-cli/mi/impl/getInboundEndpoints.go
@@ -1,0 +1,110 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultInboundEndpointListTableFormat = "table {{.Name}}\t{{.Type}}"
+	defaultInboundEndpointDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Type - {{.Type}}\n" +
+		"Stats - {{.Stats}}\n" +
+		"Tracing - {{.Tracing}}\n" +
+		"Parameters :\n" +
+		"NAME\tVALUE\n" +
+		"{{range .Parameters}}{{.Name}}\t{{.Value}}\n{{end}}"
+)
+
+// GetInboundEndpointList returns a list of inbound endpoints deployed in the micro integrator in a given environment
+func GetInboundEndpointList(env string) (*artifactutils.InboundEndpointList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementInboundEndpointResource, env, &artifactutils.InboundEndpointList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.InboundEndpointList), nil
+}
+
+// PrintInboundEndpointList print a list of inbound endpoints according to the given format
+func PrintInboundEndpointList(inboundEPList *artifactutils.InboundEndpointList, format string) {
+
+	if inboundEPList.Count > 0 {
+
+		inboundEPs := inboundEPList.InboundEndpoints
+
+		inboundEPListContext := getContextWithFormat(format, defaultInboundEndpointListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, inboundEP := range inboundEPs {
+				if err := t.Execute(w, inboundEP); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		inboundEPListTableHeaders := map[string]string{
+			"Name": nameHeader,
+			"Type": typeHeader,
+		}
+
+		if err := inboundEPListContext.Write(renderer, inboundEPListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Inbound Endpoints found")
+	}
+}
+
+// GetInboundEndpoint returns a information about a specific inbound endpoint deployed in the micro integrator in a given environment
+func GetInboundEndpoint(env, inboundEPName string) (*artifactutils.InboundEndpoint, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementInboundEndpointResource, "inboundEndpointName", inboundEPName, env,
+		&artifactutils.InboundEndpoint{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.InboundEndpoint), nil
+}
+
+// PrintInboundEndpointDetails prints details about an inbound endpoint according to the given format
+func PrintInboundEndpointDetails(inboundEP *artifactutils.InboundEndpoint, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultInboundEndpointDetailedFormat
+	}
+
+	inboundEPContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(inboundEP)
+
+	if err := inboundEPContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getInboundEndpoints.go
+++ b/import-export-cli/mi/impl/getInboundEndpoints.go
@@ -43,7 +43,6 @@ const (
 
 // GetInboundEndpointList returns a list of inbound endpoints deployed in the micro integrator in a given environment
 func GetInboundEndpointList(env string) (*artifactutils.InboundEndpointList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementInboundEndpointResource, env, &artifactutils.InboundEndpointList{})
 	if err != nil {
 		return nil, err
@@ -53,11 +52,8 @@ func GetInboundEndpointList(env string) (*artifactutils.InboundEndpointList, err
 
 // PrintInboundEndpointList print a list of inbound endpoints according to the given format
 func PrintInboundEndpointList(inboundEPList *artifactutils.InboundEndpointList, format string) {
-
 	if inboundEPList.Count > 0 {
-
 		inboundEPs := inboundEPList.InboundEndpoints
-
 		inboundEPListContext := getContextWithFormat(format, defaultInboundEndpointListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -69,12 +65,10 @@ func PrintInboundEndpointList(inboundEPList *artifactutils.InboundEndpointList, 
 			}
 			return nil
 		}
-
 		inboundEPListTableHeaders := map[string]string{
 			"Name": nameHeader,
 			"Type": typeHeader,
 		}
-
 		if err := inboundEPListContext.Write(renderer, inboundEPListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -85,7 +79,6 @@ func PrintInboundEndpointList(inboundEPList *artifactutils.InboundEndpointList, 
 
 // GetInboundEndpoint returns a information about a specific inbound endpoint deployed in the micro integrator in a given environment
 func GetInboundEndpoint(env, inboundEPName string) (*artifactutils.InboundEndpoint, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementInboundEndpointResource, "inboundEndpointName", inboundEPName, env,
 		&artifactutils.InboundEndpoint{})
 	if err != nil {
@@ -96,7 +89,6 @@ func GetInboundEndpoint(env, inboundEPName string) (*artifactutils.InboundEndpoi
 
 // PrintInboundEndpointDetails prints details about an inbound endpoint according to the given format
 func PrintInboundEndpointDetails(inboundEP *artifactutils.InboundEndpoint, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultInboundEndpointDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getIntegrationApis.go
+++ b/import-export-cli/mi/impl/getIntegrationApis.go
@@ -1,0 +1,110 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultIntegrationAPIListTableFormat = "table {{.Name}}\t{{.Url}}"
+	defaultIntegrationAPIDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Version - {{.Version}}\n" +
+		"Url - {{.Url}}\n" +
+		"Stats - {{.Stats}}\n" +
+		"Tracing - {{.Tracing}}\n" +
+		"Resources :\n" +
+		"URL\tMETHOD\n" +
+		"{{range .Resources}}{{.Url}}\t{{.Methods}}\n{{end}}"
+)
+
+// GetIntegrationAPIList returns a list of apis deployed in the micro integrator in a given environment
+func GetIntegrationAPIList(env string) (*artifactutils.IntegrationAPIList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementAPIResource, env, &artifactutils.IntegrationAPIList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.IntegrationAPIList), nil
+}
+
+// PrintIntegrationAPIList print a list of apis according to the given format
+func PrintIntegrationAPIList(apiList *artifactutils.IntegrationAPIList, format string) {
+
+	if apiList.Count > 0 {
+
+		apis := apiList.Apis
+
+		apiListContext := getContextWithFormat(format, defaultIntegrationAPIListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, api := range apis {
+				if err := t.Execute(w, api); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		apiListTableHeaders := map[string]string{
+			"Name": nameHeader,
+			"Url":  urlHeader,
+		}
+
+		if err := apiListContext.Write(renderer, apiListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No APIs found")
+	}
+}
+
+// GetIntegrationAPI returns a information about a specific api deployed in the micro integrator in a given environment
+func GetIntegrationAPI(env, apiName string) (*artifactutils.IntegrationAPI, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementAPIResource, "apiName", apiName, env, &artifactutils.IntegrationAPI{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.IntegrationAPI), nil
+}
+
+// PrintIntegrationAPIDetails prints details about an api according to the given format
+func PrintIntegrationAPIDetails(api *artifactutils.IntegrationAPI, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultIntegrationAPIDetailedFormat
+	}
+
+	apiContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(api)
+
+	if err := apiContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getIntegrationApis.go
+++ b/import-export-cli/mi/impl/getIntegrationApis.go
@@ -44,7 +44,6 @@ const (
 
 // GetIntegrationAPIList returns a list of apis deployed in the micro integrator in a given environment
 func GetIntegrationAPIList(env string) (*artifactutils.IntegrationAPIList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementAPIResource, env, &artifactutils.IntegrationAPIList{})
 	if err != nil {
 		return nil, err
@@ -54,11 +53,8 @@ func GetIntegrationAPIList(env string) (*artifactutils.IntegrationAPIList, error
 
 // PrintIntegrationAPIList print a list of apis according to the given format
 func PrintIntegrationAPIList(apiList *artifactutils.IntegrationAPIList, format string) {
-
 	if apiList.Count > 0 {
-
 		apis := apiList.Apis
-
 		apiListContext := getContextWithFormat(format, defaultIntegrationAPIListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -70,12 +66,10 @@ func PrintIntegrationAPIList(apiList *artifactutils.IntegrationAPIList, format s
 			}
 			return nil
 		}
-
 		apiListTableHeaders := map[string]string{
 			"Name": nameHeader,
 			"Url":  urlHeader,
 		}
-
 		if err := apiListContext.Write(renderer, apiListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -86,7 +80,6 @@ func PrintIntegrationAPIList(apiList *artifactutils.IntegrationAPIList, format s
 
 // GetIntegrationAPI returns a information about a specific api deployed in the micro integrator in a given environment
 func GetIntegrationAPI(env, apiName string) (*artifactutils.IntegrationAPI, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementAPIResource, "apiName", apiName, env, &artifactutils.IntegrationAPI{})
 	if err != nil {
 		return nil, err
@@ -96,7 +89,6 @@ func GetIntegrationAPI(env, apiName string) (*artifactutils.IntegrationAPI, erro
 
 // PrintIntegrationAPIDetails prints details about an api according to the given format
 func PrintIntegrationAPIDetails(api *artifactutils.IntegrationAPI, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultIntegrationAPIDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getLocalEntries.go
+++ b/import-export-cli/mi/impl/getLocalEntries.go
@@ -36,7 +36,6 @@ const (
 
 // GetLocalEntryList returns a list of local entries deployed in the micro integrator in a given environment
 func GetLocalEntryList(env string) (*artifactutils.LocalEntryList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementLocalEntrieResource, env, &artifactutils.LocalEntryList{})
 	if err != nil {
 		return nil, err
@@ -46,11 +45,8 @@ func GetLocalEntryList(env string) (*artifactutils.LocalEntryList, error) {
 
 // PrintLocalEntryList print a list of local entries according to the given format
 func PrintLocalEntryList(localEntryList *artifactutils.LocalEntryList, format string) {
-
 	if localEntryList.Count > 0 {
-
 		localEntrys := localEntryList.LocalEntries
-
 		localEntryListContext := getContextWithFormat(format, defaultLocalEntryListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -62,12 +58,10 @@ func PrintLocalEntryList(localEntryList *artifactutils.LocalEntryList, format st
 			}
 			return nil
 		}
-
 		localEntryListTableHeaders := map[string]string{
 			"Name": nameHeader,
 			"Type": typeHeader,
 		}
-
 		if err := localEntryListContext.Write(renderer, localEntryListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -78,7 +72,6 @@ func PrintLocalEntryList(localEntryList *artifactutils.LocalEntryList, format st
 
 // GetLocalEntry returns a information about a specific local entry deployed in the micro integrator in a given environment
 func GetLocalEntry(env, localEntryName string) (*artifactutils.LocalEntryData, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementLocalEntrieResource, "name", localEntryName, env, &artifactutils.LocalEntryData{})
 	if err != nil {
 		return nil, err
@@ -88,7 +81,6 @@ func GetLocalEntry(env, localEntryName string) (*artifactutils.LocalEntryData, e
 
 // PrintLocalEntryDetails prints details about a local entry according to the given format
 func PrintLocalEntryDetails(localEntry *artifactutils.LocalEntryData, format string) {
-
 	localEntryContext := getContextWithFormat(format, defaultLocalEntryDetailedFormat)
 	renderer := getItemRendererEndsWithNewLine(localEntry)
 

--- a/import-export-cli/mi/impl/getLocalEntries.go
+++ b/import-export-cli/mi/impl/getLocalEntries.go
@@ -1,0 +1,98 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultLocalEntryListTableFormat = "table {{.Name}}\t{{.Type}}"
+	defaultLocalEntryDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Type - {{.Type}}\n" +
+		"Value - {{.Value}}"
+)
+
+// GetLocalEntryList returns a list of local entries deployed in the micro integrator in a given environment
+func GetLocalEntryList(env string) (*artifactutils.LocalEntryList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementLocalEntrieResource, env, &artifactutils.LocalEntryList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.LocalEntryList), nil
+}
+
+// PrintLocalEntryList print a list of local entries according to the given format
+func PrintLocalEntryList(localEntryList *artifactutils.LocalEntryList, format string) {
+
+	if localEntryList.Count > 0 {
+
+		localEntrys := localEntryList.LocalEntries
+
+		localEntryListContext := getContextWithFormat(format, defaultLocalEntryListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, localEntry := range localEntrys {
+				if err := t.Execute(w, localEntry); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		localEntryListTableHeaders := map[string]string{
+			"Name": nameHeader,
+			"Type": typeHeader,
+		}
+
+		if err := localEntryListContext.Write(renderer, localEntryListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Local Entries found")
+	}
+}
+
+// GetLocalEntry returns a information about a specific local entry deployed in the micro integrator in a given environment
+func GetLocalEntry(env, localEntryName string) (*artifactutils.LocalEntryData, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementLocalEntrieResource, "name", localEntryName, env, &artifactutils.LocalEntryData{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.LocalEntryData), nil
+}
+
+// PrintLocalEntryDetails prints details about a local entry according to the given format
+func PrintLocalEntryDetails(localEntry *artifactutils.LocalEntryData, format string) {
+
+	localEntryContext := getContextWithFormat(format, defaultLocalEntryDetailedFormat)
+	renderer := getItemRendererEndsWithNewLine(localEntry)
+
+	if err := localEntryContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getLogFiles.go
+++ b/import-export-cli/mi/impl/getLogFiles.go
@@ -44,11 +44,8 @@ func GetLogFileList(env string) (*artifactutils.LogFileList, error) {
 
 // PrintLogFileList print a list of log file names and sizes according to the given format
 func PrintLogFileList(logFileList *artifactutils.LogFileList, format string) {
-
 	if logFileList.Count > 0 {
-
 		logFiles := logFileList.LogFiles
-
 		logFileListContext := getContextWithFormat(format, defaultLogFileListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -60,12 +57,10 @@ func PrintLogFileList(logFileList *artifactutils.LogFileList, format string) {
 			}
 			return nil
 		}
-
 		logFileListTableHeaders := map[string]string{
 			"FileName": nameHeader,
 			"Size":     sizeHeader,
 		}
-
 		if err := logFileListContext.Write(renderer, logFileListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -88,12 +83,10 @@ func FilterOnlyLogFiles(logFileList *artifactutils.LogFileList) *artifactutils.L
 
 // GetLogFile downloads the specified log file created by the micro integrator in a given environment as a byte stream
 func GetLogFile(env, logFileName string) ([]byte, error) {
-
 	params := make(map[string]string)
 	params["file"] = logFileName
 
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementLogResource, env, utils.MainConfigFilePath)
-
 	resp, err := downloadLogFileData(url, params, env)
 
 	if err != nil {

--- a/import-export-cli/mi/impl/getLogFiles.go
+++ b/import-export-cli/mi/impl/getLogFiles.go
@@ -1,0 +1,113 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultLogFileListTableFormat = "table {{.FileName}}\t{{.Size}}"
+)
+
+// GetLogFileList returns a list of log files created by the micro integrator in a given environment
+func GetLogFileList(env string) (*artifactutils.LogFileList, error) {
+	resp, err := getArtifactList(utils.MiManagementLogResource, env, &artifactutils.LogFileList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.LogFileList), nil
+}
+
+// PrintLogFileList print a list of log file names and sizes according to the given format
+func PrintLogFileList(logFileList *artifactutils.LogFileList, format string) {
+
+	if logFileList.Count > 0 {
+
+		logFiles := logFileList.LogFiles
+
+		logFileListContext := getContextWithFormat(format, defaultLogFileListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, logFile := range logFiles {
+				if err := t.Execute(w, logFile); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		logFileListTableHeaders := map[string]string{
+			"FileName": nameHeader,
+			"Size":     sizeHeader,
+		}
+
+		if err := logFileListContext.Write(renderer, logFileListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Log Files found")
+	}
+}
+
+// FilterOnlyLogFiles filter the files and return only a list of log files that has .log suffix
+func FilterOnlyLogFiles(logFileList *artifactutils.LogFileList) *artifactutils.LogFileList {
+	filteredList := new(artifactutils.LogFileList)
+	for _, logFile := range logFileList.LogFiles {
+		if strings.HasSuffix(logFile.FileName, ".log") {
+			filteredList.LogFiles = append(filteredList.LogFiles, logFile)
+		}
+	}
+	filteredList.Count = int32(len(filteredList.LogFiles))
+	return filteredList
+}
+
+// GetLogFile downloads the specified log file created by the micro integrator in a given environment as a byte stream
+func GetLogFile(env, logFileName string) ([]byte, error) {
+
+	params := make(map[string]string)
+	params["file"] = logFileName
+
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementLogResource, env, utils.MainConfigFilePath)
+
+	resp, err := downloadLogFileData(url, params, env)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// WriteLogFile writes the log file in the specified target directory
+func WriteLogFile(logFileData []byte, filePath string) {
+	err := ioutil.WriteFile(filePath, logFileData, 0644)
+	if err != nil {
+		fmt.Println("Error writing the log file", err.Error())
+	} else {
+		fmt.Println("Log file downloaded to", filePath)
+	}
+}

--- a/import-export-cli/mi/impl/getLogger.go
+++ b/import-export-cli/mi/impl/getLogger.go
@@ -1,0 +1,58 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultLoggerTableFormat = "table {{.LoggerName}}\t{{.LogLevel}}\t{{.ComponentName}}"
+)
+
+// GetLoggerInfo returns information about a specific logger
+func GetLoggerInfo(env, loggerName string) (*artifactutils.Logger, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementLoggingResource, "loggerName", loggerName, env, &artifactutils.Logger{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.Logger), nil
+}
+
+// PrintLoggerInfo prints details about a logger
+func PrintLoggerInfo(logger *artifactutils.Logger, format string) {
+
+	loggerContext := getContextWithFormat(format, defaultLoggerTableFormat)
+
+	renderer := getItemRendererEndsWithNewLine(logger)
+
+	loggerInfoTableHeaders := map[string]string{
+		"LoggerName":    nameHeader,
+		"LogLevel":      loglevelHeader,
+		"ComponentName": componentHeader,
+	}
+
+	if err := loggerContext.Write(renderer, loggerInfoTableHeaders); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getLogger.go
+++ b/import-export-cli/mi/impl/getLogger.go
@@ -31,7 +31,6 @@ const (
 
 // GetLoggerInfo returns information about a specific logger
 func GetLoggerInfo(env, loggerName string) (*artifactutils.Logger, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementLoggingResource, "loggerName", loggerName, env, &artifactutils.Logger{})
 	if err != nil {
 		return nil, err
@@ -41,9 +40,7 @@ func GetLoggerInfo(env, loggerName string) (*artifactutils.Logger, error) {
 
 // PrintLoggerInfo prints details about a logger
 func PrintLoggerInfo(logger *artifactutils.Logger, format string) {
-
 	loggerContext := getContextWithFormat(format, defaultLoggerTableFormat)
-
 	renderer := getItemRendererEndsWithNewLine(logger)
 
 	loggerInfoTableHeaders := map[string]string{
@@ -51,7 +48,6 @@ func PrintLoggerInfo(logger *artifactutils.Logger, format string) {
 		"LogLevel":      loglevelHeader,
 		"ComponentName": componentHeader,
 	}
-
 	if err := loggerContext.Write(renderer, loggerInfoTableHeaders); err != nil {
 		fmt.Println("Error executing template:", err.Error())
 	}

--- a/import-export-cli/mi/impl/getMessageProcessors.go
+++ b/import-export-cli/mi/impl/getMessageProcessors.go
@@ -1,0 +1,117 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultMessageProcessorListTableFormat = "table {{.Name}}\t{{.Type}}\t{{.Status}}"
+	defaultMessageProcessorDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Type - {{.Type}}\n" +
+		"File Name - {{.FileName}}\n" +
+		"Message Store - {{.Store}}\n" +
+		"Artifact Container - {{.Container}}\n" +
+		"Status - {{.Status}}\n" +
+		"Parameters :\n" +
+		"{{ if eq (len .Parameters) 0 }}" +
+		"No Parameters found\n" +
+		"{{else}}" +
+		"{{ range $key, $value := .Parameters }}" +
+		" {{ $key }} = {{ $value }}\n" +
+		"{{ end }}" +
+		"{{ end }}"
+)
+
+// GetMessageProcessorList returns a list of message processors deployed in the micro integrator in a given environment
+func GetMessageProcessorList(env string) (*artifactutils.MessageProcessorList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementMessageProcessorResource, env, &artifactutils.MessageProcessorList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.MessageProcessorList), nil
+}
+
+// PrintMessageProcessorList print a list of message processors according to the given format
+func PrintMessageProcessorList(messageProcessorList *artifactutils.MessageProcessorList, format string) {
+
+	if messageProcessorList.Count > 0 {
+
+		messageProcessors := messageProcessorList.MessageProcessors
+
+		messageProcessorListContext := getContextWithFormat(format, defaultMessageProcessorListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, messageProcessor := range messageProcessors {
+				if err := t.Execute(w, messageProcessor); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		messageProcessorListTableHeaders := map[string]string{
+			"Name":   nameHeader,
+			"Type":   typeHeader,
+			"Status": statusHeader,
+		}
+
+		if err := messageProcessorListContext.Write(renderer, messageProcessorListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Message Processors found")
+	}
+}
+
+// GetMessageProcessor returns a information about a specific message processor deployed in the micro integrator in a given environment
+func GetMessageProcessor(env, messageProcessorName string) (*artifactutils.MessageProcessorData, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementMessageProcessorResource, "name", messageProcessorName, env, &artifactutils.MessageProcessorData{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.MessageProcessorData), nil
+}
+
+// PrintMessageProcessorDetails prints details about a message processor according to the given format
+func PrintMessageProcessorDetails(messageProcessor *artifactutils.MessageProcessorData, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultMessageProcessorDetailedFormat
+	}
+
+	messageProcessorContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(messageProcessor)
+
+	if err := messageProcessorContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getMessageProcessors.go
+++ b/import-export-cli/mi/impl/getMessageProcessors.go
@@ -50,7 +50,6 @@ const (
 
 // GetMessageProcessorList returns a list of message processors deployed in the micro integrator in a given environment
 func GetMessageProcessorList(env string) (*artifactutils.MessageProcessorList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementMessageProcessorResource, env, &artifactutils.MessageProcessorList{})
 	if err != nil {
 		return nil, err
@@ -60,11 +59,8 @@ func GetMessageProcessorList(env string) (*artifactutils.MessageProcessorList, e
 
 // PrintMessageProcessorList print a list of message processors according to the given format
 func PrintMessageProcessorList(messageProcessorList *artifactutils.MessageProcessorList, format string) {
-
 	if messageProcessorList.Count > 0 {
-
 		messageProcessors := messageProcessorList.MessageProcessors
-
 		messageProcessorListContext := getContextWithFormat(format, defaultMessageProcessorListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -76,13 +72,11 @@ func PrintMessageProcessorList(messageProcessorList *artifactutils.MessageProces
 			}
 			return nil
 		}
-
 		messageProcessorListTableHeaders := map[string]string{
 			"Name":   nameHeader,
 			"Type":   typeHeader,
 			"Status": statusHeader,
 		}
-
 		if err := messageProcessorListContext.Write(renderer, messageProcessorListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -93,7 +87,6 @@ func PrintMessageProcessorList(messageProcessorList *artifactutils.MessageProces
 
 // GetMessageProcessor returns a information about a specific message processor deployed in the micro integrator in a given environment
 func GetMessageProcessor(env, messageProcessorName string) (*artifactutils.MessageProcessorData, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementMessageProcessorResource, "name", messageProcessorName, env, &artifactutils.MessageProcessorData{})
 	if err != nil {
 		return nil, err
@@ -103,7 +96,6 @@ func GetMessageProcessor(env, messageProcessorName string) (*artifactutils.Messa
 
 // PrintMessageProcessorDetails prints details about a message processor according to the given format
 func PrintMessageProcessorDetails(messageProcessor *artifactutils.MessageProcessorData, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultMessageProcessorDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getMessageStores.go
+++ b/import-export-cli/mi/impl/getMessageStores.go
@@ -50,7 +50,6 @@ const (
 
 // GetMessageStoreList returns a list of message stores deployed in the micro integrator in a given environment
 func GetMessageStoreList(env string) (*artifactutils.MessageStoreList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementMessageStoreResource, env, &artifactutils.MessageStoreList{})
 	if err != nil {
 		return nil, err
@@ -60,11 +59,8 @@ func GetMessageStoreList(env string) (*artifactutils.MessageStoreList, error) {
 
 // PrintMessageStoreList print a list of message stores according to the given format
 func PrintMessageStoreList(messageStoreList *artifactutils.MessageStoreList, format string) {
-
 	if messageStoreList.Count > 0 {
-
 		messageStores := messageStoreList.MessageStores
-
 		messageStoreListContext := getContextWithFormat(format, defaultMessageStoreListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -76,13 +72,11 @@ func PrintMessageStoreList(messageStoreList *artifactutils.MessageStoreList, for
 			}
 			return nil
 		}
-
 		messageStoreListTableHeaders := map[string]string{
 			"Name": nameHeader,
 			"Type": typeHeader,
 			"Size": sizeHeader,
 		}
-
 		if err := messageStoreListContext.Write(renderer, messageStoreListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -93,7 +87,6 @@ func PrintMessageStoreList(messageStoreList *artifactutils.MessageStoreList, for
 
 // GetMessageStore returns a information about a specific message store deployed in the micro integrator in a given environment
 func GetMessageStore(env, messageStoreName string) (*artifactutils.MessageStoreData, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementMessageStoreResource, "name", messageStoreName, env, &artifactutils.MessageStoreData{})
 	if err != nil {
 		return nil, err
@@ -103,7 +96,6 @@ func GetMessageStore(env, messageStoreName string) (*artifactutils.MessageStoreD
 
 // PrintMessageStoreDetails prints details about a message store according to the given format
 func PrintMessageStoreDetails(messageStore *artifactutils.MessageStoreData, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultMessageStoreDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getMessageStores.go
+++ b/import-export-cli/mi/impl/getMessageStores.go
@@ -1,0 +1,117 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultMessageStoreListTableFormat = "table {{.Name}}\t{{.Type}}\t{{.Size}}"
+	defaultMessageStoreDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"File Name - {{.FileName}}\n" +
+		"Container - {{.Container}}\n" +
+		"Producer - {{.Producer}}\n" +
+		"Consumer - {{.Consumer}}\n" +
+		"Size - {{.Size}}\n" +
+		"Properties :\n" +
+		"{{ if eq (len .Properties) 0 }}" +
+		"No Properties found\n" +
+		"{{else}}" +
+		"{{ range $key, $value := .Properties }}" +
+		" {{ $key }} = {{ $value }}\n" +
+		"{{ end }}" +
+		"{{ end }}"
+)
+
+// GetMessageStoreList returns a list of message stores deployed in the micro integrator in a given environment
+func GetMessageStoreList(env string) (*artifactutils.MessageStoreList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementMessageStoreResource, env, &artifactutils.MessageStoreList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.MessageStoreList), nil
+}
+
+// PrintMessageStoreList print a list of message stores according to the given format
+func PrintMessageStoreList(messageStoreList *artifactutils.MessageStoreList, format string) {
+
+	if messageStoreList.Count > 0 {
+
+		messageStores := messageStoreList.MessageStores
+
+		messageStoreListContext := getContextWithFormat(format, defaultMessageStoreListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, messageStore := range messageStores {
+				if err := t.Execute(w, messageStore); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		messageStoreListTableHeaders := map[string]string{
+			"Name": nameHeader,
+			"Type": typeHeader,
+			"Size": sizeHeader,
+		}
+
+		if err := messageStoreListContext.Write(renderer, messageStoreListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Message Stores found")
+	}
+}
+
+// GetMessageStore returns a information about a specific message store deployed in the micro integrator in a given environment
+func GetMessageStore(env, messageStoreName string) (*artifactutils.MessageStoreData, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementMessageStoreResource, "name", messageStoreName, env, &artifactutils.MessageStoreData{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.MessageStoreData), nil
+}
+
+// PrintMessageStoreDetails prints details about a message store according to the given format
+func PrintMessageStoreDetails(messageStore *artifactutils.MessageStoreData, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultMessageStoreDetailedFormat
+	}
+
+	messageStoreContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(messageStore)
+
+	if err := messageStoreContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getProxyServices.go
+++ b/import-export-cli/mi/impl/getProxyServices.go
@@ -1,0 +1,107 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultProxyServiceListTableFormat = "table {{.Name}}\t{{.Wsdl11}}\t{{.Wsdl20}}"
+	defaultProxyServiceDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"WSDL 1.1 - {{.Wsdl11}}\n" +
+		"WSDL 2.0 - {{.Wsdl20}}\n" +
+		"Stats - {{.Stats}}\n" +
+		"Tracing - {{.Tracing}}"
+)
+
+// GetProxyServiceList returns a list of proxy serives deployed in the micro integrator in a given environment
+func GetProxyServiceList(env string) (*artifactutils.ProxyServiceList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementProxyServiceResource, env, &artifactutils.ProxyServiceList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.ProxyServiceList), nil
+}
+
+// PrintProxyServiceList print a list of proxy serives according to the given format
+func PrintProxyServiceList(proxyList *artifactutils.ProxyServiceList, format string) {
+
+	if proxyList.Count > 0 {
+
+		proxies := proxyList.Proxies
+
+		proxyListContext := getContextWithFormat(format, defaultProxyServiceListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, proxy := range proxies {
+				if err := t.Execute(w, proxy); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		proxyListTableHeaders := map[string]string{
+			"Name":   nameHeader,
+			"Wsdl11": wsdl11Header,
+			"Wsdl20": wsdl20Header,
+		}
+
+		if err := proxyListContext.Write(renderer, proxyListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Proxy Services found")
+	}
+}
+
+// GetProxyService returns a information about a specific proxy deployed in the micro integrator in a given environment
+func GetProxyService(env, proxyName string) (*artifactutils.Proxy, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementProxyServiceResource, "proxyServiceName", proxyName, env, &artifactutils.Proxy{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.Proxy), nil
+}
+
+// PrintProxyServiceDetails prints details about a proxy according to the given format
+func PrintProxyServiceDetails(proxy *artifactutils.Proxy, format string) {
+
+	if format == "" {
+		format = defaultProxyServiceDetailedFormat
+	}
+
+	proxyContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRendererEndsWithNewLine(proxy)
+
+	if err := proxyContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getProxyServices.go
+++ b/import-export-cli/mi/impl/getProxyServices.go
@@ -40,7 +40,6 @@ const (
 
 // GetProxyServiceList returns a list of proxy serives deployed in the micro integrator in a given environment
 func GetProxyServiceList(env string) (*artifactutils.ProxyServiceList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementProxyServiceResource, env, &artifactutils.ProxyServiceList{})
 	if err != nil {
 		return nil, err
@@ -50,11 +49,8 @@ func GetProxyServiceList(env string) (*artifactutils.ProxyServiceList, error) {
 
 // PrintProxyServiceList print a list of proxy serives according to the given format
 func PrintProxyServiceList(proxyList *artifactutils.ProxyServiceList, format string) {
-
 	if proxyList.Count > 0 {
-
 		proxies := proxyList.Proxies
-
 		proxyListContext := getContextWithFormat(format, defaultProxyServiceListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -66,13 +62,11 @@ func PrintProxyServiceList(proxyList *artifactutils.ProxyServiceList, format str
 			}
 			return nil
 		}
-
 		proxyListTableHeaders := map[string]string{
 			"Name":   nameHeader,
 			"Wsdl11": wsdl11Header,
 			"Wsdl20": wsdl20Header,
 		}
-
 		if err := proxyListContext.Write(renderer, proxyListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -83,7 +77,6 @@ func PrintProxyServiceList(proxyList *artifactutils.ProxyServiceList, format str
 
 // GetProxyService returns a information about a specific proxy deployed in the micro integrator in a given environment
 func GetProxyService(env, proxyName string) (*artifactutils.Proxy, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementProxyServiceResource, "proxyServiceName", proxyName, env, &artifactutils.Proxy{})
 	if err != nil {
 		return nil, err
@@ -93,7 +86,6 @@ func GetProxyService(env, proxyName string) (*artifactutils.Proxy, error) {
 
 // PrintProxyServiceDetails prints details about a proxy according to the given format
 func PrintProxyServiceDetails(proxy *artifactutils.Proxy, format string) {
-
 	if format == "" {
 		format = defaultProxyServiceDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getSequences.go
+++ b/import-export-cli/mi/impl/getSequences.go
@@ -45,7 +45,6 @@ const (
 
 // GetSequenceList returns a list of sequences deployed in the micro integrator in a given environment
 func GetSequenceList(env string) (*artifactutils.SequenceList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementSequenceResource, env, &artifactutils.SequenceList{})
 	if err != nil {
 		return nil, err
@@ -55,11 +54,8 @@ func GetSequenceList(env string) (*artifactutils.SequenceList, error) {
 
 // PrintSequenceList print a list of sequences according to the given format
 func PrintSequenceList(sequenceList *artifactutils.SequenceList, format string) {
-
 	if sequenceList.Count > 0 {
-
 		sequences := sequenceList.Sequences
-
 		sequenceListContext := getContextWithFormat(format, defaultSequenceListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -71,13 +67,11 @@ func PrintSequenceList(sequenceList *artifactutils.SequenceList, format string) 
 			}
 			return nil
 		}
-
 		sequenceListTableHeaders := map[string]string{
 			"Name":    nameHeader,
 			"Stats":   statsHeader,
 			"Tracing": tracingHeader,
 		}
-
 		if err := sequenceListContext.Write(renderer, sequenceListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -88,7 +82,6 @@ func PrintSequenceList(sequenceList *artifactutils.SequenceList, format string) 
 
 // GetSequence returns a information about a specific sequence deployed in the micro integrator in a given environment
 func GetSequence(env, sequenceName string) (*artifactutils.Sequence, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementSequenceResource, "sequenceName", sequenceName, env, &artifactutils.Sequence{})
 	if err != nil {
 		return nil, err
@@ -98,7 +91,6 @@ func GetSequence(env, sequenceName string) (*artifactutils.Sequence, error) {
 
 // PrintSequenceDetails prints details about a sequence according to the given format
 func PrintSequenceDetails(sequence *artifactutils.Sequence, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultSequenceDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getSequences.go
+++ b/import-export-cli/mi/impl/getSequences.go
@@ -1,0 +1,112 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultSequenceListTableFormat = "table {{.Name}}\t{{.Stats}}\t{{.Tracing}}"
+	defaultSequenceDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Container - {{.Container}}\n" +
+		"Stats - {{.Stats}}\n" +
+		"Tracing - {{.Tracing}}\n" +
+		"Mediators - " +
+		"{{range $index, $mediator := .Mediators}}" +
+		"{{if $index}}, {{end}}" +
+		"{{$mediator}}" +
+		"{{end}}"
+)
+
+// GetSequenceList returns a list of sequences deployed in the micro integrator in a given environment
+func GetSequenceList(env string) (*artifactutils.SequenceList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementSequenceResource, env, &artifactutils.SequenceList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.SequenceList), nil
+}
+
+// PrintSequenceList print a list of sequences according to the given format
+func PrintSequenceList(sequenceList *artifactutils.SequenceList, format string) {
+
+	if sequenceList.Count > 0 {
+
+		sequences := sequenceList.Sequences
+
+		sequenceListContext := getContextWithFormat(format, defaultSequenceListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, sequence := range sequences {
+				if err := t.Execute(w, sequence); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		sequenceListTableHeaders := map[string]string{
+			"Name":    nameHeader,
+			"Stats":   statsHeader,
+			"Tracing": tracingHeader,
+		}
+
+		if err := sequenceListContext.Write(renderer, sequenceListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Sequences found")
+	}
+}
+
+// GetSequence returns a information about a specific sequence deployed in the micro integrator in a given environment
+func GetSequence(env, sequenceName string) (*artifactutils.Sequence, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementSequenceResource, "sequenceName", sequenceName, env, &artifactutils.Sequence{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.Sequence), nil
+}
+
+// PrintSequenceDetails prints details about a sequence according to the given format
+func PrintSequenceDetails(sequence *artifactutils.Sequence, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultSequenceDetailedFormat
+	}
+
+	sequenceContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRendererEndsWithNewLine(sequence)
+
+	if err := sequenceContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getTasks.go
+++ b/import-export-cli/mi/impl/getTasks.go
@@ -43,7 +43,6 @@ const (
 
 // GetTaskList returns a list of Tasks deployed in the micro integrator in a given environment
 func GetTaskList(env string) (*artifactutils.TaskList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementTaskResource, env, &artifactutils.TaskList{})
 	if err != nil {
 		return nil, err
@@ -53,11 +52,8 @@ func GetTaskList(env string) (*artifactutils.TaskList, error) {
 
 // PrintTaskList print a list of Tasks according to the given format
 func PrintTaskList(taskList *artifactutils.TaskList, format string) {
-
 	if taskList.Count > 0 {
-
 		tasks := taskList.Tasks
-
 		taskListContext := getContextWithFormat(format, defaultTaskListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -69,11 +65,9 @@ func PrintTaskList(taskList *artifactutils.TaskList, format string) {
 			}
 			return nil
 		}
-
 		taskListTableHeaders := map[string]string{
 			"Name": nameHeader,
 		}
-
 		if err := taskListContext.Write(renderer, taskListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -84,7 +78,6 @@ func PrintTaskList(taskList *artifactutils.TaskList, format string) {
 
 // GetTask returns a information about a specific Task deployed in the micro integrator in a given environment
 func GetTask(env, taskName string) (*artifactutils.Task, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementTaskResource, "taskName", taskName, env, &artifactutils.Task{})
 	if err != nil {
 		return nil, err
@@ -94,7 +87,6 @@ func GetTask(env, taskName string) (*artifactutils.Task, error) {
 
 // PrintTaskDetails prints details about a Task according to the given format
 func PrintTaskDetails(task *artifactutils.Task, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultTaskDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getTasks.go
+++ b/import-export-cli/mi/impl/getTasks.go
@@ -1,0 +1,108 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultTaskListTableFormat = "table {{.Name}}"
+	defaultTaskDetailedFormat  = "detail Name - {{.Name}}\n" +
+		"Trigger Type - {{.Type}}\n" +
+		"{{if .TriggerCron}}Cron Expression - {{.TriggerCron}}" +
+		"{{else}}" +
+		"Trigger Count - {{.TriggerCount}}\n" +
+		"Trigger Interval - {{.TriggerInterval}}" +
+		"{{end}}"
+)
+
+// GetTaskList returns a list of Tasks deployed in the micro integrator in a given environment
+func GetTaskList(env string) (*artifactutils.TaskList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementTaskResource, env, &artifactutils.TaskList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TaskList), nil
+}
+
+// PrintTaskList print a list of Tasks according to the given format
+func PrintTaskList(taskList *artifactutils.TaskList, format string) {
+
+	if taskList.Count > 0 {
+
+		tasks := taskList.Tasks
+
+		taskListContext := getContextWithFormat(format, defaultTaskListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, task := range tasks {
+				if err := t.Execute(w, task); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		taskListTableHeaders := map[string]string{
+			"Name": nameHeader,
+		}
+
+		if err := taskListContext.Write(renderer, taskListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Tasks found")
+	}
+}
+
+// GetTask returns a information about a specific Task deployed in the micro integrator in a given environment
+func GetTask(env, taskName string) (*artifactutils.Task, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementTaskResource, "taskName", taskName, env, &artifactutils.Task{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.Task), nil
+}
+
+// PrintTaskDetails prints details about a Task according to the given format
+func PrintTaskDetails(task *artifactutils.Task, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultTaskDetailedFormat
+	}
+
+	taskContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRendererEndsWithNewLine(task)
+
+	if err := taskContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getTemplates.go
+++ b/import-export-cli/mi/impl/getTemplates.go
@@ -81,7 +81,6 @@ func (a *templateArtifact) MarshalJSON() ([]byte, error) {
 
 // GetTemplateList returns a list of Templates deployed in the micro integrator in a given environment
 func GetTemplateList(env string) (*artifactutils.TemplateList, error) {
-
 	resp, err := getArtifactList(utils.MiManagementTemplateResource, env, &artifactutils.TemplateList{})
 	if err != nil {
 		return nil, err
@@ -91,12 +90,10 @@ func GetTemplateList(env string) (*artifactutils.TemplateList, error) {
 
 // PrintTemplateList print a list of Templates according to the given format
 func PrintTemplateList(templateList *artifactutils.TemplateList, format string) {
-
 	var sequenceTemplatesCount = len(templateList.SequenceTemplates)
 	var endpointTemplatesCount = len(templateList.EndpointTemplates)
 
 	if sequenceTemplatesCount+endpointTemplatesCount > 0 {
-
 		templates := make([]templateArtifact, 0, sequenceTemplatesCount+endpointTemplatesCount)
 
 		for _, template := range templateList.SequenceTemplates {
@@ -107,7 +104,6 @@ func PrintTemplateList(templateList *artifactutils.TemplateList, format string) 
 			templateArtifact := templateArtifact{template.Name, "Endpoint"}
 			templates = append(templates, templateArtifact)
 		}
-
 		templateListContext := getContextWithFormat(format, defaultTemplateListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -119,16 +115,13 @@ func PrintTemplateList(templateList *artifactutils.TemplateList, format string) 
 			}
 			return nil
 		}
-
 		templateListTableHeaders := map[string]string{
 			"TemplateName": nameHeader,
 			"TemplateType": typeHeader,
 		}
-
 		if err := templateListContext.Write(renderer, templateListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
-
 	} else {
 		fmt.Println("No Templates found")
 	}
@@ -136,7 +129,6 @@ func PrintTemplateList(templateList *artifactutils.TemplateList, format string) 
 
 // GetTemplatesByType returns a list of Templates of specified type deployed in the micro integrator in a given environment
 func GetTemplatesByType(env, templateType string) (*artifactutils.TemplateListByType, error) {
-
 	resp, err := getArtifactInfo(utils.MiManagementTemplateResource, "type", templateType, env, &artifactutils.TemplateListByType{})
 	if err != nil {
 		return nil, err
@@ -146,11 +138,8 @@ func GetTemplatesByType(env, templateType string) (*artifactutils.TemplateListBy
 
 // PrintTemplatesByType print a list of Templates of specified type according to the given format
 func PrintTemplatesByType(templateList *artifactutils.TemplateListByType, format string) {
-
 	if templateList.Count > 0 {
-
 		templates := templateList.Templates
-
 		templateListByTypeContext := getContextWithFormat(format, defaultTemplateListByTypeTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -162,11 +151,9 @@ func PrintTemplatesByType(templateList *artifactutils.TemplateListByType, format
 			}
 			return nil
 		}
-
 		templateListByTypeTableHeaders := map[string]string{
 			"Name": nameHeader,
 		}
-
 		if err := templateListByTypeContext.Write(renderer, templateListByTypeTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -177,7 +164,6 @@ func PrintTemplatesByType(templateList *artifactutils.TemplateListByType, format
 
 // GetEndpointTemplate returns a information about a specific endpoint template deployed in the micro integrator in a given environment
 func GetEndpointTemplate(env, templateName string) (*artifactutils.TemplateEndpointListByName, error) {
-
 	resp, err := getTemplate(env, "endpoint", templateName, &artifactutils.TemplateEndpointListByName{})
 	if err != nil {
 		return nil, err
@@ -187,7 +173,6 @@ func GetEndpointTemplate(env, templateName string) (*artifactutils.TemplateEndpo
 
 // GetSequenceTemplate returns a information about a specific sequence template deployed in the micro integrator in a given environment
 func GetSequenceTemplate(env, templateName string) (*artifactutils.TemplateSequenceListByName, error) {
-
 	resp, err := getTemplate(env, "sequence", templateName, &artifactutils.TemplateSequenceListByName{})
 	if err != nil {
 		return nil, err
@@ -209,7 +194,6 @@ func getTemplate(env, templateType, templateName string, model interface{}) (int
 
 // PrintSequenceTemplateDetails prints details about a sequence template according to the given format
 func PrintSequenceTemplateDetails(sequenceTemplate *artifactutils.TemplateSequenceListByName, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultSequenceTemplateDetailedFormat
 	}
@@ -224,7 +208,6 @@ func PrintSequenceTemplateDetails(sequenceTemplate *artifactutils.TemplateSequen
 
 // PrintEndpointTemplateDetails prints details about a endpoint template according to the given format
 func PrintEndpointTemplateDetails(endpointTemplate *artifactutils.TemplateEndpointListByName, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultEndpointTemplateDetailedFormat
 	}

--- a/import-export-cli/mi/impl/getTemplates.go
+++ b/import-export-cli/mi/impl/getTemplates.go
@@ -1,0 +1,238 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultTemplateListTableFormat        = "table {{.TemplateName}}\t{{.TemplateType}}"
+	defaultTemplateListByTypeTableFormat  = "table {{.Name}}"
+	defaultSequenceTemplateDetailedFormat = "detail Name - {{.Name}}\n" +
+		"Parameters :\n" +
+		"{{ if eq (len .Parameters) 0 }}" +
+		"No Parameters found\n" +
+		"{{else}}" +
+		"NAME\tDEFAULT VALUE\tMANDATORY\n" +
+		"{{range .Parameters}}{{.Name}}\t{{.DefaultValue}}\t{{.IsMandatory}}\n{{end}}" +
+		"{{ end }}"
+	defaultEndpointTemplateDetailedFormat = "detail Name - {{.Name}}\n" +
+		"Parameters : " +
+		"{{ if eq (len .Parameters) 0 }}" +
+		"No Parameters found\n" +
+		"{{else}}" +
+		"{{range $index, $param := .Parameters}}" +
+		"{{if $index}}, {{end}}" +
+		"{{$param}}" +
+		"{{end}}" +
+		"{{end}}"
+)
+
+// templateArtifact holds information about a template for outputting
+type templateArtifact struct {
+	templateName string
+	templateType string
+}
+
+// creates a new api from utils.API
+func newTemplateArtifactDefinitionFromTemplate(template artifactutils.Template, templateType string) *templateArtifact {
+	return &templateArtifact{template.Name, templateType}
+}
+
+// Name of template
+func (a templateArtifact) TemplateName() string {
+	return a.templateName
+}
+
+// Type of template
+func (a templateArtifact) TemplateType() string {
+	return a.templateType
+}
+
+// MarshalJSON marshals templateArtifact using custom marshaller which uses methods instead of fields
+func (a *templateArtifact) MarshalJSON() ([]byte, error) {
+	return formatter.MarshalJSON(a)
+}
+
+// GetTemplateList returns a list of Templates deployed in the micro integrator in a given environment
+func GetTemplateList(env string) (*artifactutils.TemplateList, error) {
+
+	resp, err := getArtifactList(utils.MiManagementTemplateResource, env, &artifactutils.TemplateList{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TemplateList), nil
+}
+
+// PrintTemplateList print a list of Templates according to the given format
+func PrintTemplateList(templateList *artifactutils.TemplateList, format string) {
+
+	var sequenceTemplatesCount = len(templateList.SequenceTemplates)
+	var endpointTemplatesCount = len(templateList.EndpointTemplates)
+
+	if sequenceTemplatesCount+endpointTemplatesCount > 0 {
+
+		templates := make([]templateArtifact, 0, sequenceTemplatesCount+endpointTemplatesCount)
+
+		for _, template := range templateList.SequenceTemplates {
+			templateArtifact := templateArtifact{template.Name, "Sequence"}
+			templates = append(templates, templateArtifact)
+		}
+		for _, template := range templateList.EndpointTemplates {
+			templateArtifact := templateArtifact{template.Name, "Endpoint"}
+			templates = append(templates, templateArtifact)
+		}
+
+		templateListContext := getContextWithFormat(format, defaultTemplateListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, template := range templates {
+				if err := t.Execute(w, template); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		templateListTableHeaders := map[string]string{
+			"TemplateName": nameHeader,
+			"TemplateType": typeHeader,
+		}
+
+		if err := templateListContext.Write(renderer, templateListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+
+	} else {
+		fmt.Println("No Templates found")
+	}
+}
+
+// GetTemplatesByType returns a list of Templates of specified type deployed in the micro integrator in a given environment
+func GetTemplatesByType(env, templateType string) (*artifactutils.TemplateListByType, error) {
+
+	resp, err := getArtifactInfo(utils.MiManagementTemplateResource, "type", templateType, env, &artifactutils.TemplateListByType{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TemplateListByType), nil
+}
+
+// PrintTemplatesByType print a list of Templates of specified type according to the given format
+func PrintTemplatesByType(templateList *artifactutils.TemplateListByType, format string) {
+
+	if templateList.Count > 0 {
+
+		templates := templateList.Templates
+
+		templateListByTypeContext := getContextWithFormat(format, defaultTemplateListByTypeTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, template := range templates {
+				if err := t.Execute(w, template); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		templateListByTypeTableHeaders := map[string]string{
+			"Name": nameHeader,
+		}
+
+		if err := templateListByTypeContext.Write(renderer, templateListByTypeTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Templates found for the given type")
+	}
+}
+
+// GetEndpointTemplate returns a information about a specific endpoint template deployed in the micro integrator in a given environment
+func GetEndpointTemplate(env, templateName string) (*artifactutils.TemplateEndpointListByName, error) {
+
+	resp, err := getTemplate(env, "endpoint", templateName, &artifactutils.TemplateEndpointListByName{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TemplateEndpointListByName), nil
+}
+
+// GetSequenceTemplate returns a information about a specific sequence template deployed in the micro integrator in a given environment
+func GetSequenceTemplate(env, templateName string) (*artifactutils.TemplateSequenceListByName, error) {
+
+	resp, err := getTemplate(env, "sequence", templateName, &artifactutils.TemplateSequenceListByName{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TemplateSequenceListByName), nil
+}
+
+func getTemplate(env, templateType, templateName string, model interface{}) (interface{}, error) {
+	params := make(map[string]string)
+	params["type"] = templateType
+	params["name"] = templateName
+
+	resp, err := callMIManagementEndpointOfResource(utils.MiManagementTemplateResource, params, env, model)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// PrintSequenceTemplateDetails prints details about a sequence template according to the given format
+func PrintSequenceTemplateDetails(sequenceTemplate *artifactutils.TemplateSequenceListByName, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultSequenceTemplateDetailedFormat
+	}
+
+	templateContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRenderer(sequenceTemplate)
+
+	if err := templateContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}
+
+// PrintEndpointTemplateDetails prints details about a endpoint template according to the given format
+func PrintEndpointTemplateDetails(endpointTemplate *artifactutils.TemplateEndpointListByName, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultEndpointTemplateDetailedFormat
+	}
+
+	templateContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRendererEndsWithNewLine(endpointTemplate)
+
+	if err := templateContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getTransactionCounts.go
+++ b/import-export-cli/mi/impl/getTransactionCounts.go
@@ -31,7 +31,6 @@ const (
 
 // GetTransactionCount returns inbound transactions received by the micro integrator in a given environment
 func GetTransactionCount(env string, period []string) (*artifactutils.TransactionCount, error) {
-
 	var params map[string]string
 
 	if len(period) == 2 {
@@ -41,7 +40,6 @@ func GetTransactionCount(env string, period []string) (*artifactutils.Transactio
 	}
 
 	var transactionCountResource = utils.MiManagementTransactionResource + "/" + utils.MiManagementTransactionCountResource
-
 	resp, err := callMIManagementEndpointOfResource(transactionCountResource, params, env, &artifactutils.TransactionCount{})
 	if err != nil {
 		return nil, err
@@ -51,9 +49,7 @@ func GetTransactionCount(env string, period []string) (*artifactutils.Transactio
 
 // PrintTransactionCount prints the transaction count according to the given format
 func PrintTransactionCount(transactionCount *artifactutils.TransactionCount, format string) {
-
 	transactionContext := getContextWithFormat(format, defaultTransactionCountTableFormat)
-
 	renderer := getItemRendererEndsWithNewLine(transactionCount)
 
 	transactionCountTableHeaders := map[string]string{
@@ -61,7 +57,6 @@ func PrintTransactionCount(transactionCount *artifactutils.TransactionCount, for
 		"Month":            monthHeader,
 		"TransactionCount": transactionCountHeader,
 	}
-
 	if err := transactionContext.Write(renderer, transactionCountTableHeaders); err != nil {
 		fmt.Println("Error executing template:", err.Error())
 	}

--- a/import-export-cli/mi/impl/getTransactionCounts.go
+++ b/import-export-cli/mi/impl/getTransactionCounts.go
@@ -1,0 +1,68 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultTransactionCountTableFormat = "table {{.Year}}\t{{.Month}}\t{{.TransactionCount}}"
+)
+
+// GetTransactionCount returns inbound transactions received by the micro integrator in a given environment
+func GetTransactionCount(env string, period []string) (*artifactutils.TransactionCount, error) {
+
+	var params map[string]string
+
+	if len(period) == 2 {
+		params = make(map[string]string)
+		params["year"] = period[0]
+		params["month"] = period[1]
+	}
+
+	var transactionCountResource = utils.MiManagementTransactionResource + "/" + utils.MiManagementTransactionCountResource
+
+	resp, err := callMIManagementEndpointOfResource(transactionCountResource, params, env, &artifactutils.TransactionCount{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TransactionCount), nil
+}
+
+// PrintTransactionCount prints the transaction count according to the given format
+func PrintTransactionCount(transactionCount *artifactutils.TransactionCount, format string) {
+
+	transactionContext := getContextWithFormat(format, defaultTransactionCountTableFormat)
+
+	renderer := getItemRendererEndsWithNewLine(transactionCount)
+
+	transactionCountTableHeaders := map[string]string{
+		"Year":             yearHeader,
+		"Month":            monthHeader,
+		"TransactionCount": transactionCountHeader,
+	}
+
+	if err := transactionContext.Write(renderer, transactionCountTableHeaders); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getTransactionReports.go
+++ b/import-export-cli/mi/impl/getTransactionReports.go
@@ -32,13 +32,11 @@ const transactionReportFilePrefix = "transaction-count-summary-"
 
 // GetTransactionReport returns inbound transactions received by the micro integrator in a given environment as a report
 func GetTransactionReport(env string, period []string) (*artifactutils.TransactionCountInfo, error) {
-
 	params := make(map[string]string)
 	params["start"] = period[0]
 	params["end"] = period[1]
 
 	var transactionReportResource = utils.MiManagementTransactionResource + "/" + utils.MiManagementTransactionReportResource
-
 	resp, err := callMIManagementEndpointOfResource(transactionReportResource, params, env, &artifactutils.TransactionCountInfo{})
 	if err != nil {
 		return nil, err

--- a/import-export-cli/mi/impl/getTransactionReports.go
+++ b/import-export-cli/mi/impl/getTransactionReports.go
@@ -1,0 +1,60 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const transactionReportFilePrefix = "transaction-count-summary-"
+
+// GetTransactionReport returns inbound transactions received by the micro integrator in a given environment as a report
+func GetTransactionReport(env string, period []string) (*artifactutils.TransactionCountInfo, error) {
+
+	params := make(map[string]string)
+	params["start"] = period[0]
+	params["end"] = period[1]
+
+	var transactionReportResource = utils.MiManagementTransactionResource + "/" + utils.MiManagementTransactionReportResource
+
+	resp, err := callMIManagementEndpointOfResource(transactionReportResource, params, env, &artifactutils.TransactionCountInfo{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.TransactionCountInfo), nil
+}
+
+// WriteTransactionReportAsCSV writes the transaction report to a csv file in the specified target directory
+func WriteTransactionReportAsCSV(transactions *artifactutils.TransactionCountInfo, targetDirectory string) {
+	fileName := transactionReportFilePrefix + strconv.FormatInt(time.Now().UnixNano(), 10) + ".csv"
+	destinationFilePath := filepath.Join(targetDirectory, fileName)
+	transactionCountLines := transactions.TransactionCounts
+	err := utils.WriteLinesToCSVFile(transactionCountLines, destinationFilePath)
+	if err != nil {
+		fmt.Println("Error writing the transaction report", err.Error())
+	} else {
+		fmt.Println("Transaction Count Report created in", destinationFilePath)
+	}
+}

--- a/import-export-cli/mi/impl/getUsers.go
+++ b/import-export-cli/mi/impl/getUsers.go
@@ -1,0 +1,115 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/utils/artifactutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	defaultUserListTableFormat = "table {{.UserId}}"
+	defaultUserDetailedFormat  = "detail Name - {{.UserId}}\n" +
+		"Is Admin - {{.IsAdmin}}\n" +
+		"Roles - " +
+		"{{range $index, $role := .Roles}}" +
+		"{{if $index}}, {{end}}" +
+		"{{$role}}" +
+		"{{end}}"
+)
+
+// GetUserList returns a list of users in the micro integrator in a given environment
+func GetUserList(env, role, pattern string) (*artifactutils.UserList, error) {
+
+	params := make(map[string]string)
+	putNonEmptyValueToMap(params, "role", role)
+	putNonEmptyValueToMap(params, "pattern", pattern)
+
+	resp, err := callMIManagementEndpointOfResource(utils.MiManagementUserResource, params, env, &artifactutils.UserList{})
+
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.UserList), nil
+}
+
+// PrintUserList print a list of mi users according to the given format
+func PrintUserList(userList *artifactutils.UserList, format string) {
+
+	if userList.Count > 0 {
+
+		users := userList.Users
+
+		userListContext := getContextWithFormat(format, defaultUserListTableFormat)
+
+		renderer := func(w io.Writer, t *template.Template) error {
+			for _, user := range users {
+				if err := t.Execute(w, user); err != nil {
+					return err
+				}
+				_, _ = w.Write([]byte{'\n'})
+			}
+			return nil
+		}
+
+		userListTableHeaders := map[string]string{
+			"UserId": userIDHeader,
+		}
+
+		if err := userListContext.Write(renderer, userListTableHeaders); err != nil {
+			fmt.Println("Error executing template:", err.Error())
+		}
+	} else {
+		fmt.Println("No Users found")
+	}
+}
+
+// GetUserInfo returns a information about a specific user in the micro integrator in a given environment
+func GetUserInfo(env, userID string) (*artifactutils.UserSummary, error) {
+
+	var userInfoResource = utils.MiManagementUserResource + "/" + userID
+
+	resp, err := callMIManagementEndpointOfResource(userInfoResource, nil, env, &artifactutils.UserSummary{})
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*artifactutils.UserSummary), nil
+}
+
+// PrintUserDetails prints details about a mi user according to the given format
+func PrintUserDetails(userInfo *artifactutils.UserSummary, format string) {
+
+	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
+		format = defaultUserDetailedFormat
+	}
+
+	userInfoContext := formatter.NewContext(os.Stdout, format)
+	renderer := getItemRendererEndsWithNewLine(userInfo)
+
+	if err := userInfoContext.Write(renderer, nil); err != nil {
+		fmt.Println("Error executing template:", err.Error())
+	}
+}

--- a/import-export-cli/mi/impl/getUsers.go
+++ b/import-export-cli/mi/impl/getUsers.go
@@ -43,13 +43,11 @@ const (
 
 // GetUserList returns a list of users in the micro integrator in a given environment
 func GetUserList(env, role, pattern string) (*artifactutils.UserList, error) {
-
 	params := make(map[string]string)
 	putNonEmptyValueToMap(params, "role", role)
 	putNonEmptyValueToMap(params, "pattern", pattern)
 
 	resp, err := callMIManagementEndpointOfResource(utils.MiManagementUserResource, params, env, &artifactutils.UserList{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -58,11 +56,8 @@ func GetUserList(env, role, pattern string) (*artifactutils.UserList, error) {
 
 // PrintUserList print a list of mi users according to the given format
 func PrintUserList(userList *artifactutils.UserList, format string) {
-
 	if userList.Count > 0 {
-
 		users := userList.Users
-
 		userListContext := getContextWithFormat(format, defaultUserListTableFormat)
 
 		renderer := func(w io.Writer, t *template.Template) error {
@@ -74,11 +69,9 @@ func PrintUserList(userList *artifactutils.UserList, format string) {
 			}
 			return nil
 		}
-
 		userListTableHeaders := map[string]string{
 			"UserId": userIDHeader,
 		}
-
 		if err := userListContext.Write(renderer, userListTableHeaders); err != nil {
 			fmt.Println("Error executing template:", err.Error())
 		}
@@ -89,7 +82,6 @@ func PrintUserList(userList *artifactutils.UserList, format string) {
 
 // GetUserInfo returns a information about a specific user in the micro integrator in a given environment
 func GetUserInfo(env, userID string) (*artifactutils.UserSummary, error) {
-
 	var userInfoResource = utils.MiManagementUserResource + "/" + userID
 
 	resp, err := callMIManagementEndpointOfResource(userInfoResource, nil, env, &artifactutils.UserSummary{})
@@ -101,7 +93,6 @@ func GetUserInfo(env, userID string) (*artifactutils.UserSummary, error) {
 
 // PrintUserDetails prints details about a mi user according to the given format
 func PrintUserDetails(userInfo *artifactutils.UserSummary, format string) {
-
 	if format == "" || strings.HasPrefix(format, formatter.TableFormatKey) {
 		format = defaultUserDetailedFormat
 	}

--- a/import-export-cli/mi/utils/artifactutils/apiUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/apiUtils.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type IntegrationAPI struct {
+	Name      string     `json:"name"`
+	Url       string     `json:"url"`
+	Version   string     `json:"version"`
+	Stats     string     `json:"stats"`
+	Tracing   string     `json:"tracing"`
+	Resources []Resource `json:"resources"`
+}
+
+type Resource struct {
+	Methods []string `json:"methods"`
+	Url     string   `json:"url"`
+}
+
+type IntegrationAPIList struct {
+	Count int32                   `json:"count"`
+	Apis  []IntegrationAPISummary `json:"list"`
+}
+
+type IntegrationAPISummary struct {
+	Name string `json:"name"`
+	Url  string `json:"url"`
+}

--- a/import-export-cli/mi/utils/artifactutils/compositeAppUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/compositeAppUtils.go
@@ -1,0 +1,40 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type CompositeAppList struct {
+	Count         int32                 `json:"count"`
+	CompositeApps []CompositeAppSummary `json:"list"`
+}
+
+type CompositeAppSummary struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type CompositeApp struct {
+	Name      string     `json:"name"`
+	Version   string     `json:"version"`
+	Artifacts []Artifact `json:"artifacts"`
+}
+
+type Artifact struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}

--- a/import-export-cli/mi/utils/artifactutils/connectorUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/connectorUtils.go
@@ -1,0 +1,31 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type ConnectorList struct {
+	Count      int32              `json:"count"`
+	Connectors []ConnectorSummary `json:"list"`
+}
+
+type ConnectorSummary struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Package     string `json:"package"`
+	Description string `json:"description"`
+}

--- a/import-export-cli/mi/utils/artifactutils/dataServiceUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/dataServiceUtils.go
@@ -1,0 +1,44 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type DataServicesList struct {
+	Count int32                `json:"count"`
+	List  []DataServiceSummary `json:"list"`
+}
+
+type DataServiceInfo struct {
+	ServiceName        string         `json:"serviceName"`
+	ServiceDescription string         `json:"serviceDescription"`
+	ServiceGroupName   string         `json:"serviceGroupName"`
+	Wsdl11             string         `json:"wsdl1_1"`
+	Wsdl20             string         `json:"wsdl2_0"`
+	Queries            []QuerySummary `json:"queries"`
+}
+
+type DataServiceSummary struct {
+	ServiceName string `json:"name"`
+	Wsdl11      string `json:"wsdl1_1"`
+	Wsdl20      string `json:"wsdl2_0"`
+}
+
+type QuerySummary struct {
+	Id        string `json:"id"`
+	Namespace string `json:"namespace"`
+}

--- a/import-export-cli/mi/utils/artifactutils/endpointUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/endpointUtils.go
@@ -1,0 +1,44 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type EndpointList struct {
+	Count     int32             `json:"count"`
+	Endpoints []EndpointSummary `json:"list"`
+}
+
+type EndpointSummary struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Active bool   `json:"isActive"`
+}
+
+type Endpoint struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Active      bool   `json:"isActive"`
+	Method      string `json:"method"`
+	Url         string `json:"url"`
+	Stats       string `json:"stats"`
+	Address     string `json:"address"`
+	URITemplate string `json:"uriTemplate"`
+	ServiceName string `json:"serviceName"`
+	PortName    string `json:"portName"`
+	WsdlURI     string `json:"wsdlUri"`
+}

--- a/import-export-cli/mi/utils/artifactutils/inboundEndpointUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/inboundEndpointUtils.go
@@ -1,0 +1,42 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type InboundEndpointList struct {
+	Count            int32                    `json:"count"`
+	InboundEndpoints []InboundEndpointSummary `json:"list"`
+}
+
+type InboundEndpointSummary struct {
+	Name string `json:"name"`
+	Type string `json:"protocol"`
+}
+
+type InboundEndpoint struct {
+	Name       string      `json:"name"`
+	Type       string      `json:"protocol"`
+	Stats      string      `json:"stats"`
+	Tracing    string      `json:"tracing"`
+	Parameters []Parameter `json:"parameters"`
+}
+
+type Parameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/import-export-cli/mi/utils/artifactutils/localEntryUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/localEntryUtils.go
@@ -1,0 +1,35 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type LocalEntryList struct {
+	Count        int32        `json:"count"`
+	LocalEntries []LocalEntry `json:"list"`
+}
+
+type LocalEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type LocalEntryData struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}

--- a/import-export-cli/mi/utils/artifactutils/logFileUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/logFileUtils.go
@@ -1,0 +1,29 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type LogFileList struct {
+	Count    int32     `json:"count"`
+	LogFiles []LogFile `json:"list"`
+}
+
+type LogFile struct {
+	FileName string `json:"FileName"`
+	Size     string `json:"size"`
+}

--- a/import-export-cli/mi/utils/artifactutils/loggerUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/loggerUtils.go
@@ -1,0 +1,25 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type Logger struct {
+	LoggerName    string `json:"loggerName"`
+	ComponentName string `json:"componentName"`
+	LogLevel      string `json:"level"`
+}

--- a/import-export-cli/mi/utils/artifactutils/messageProcessorUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/messageProcessorUtils.go
@@ -1,0 +1,40 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type MessageProcessorList struct {
+	Count             int32              `json:"count"`
+	MessageProcessors []MessageProcessor `json:"list"`
+}
+
+type MessageProcessor struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+type MessageProcessorData struct {
+	Name       string            `json:"name"`
+	FileName   string            `json:"fileName"`
+	Type       string            `json:"type"`
+	Store      string            `json:"messageStore"`
+	Container  string            `json:"artifactContainer"`
+	Parameters map[string]string `json:"parameters"`
+	Status     string            `json:"status"`
+}

--- a/import-export-cli/mi/utils/artifactutils/messageStoreUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/messageStoreUtils.go
@@ -1,0 +1,40 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type MessageStoreList struct {
+	Count         int32          `json:"count"`
+	MessageStores []MessageStore `json:"list"`
+}
+
+type MessageStore struct {
+	Name string `json:"name"`
+	Size int    `json:"size"`
+	Type string `json:"type"`
+}
+
+type MessageStoreData struct {
+	Name       string            `json:"name"`
+	FileName   string            `json:"file"`
+	Container  string            `json:"container"`
+	Properties map[string]string `json:"properties"`
+	Producer   string            `json:"producer"`
+	Consumer   string            `json:"consumer"`
+	Size       int               `json:"size"`
+}

--- a/import-export-cli/mi/utils/artifactutils/proxyServiceUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/proxyServiceUtils.go
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type Proxy struct {
+	Name    string `json:"name"`
+	Wsdl11  string `json:"wsdl1_1"`
+	Wsdl20  string `json:"wsdl2_0"`
+	Stats   string `json:"stats"`
+	Tracing string `json:"tracing"`
+}
+
+type ProxyServiceList struct {
+	Count   int32          `json:"count"`
+	Proxies []ProxySummary `json:"list"`
+}
+
+type ProxySummary struct {
+	Name   string `json:"name"`
+	Wsdl11 string `json:"wsdl1_1"`
+	Wsdl20 string `json:"wsdl2_0"`
+}

--- a/import-export-cli/mi/utils/artifactutils/sequenceUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/sequenceUtils.go
@@ -1,0 +1,39 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type SequenceList struct {
+	Count     int32             `json:"count"`
+	Sequences []SequenceSummary `json:"list"`
+}
+
+type SequenceSummary struct {
+	Name      string `json:"name"`
+	Container string `json:"container"`
+	Stats     string `json:"stats"`
+	Tracing   string `json:"tracing"`
+}
+
+type Sequence struct {
+	Name      string   `json:"name"`
+	Container string   `json:"container"`
+	Stats     string   `json:"stats"`
+	Tracing   string   `json:"tracing"`
+	Mediators []string `json:"mediators"`
+}

--- a/import-export-cli/mi/utils/artifactutils/taskUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/taskUtils.go
@@ -1,0 +1,32 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type TaskList struct {
+	Count int32  `json:"count"`
+	Tasks []Task `json:"list"`
+}
+
+type Task struct {
+	Name            string `json:"name"`
+	Type            string `json:"triggerType"`
+	TriggerCount    string `json:"triggerCount"`
+	TriggerInterval string `json:"triggerInterval"`
+	TriggerCron     string `json:"cronExpression"`
+}

--- a/import-export-cli/mi/utils/artifactutils/templateUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/templateUtils.go
@@ -1,0 +1,49 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type TemplateList struct {
+	SequenceTemplates []Template `json:"sequenceTemplateList"`
+	EndpointTemplates []Template `json:"endpointTemplateList"`
+}
+
+type TemplateListByType struct {
+	Count     int32      `json:"count"`
+	Templates []Template `json:"list"`
+}
+
+type TemplateSequenceListByName struct {
+	Parameters []TemplateSequenceDetail `json:"Parameters"`
+	Name       string                   `json:"name"`
+}
+
+type TemplateEndpointListByName struct {
+	Parameters []string `json:"Parameters"`
+	Name       string   `json:"name"`
+}
+
+type Template struct {
+	Name string `json:"name"`
+}
+
+type TemplateSequenceDetail struct {
+	Name         string `json:"name"`
+	IsMandatory  bool   `json:"mandatory"`
+	DefaultValue string `json:"defaultValue"`
+}

--- a/import-export-cli/mi/utils/artifactutils/transactionUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/transactionUtils.go
@@ -1,0 +1,29 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type TransactionCount struct {
+	Year             int   `json:"Year"`
+	Month            int   `json:"Month"`
+	TransactionCount int64 `json:"TransactionCount"`
+}
+
+type TransactionCountInfo struct {
+	TransactionCounts [][]string `json:"TransactionCountData"`
+}

--- a/import-export-cli/mi/utils/artifactutils/userUtils.go
+++ b/import-export-cli/mi/utils/artifactutils/userUtils.go
@@ -1,0 +1,34 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package artifactutils
+
+type UserList struct {
+	Count int32  `json:"count"`
+	Users []User `json:"list"`
+}
+
+type UserSummary struct {
+	Roles   []string `json:"roles"`
+	IsAdmin bool     `json:"isAdmin"`
+	UserId  string   `json:"userId"`
+}
+
+type User struct {
+	UserId string `json:"userId"`
+}

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -436,3 +436,249 @@
 </code></pre>
     </li>
 </ul>
+<ul>
+    <li>
+        <h4 id="login">mi login [environment]</h4>
+        <pre><code class="lang-bash">   Flags:
+       Optional:
+           --username, -u
+           --password, -p
+           NOTE: user will be prompted to enter credentials if they are not provided with these flags
+   Examples:
+       apictl mi login dev -u admin -p admin
+       apictl mi login dev -u admin
+       apictl mi login dev
+       cat ~/.mypassword | apictl mi login dev -u admin
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="logout">mi logout [environment]</h4>
+        <pre><code class="lang-bash">   Examples:
+       apictl mi logout dev
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="get-apis">mi get apis [api-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get apis -e dev
+          apictl mi get apis SampleAPI -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-composite-apps">mi get composite-apps [app-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get composite-apps -e dev
+          apictl mi get composite-apps SampleApp -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-connectors">mi get connectors</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get connectors -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-data-services">mi get data-services [dataservice-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get data-services -e dev
+          apictl mi get data-services SampleDataService -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-endpoints">mi get endpoints [endpoint-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get endpoints -e dev
+          apictl mi get endpoints SampleEndpoint -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-inbound-endpoints">mi get inbound-endpoints [inbound-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get inbound-endpoints -e dev
+          apictl mi get inbound-endpoints SampleInboundEndpoint -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-local-entries">mi get local-entries [localentry-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get local-entries -e dev
+          apictl mi get local-entries SampleLocalEntry -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-log-levels">mi get log-levels [logger-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get log-levels org-apache-coyote -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-logs">mi get logs [file-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+              --path, -p
+      Examples:
+          apictl mi get logs -e dev
+          apictl mi get logs wso2error.log -p ./logs -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-message-processors">mi get message-processors [messageprocessor-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get message-processors -e dev
+          apictl mi get message-processors TestMessageProcessor -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-message-stores">mi get message-stores [messagestore-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get message-stores -e dev
+          apictl mi get message-stores TestMessageStore -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-proxy-services">mi get proxy-services [proxy-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get proxy-services -e dev
+          apictl mi get proxy-services SampleProxy -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-sequences">mi get sequences [sequence-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get sequences -e dev
+          apictl mi get sequences SampleSequence -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-tasks">mi get tasks [task-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get tasks -e dev
+          apictl mi get tasks SampleTask -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-templates">mi get templates [template-type] [template-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get templates -e dev
+          apictl mi get templates endpoint -e dev
+          apictl mi get templates endpoint SampleEPTemplate -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-transaction-counts">mi get transaction-counts [year] [month]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+      Examples:
+          apictl mi get transaction-counts -e dev
+          apictl mi get transaction-counts 2020 06 -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-transaction-reports">mi get transaction-reports [start] [end]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+              --path, -p
+      Examples:
+          apictl mi get transaction-reports 2020-01 2020-05 -e dev
+          apictl mi get transaction-reports 2020-05 2020-06 --path ./reports -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="get-users">mi get users [user-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+          Optional:
+              --format
+              --role, -r
+              --pattern, -p
+      Examples:
+          apictl mi get users -e dev
+          apictl mi get users -r admin -e dev
+          apictl mi get users -p mi -e dev
+</code></pre>
+    </li>
+</ul>

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -2689,6 +2689,798 @@ _apictl_mg()
     noun_aliases=()
 }
 
+_apictl_mi_get_apis()
+{
+    last_command="apictl_mi_get_apis"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_composite-apps()
+{
+    last_command="apictl_mi_get_composite-apps"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_connectors()
+{
+    last_command="apictl_mi_get_connectors"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_data-services()
+{
+    last_command="apictl_mi_get_data-services"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_endpoints()
+{
+    last_command="apictl_mi_get_endpoints"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_help()
+{
+    last_command="apictl_mi_get_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_get_inbound-endpoints()
+{
+    last_command="apictl_mi_get_inbound-endpoints"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_local-entries()
+{
+    last_command="apictl_mi_get_local-entries"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_log-levels()
+{
+    last_command="apictl_mi_get_log-levels"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_logs()
+{
+    last_command="apictl_mi_get_logs"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--path=")
+    two_word_flags+=("--path")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--path")
+    local_nonpersistent_flags+=("--path=")
+    local_nonpersistent_flags+=("-p")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_message-processors()
+{
+    last_command="apictl_mi_get_message-processors"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_message-stores()
+{
+    last_command="apictl_mi_get_message-stores"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_proxy-services()
+{
+    last_command="apictl_mi_get_proxy-services"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_sequences()
+{
+    last_command="apictl_mi_get_sequences"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_tasks()
+{
+    last_command="apictl_mi_get_tasks"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_templates()
+{
+    last_command="apictl_mi_get_templates"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_transaction-counts()
+{
+    last_command="apictl_mi_get_transaction-counts"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_transaction-reports()
+{
+    last_command="apictl_mi_get_transaction-reports"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--path=")
+    two_word_flags+=("--path")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--path")
+    local_nonpersistent_flags+=("--path=")
+    local_nonpersistent_flags+=("-p")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get_users()
+{
+    last_command="apictl_mi_get_users"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--pattern=")
+    two_word_flags+=("--pattern")
+    two_word_flags+=("-p")
+    local_nonpersistent_flags+=("--pattern")
+    local_nonpersistent_flags+=("--pattern=")
+    local_nonpersistent_flags+=("-p")
+    flags+=("--role=")
+    two_word_flags+=("--role")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--role")
+    local_nonpersistent_flags+=("--role=")
+    local_nonpersistent_flags+=("-r")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_get()
+{
+    last_command="apictl_mi_get"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("apis")
+    commands+=("composite-apps")
+    commands+=("connectors")
+    commands+=("data-services")
+    commands+=("endpoints")
+    commands+=("help")
+    commands+=("inbound-endpoints")
+    commands+=("local-entries")
+    commands+=("log-levels")
+    commands+=("logs")
+    commands+=("message-processors")
+    commands+=("message-stores")
+    commands+=("proxy-services")
+    commands+=("sequences")
+    commands+=("tasks")
+    commands+=("templates")
+    commands+=("transaction-counts")
+    commands+=("transaction-reports")
+    commands+=("users")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_mi_help()
 {
     last_command="apictl_mi_help"
@@ -2788,6 +3580,7 @@ _apictl_mi()
     command_aliases=()
 
     commands=()
+    commands+=("get")
     commands+=("help")
     commands+=("login")
     commands+=("logout")

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -209,5 +209,7 @@ const MiManagementMiLoginResource = "login"
 const MiManagementMiLogoutResource = "logout"
 const MiManagementUserResource = "users"
 const MiManagementTransactionResource = "transactions"
+const MiManagementTransactionCountResource = "count"
+const MiManagementTransactionReportResource = "report"
 
 const ZipFileSuffix = ".zip"

--- a/import-export-cli/utils/fileIOUtils.go
+++ b/import-export-cli/utils/fileIOUtils.go
@@ -19,6 +19,7 @@
 package utils
 
 import (
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
@@ -306,7 +307,7 @@ func CopyDir(src string, dst string) (err error) {
 
 // CopyDirectoryContents recursively copies all the content of a directory, attempting to preserve permissions.
 // Source directory must exist,and the destination directory exist.
-func CopyDirectoryContents (src string, dst string) (err error)  {
+func CopyDirectoryContents(src string, dst string) (err error) {
 	entries, err := ioutil.ReadDir(src)
 	if err != nil {
 		return
@@ -337,7 +338,7 @@ func CopyDirectoryContents (src string, dst string) (err error)  {
 // @param src source directory path
 // @param dst destiny directory path
 // @return error
-func MoveDirectoryContentsToNewDirectory(src string, dst string) (err error)  {
+func MoveDirectoryContentsToNewDirectory(src string, dst string) (err error) {
 	entries, err := ioutil.ReadDir(src)
 	if err != nil {
 		return
@@ -537,4 +538,34 @@ func CreateZipFile(filePath string, skipCleanup bool) (error, func()) {
 		return nil, cleanup
 	}
 	return nil, nil
+}
+
+// WriteLinesToCSVFile write the content of a 2D array as csv values to a file at the target path.
+func WriteLinesToCSVFile(lines [][]string, targetPath string) error {
+	if _, err := os.Stat(filepath.Dir(targetPath)); os.IsNotExist(err) {
+		return err
+	}
+
+	file, err := os.Create(targetPath)
+	if err != nil {
+		return errors.New("Could not create the file " + targetPath + ". " + err.Error())
+	}
+
+	defer func() error {
+		if e := file.Close(); e != nil {
+			return e
+		}
+		return nil
+	}()
+
+	csvWriter := csv.NewWriter(file)
+	defer csvWriter.Flush()
+
+	for _, line := range lines {
+		err := csvWriter.Write(line)
+		if err != nil {
+			return errors.New("Could not write to file " + targetPath + ". " + err.Error())
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Purpose
Update MI CLI tool and merge with APICTL
wso2/micro-integrator#1999

## Goals
- Add a new get command under mi alias to retrieve details about artifacts deployed in MI instances

## Approach
- Created a new package called get inside the mi package
- Add the necessary sub-commands inside that get package
- Created a new root level package called mi
- Add all the implementation related to retrieving and printing of artifacts inside a sub package called impl inside that mi package

## User stories
Following are the new commands introduced by this PR to retrieve details about artifacts deployed in MI instances.

| Command                           | Details                                                         |
|-----------------------------------|-----------------------------------------------------------------|
| apictl mi get apis                | Get information about apis                                      |
| apictl mi get composite-apps      | Get information about composite apps                            |
| apictl mi get connectors          | Get information about connectors                                |
| apictl mi get data-services       | Get information about data services                             |
| apictl mi get endpoints           | Get information about endpoints                                 |
| apictl mi get inbound-endpoints   | Get information about inbound endpoints                         |
| apictl mi get local-entries       | Get information about local entries                             |
| apictl mi get log-levels          | Get information about a Logger configured in a Micro Integrator |
| apictl mi get logs                | List all the available log files                                |
| apictl mi get message-processors  | Get information about message processors                        |
| apictl mi get message-stores      | Get information about message stores                            |
| apictl mi get proxy-services      | Get information about proxy services                            |
| apictl mi get sequences           | Get information about sequences                                 |
| apictl mi get tasks               | Get information about tasks                                     |
| apictl mi get templates           | Get information about templates                                 |
| apictl mi get transaction-counts  | Retrieve transaction count                                      |
| apictl mi get transaction-reports | Generate transaction count summary report                       |
| apictl mi get users               | Get information about users                                     |

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64