### PR TITLE
[2.x] Support endpoint security parameters and subscription policies from api_params.yaml

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -233,6 +233,12 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		return err
 	}
 
+	// Handle available subscription policies in api_params.yaml
+	err = handleSubscriptionPolicies(environmentParams.Policies, api)
+	if err != nil {
+		return err
+	}
+
 	apiPath = filepath.Join(apiDirectory, "Meta-information", "api.yaml")
 	utils.Logln(utils.LogPrefixInfo+"Writing merged API to:", apiPath)
 	// write this to disk
@@ -243,6 +249,31 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	err = ioutil.WriteFile(apiPath, content, 0644)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// Handle available subscription policies in api_params.yaml
+// @param envPolicies : Available subscription policies from api_params.yaml in the environment
+// @param api : Parameters from api.yaml
+// @return error
+func handleSubscriptionPolicies(envPolicies []string, api *gabs.Container) error {
+	if envPolicies != nil {
+		var availableTiers []v2.AvailableTiers
+		// Iterate the specified policies array
+		for _, tierName := range envPolicies {
+			if tierName != "" {
+				availableTiers = append(availableTiers, v2.AvailableTiers{Name: tierName})
+			}
+		}
+		// If the available tiers are not defined in api_params.yaml, the values in the api.yaml should be considered.
+		// Hence, this if statment will prevent setting the availableTiers in api.yaml to an empty array if the policies
+		// are not properly defined in the api_params.yaml
+		if availableTiers != nil {
+			if _, err := api.SetP(availableTiers, "availableTiers"); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -227,6 +227,12 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 		}
 	}
 
+	// Handle security parameters in api_params.yaml
+	err = handleSecurityEndpointsParams(environmentParams.Security, api)
+	if err != nil {
+		return err
+	}
+
 	apiPath = filepath.Join(apiDirectory, "Meta-information", "api.yaml")
 	utils.Logln(utils.LogPrefixInfo+"Writing merged API to:", apiPath)
 	// write this to disk
@@ -237,6 +243,98 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 	err = ioutil.WriteFile(apiPath, content, 0644)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// Handle security parameters in api_params.yaml
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
+// @param api : Parameters from api.yaml
+// @return error
+func handleSecurityEndpointsParams(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// If the user has set (either true or false) the enabled field under security in api_params.yaml, the
+	// following code should be executed. (if not set, the security endpoint settings will be made
+	// according to the api.yaml file as usually)
+	// In Go, irrespective of whether a boolean value is "" or false, it will contain false by default.
+	// That is why, here a string comparison was  made since strings can have both "" and "false"
+	if envSecurityEndpointParams.Enabled != "" {
+		// Convert the string enabled to boolean
+		boolEnabled, err := strconv.ParseBool(envSecurityEndpointParams.Enabled)
+		if err != nil {
+			return err
+		}
+		if _, err := api.SetP(boolEnabled, "endpointSecured"); err != nil {
+			return err
+		}
+		// If endpoint security is enabled
+		if boolEnabled {
+			// Set the security endpoint parameters when the enabled field is set to true
+			err := setSecurityEndpointsParams(envSecurityEndpointParams, api)
+			if err != nil {
+				return err
+			}
+		} else {
+			// If endpoint security is not enabled, the username and password should be empty.
+			// (otherwise the security will be enabled after importing the API, considering there are values
+			// for username and passwords)
+			if _, err := api.SetP("", "endpointUTUsername"); err != nil {
+				return err
+			}
+			if _, err := api.SetP("", "endpointUTPassword"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Set the security endpoint parameters when the enabled field is set to true
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
+// @param api : Parameters from api.yaml
+// @return error
+func setSecurityEndpointsParams(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// Check whether the username, password and type fields have set in api_params.yaml
+	if envSecurityEndpointParams.Username == "" {
+		return errors.New("You have enabled endpoint security but the username is not found in the api_params.yaml")
+	} else if envSecurityEndpointParams.Password == "" {
+		return errors.New("You have enabled endpoint security but the password is not found in the api_params.yaml")
+	} else if envSecurityEndpointParams.Type == "" {
+		return errors.New("You have enabled endpoint security but the type is not found in the api_params.yaml")
+	} else {
+		// Override the username in api.yaml with the value in api_params.yaml
+		if _, err := api.SetP(envSecurityEndpointParams.Username, "endpointUTUsername"); err != nil {
+			return err
+		}
+		// Override the password in api.yaml with the value in api_params.yaml
+		if _, err := api.SetP(envSecurityEndpointParams.Password, "endpointUTPassword"); err != nil {
+			return err
+		}
+		// Set the fields in api.yaml according to the type field in api_params.yaml
+		err := setEndpointSecurityType(envSecurityEndpointParams, api)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set the fields in api.yaml according to the type field in api_params.yaml
+// @param envSecurityEndpointParams : Environment security endpoint parameters from api_params.yaml
+// @param api : Parameters from api.yaml
+// @return error
+func setEndpointSecurityType(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
+	// Check whether the type is either basic or digest
+	if envSecurityEndpointParams.Type == "digest" {
+		if _, err := api.SetP(true, "endpointAuthDigest"); err != nil {
+			return err
+		}
+	} else if envSecurityEndpointParams.Type == "basic" {
+		if _, err := api.SetP(false, "endpointAuthDigest"); err != nil {
+			return err
+		}
+	} else {
+		// If the type is not either basic or digest, return an error
+		return errors.New("Invalid endpoint security type found in the api_params.yaml. Should be either basic or digest")
 	}
 	return nil
 }
@@ -745,7 +843,7 @@ func NewFileUploadRequest(uri string, method string, params map[string]string, p
 	// Set headers
 	headers := make(map[string]string)
 	headers[utils.HeaderContentType] = writer.FormDataContentType()
-	headers[utils.HeaderAuthorization] =  utils.HeaderValueAuthBasicPrefix+" "+b64encodedCredentials
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
 	headers[utils.HeaderAccept] = "*/*"
 	headers[utils.HeaderConnection] = utils.HeaderValueKeepAlive
 

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -253,11 +253,10 @@ func mergeAPI(apiDirectory string, environmentParams *params.Environment) error 
 // @return error
 func handleSecurityEndpointsParams(envSecurityEndpointParams *params.SecurityData, api *gabs.Container) error {
 	// If the user has set (either true or false) the enabled field under security in api_params.yaml, the
-	// following code should be executed. (if not set, the security endpoint settings will be made
 	// according to the api.yaml file as usually)
 	// In Go, irrespective of whether a boolean value is "" or false, it will contain false by default.
 	// That is why, here a string comparison was  made since strings can have both "" and "false"
-	if envSecurityEndpointParams.Enabled != "" {
+	if envSecurityEndpointParams != nil && envSecurityEndpointParams.Enabled != "" {
 		// Convert the string enabled to boolean
 		boolEnabled, err := strconv.ParseBool(envSecurityEndpointParams.Enabled)
 		if err != nil {

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -80,6 +80,18 @@ type FailoverEndpointsData struct {
 	Failover bool `yaml:"failOver" json:"failOver,omitempty"`
 }
 
+// SecurityData contains the details about endpoint security from api_params.yaml
+type SecurityData struct {
+	// Decides whether the endpoint security is enabled
+	Enabled string `yaml:"enabled" json:"enabled,omitempty"`
+	// Type of the endpoint security (can be Basic or Digest)
+	Type string `yaml:"type" json:"type,omitempty"`
+	// Username for the endpoint
+	Username string `yaml:"username" json:"username,omitempty"`
+	// Password for the endpoint
+	Password string `yaml:"password" json:"password,omitempty"`
+}
+
 // Cert stores certificate details
 type Cert struct {
 	// Host of the certificate
@@ -126,6 +138,8 @@ type Environment struct {
 	LoadBalanceEndpoints *LoadBalanceEndpointsData `yaml:"loadBalanceEndpoints"`
 	// FailoverEndpoints contain details about endpoints in a configuration for failover scenarios
 	FailoverEndpoints *FailoverEndpointsData `yaml:"failoverEndpoints"`
+	// Security contains the details about endpoint security
+	Security *SecurityData `yaml:"security"`
 	// GatewayEnvironments contains environments that used to deploy API
 	GatewayEnvironments []string `yaml:"gatewayEnvironments"`
 	// Certs for environment

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -145,6 +145,8 @@ type Environment struct {
 	// Certs for environment
 	Certs          []Cert          `yaml:"certs"`
 	MutualSslCerts []MutualSslCert `yaml:"mutualSslCerts"`
+	// Policies contains the available subscription policies in an environment that can be enforced to an API
+	Policies []string `yaml:"policies"`
 }
 
 // ApiParams represents environments defined in configuration file


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/162
Fixes: https://github.com/wso2/product-apim-tooling/issues/564

## Goals
Enhance the current capability of defining endpoint security parameters and subscription tiers (of an API) in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.
(Backporting https://github.com/wso2/product-apim-tooling/pull/237 and adding a new feature to change the policies from api_params.yaml)

## Approach
This procedure modified the template of api_params.yaml as shown in the below example. 
 - A new field has been added as *security* to the api_params.yaml to define the endpoint security. The fields enabled, username, password and type have been included in it for a particular environment.
 - Another field was added as **policies** which is an array that conists the subscription tier names for an API in an environment.
```
environments:
  - name: test
    endpoints:
     production:
       url: 'http://dev.doo.com'
       config:
         retryTimeOut: 60
         retryDelay: 70
         factor: 2
     sandbox:
        url: 'http://test.foo.sandbox.com'
    security:
        enabled: true
        type: basic ( or digest )
        username: admin
        password: admin
    policies:
        - Gold
        - Silver
```
- After importing, the endpoint security will be displayed in the **Implement** tab of an API as follows.
  ![image](https://user-images.githubusercontent.com/25246848/103530517-98839100-4ead-11eb-8107-8bf7ab1b86cf.png)
- After importing, the subscription polcieis will be displayed in the **Manage** tab of an API as follows.
  ![image](https://user-images.githubusercontent.com/25246848/103530605-bb15aa00-4ead-11eb-8682-5063ee4dfb14.png)

## User stories
- If endpoint security parameters are set in api_params.yaml file, override the values in api.yaml file.
- If endpoint security parameters are not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)
- If policies parameter is set in api_params.yaml file, override the values in api.yaml file.
- If policies parameter is not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)

## Release note
Enhance the current capability of defining endpoint security parameters in api.yaml file by providing the capability to override them using api_params.yaml file, if the user wants.

## Documentation
Documentation changes should be done. 

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64