### PR TITLE
Add commands to add, update and delete users and loggers in MI instances

### DIFF
--- a/import-export-cli/cmd/mi/add/add.go
+++ b/import-export-cli/cmd/mi/add/add.go
@@ -1,0 +1,48 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package add
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const addCmdLiteral = "add"
+const addCmdShortDesc = "Add new users or loggers to a Micro Integrator instance"
+
+const addCmdLongDesc = "Add new users or loggers to a Micro Integrator instance in the environment specified by the flag (--environment, -e)"
+
+const addCmdExamples = utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " " + "user" + " capp-developer -e dev\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " " + "log-level" + " synapse-api org.apache.synapse.rest.API DEBUG -e dev"
+
+// AddCmd represents the add command
+var AddCmd = &cobra.Command{
+	Use:     addCmdLiteral,
+	Short:   addCmdShortDesc,
+	Long:    addCmdLongDesc,
+	Example: addCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + addCmdLiteral + " called")
+		cmd.Help()
+	},
+}
+
+func printAddCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + addCmdLiteral + " " + cmd + " called")
+}

--- a/import-export-cli/cmd/mi/add/logLevel.go
+++ b/import-export-cli/cmd/mi/add/logLevel.go
@@ -1,0 +1,71 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package add
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var addLogLevelCmdEnvironment string
+
+const addLogLevelCmdLiteral = "log-level [logger-name] [class-name] [log-level]"
+const addLogLevelCmdShortDesc = "Add new Logger to a Micro Integrator"
+
+const addLogLevelCmdLongDesc = "Add new Logger named [logger-name] to the [class-name] with log level [log-level] specified by the command line arguments to a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var addLogLevelCmdExamples = "To add a new logger\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " log-level synapse-api org.apache.synapse.rest.API DEBUG -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var addLogLevelCmd = &cobra.Command{
+	Use:     addLogLevelCmdLiteral,
+	Short:   addLogLevelCmdShortDesc,
+	Long:    addLogLevelCmdLongDesc,
+	Example: addLogLevelCmdExamples,
+	Args:    cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleAddLogLevelCmdArguments(args)
+	},
+}
+
+func init() {
+	AddCmd.AddCommand(addLogLevelCmd)
+	addLogLevelCmd.Flags().StringVarP(&addLogLevelCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	addLogLevelCmd.MarkFlagRequired("environment")
+}
+
+func handleAddLogLevelCmdArguments(args []string) {
+	printAddCmdVerboseLog("log-level")
+	credentials.HandleMissingCredentials(addLogLevelCmdEnvironment)
+	executeAddNewLogger(args[0], args[1], args[2])
+}
+
+func executeAddNewLogger(loggerName, logClass, logLevel string) {
+	resp, err := impl.AddMILogger(addLogLevelCmdEnvironment, loggerName, logClass, logLevel)
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"Adding new logger [ "+loggerName+" ] ", err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/add/user.go
+++ b/import-export-cli/cmd/mi/add/user.go
@@ -1,0 +1,98 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package add
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var addUserCmdEnvironment string
+
+const addUserCmdLiteral = "user [user-name]"
+const addUserCmdShortDesc = "Add new user to a Micro Integrator"
+
+const addUserCmdLongDesc = "Add a new user with the name specified by the command line argument [user-name] to a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var addUserCmdExamples = "To add a new user\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " user capp-tester -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var addUserCmd = &cobra.Command{
+	Use:     addUserCmdLiteral,
+	Short:   addUserCmdShortDesc,
+	Long:    addUserCmdLongDesc,
+	Example: addUserCmdExamples,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleAddUserCmdArguments(args)
+	},
+}
+
+func init() {
+	AddCmd.AddCommand(addUserCmd)
+	addUserCmd.Flags().StringVarP(&addUserCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	addUserCmd.MarkFlagRequired("environment")
+}
+
+func handleAddUserCmdArguments(args []string) {
+	printAddCmdVerboseLog("user")
+	credentials.HandleMissingCredentials(addUserCmdEnvironment)
+	startConsoleToAddUser(args[0])
+}
+
+func startConsoleToAddUser(userName string) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf("Is " + userName + " an admin [y/N]: ")
+	isAdmin, _ := reader.ReadString('\n')
+
+	fmt.Printf("Enter password for " + userName + ": ")
+	byteUserPassword, _ := terminal.ReadPassword(int(syscall.Stdin))
+	userPassword := string(byteUserPassword)
+	fmt.Println()
+
+	fmt.Printf("Re-Enter password for " + userName + ": ")
+	byteUserConfirmationPassword, _ := terminal.ReadPassword(int(syscall.Stdin))
+	userConfirmPassword := string(byteUserConfirmationPassword)
+	fmt.Println()
+
+	if userConfirmPassword == userPassword {
+		executeAddNewUser(userName, userPassword, isAdmin)
+	} else {
+		fmt.Println("Passwords are not matching.")
+	}
+}
+
+func executeAddNewUser(userName, userPassword, isAdmin string) {
+	resp, err := impl.AddMIUser(addUserCmdEnvironment, userName, userPassword, isAdmin)
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"Adding new user [ "+userName+" ]", err)
+	} else {
+		fmt.Println("Adding new user [ "+userName+" ] status:", resp)
+	}
+}

--- a/import-export-cli/cmd/mi/delete/delete.go
+++ b/import-export-cli/cmd/mi/delete/delete.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package delete
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const deleteCmdLiteral = "delete"
+const deleteCmdShortDesc = "Delete users from a Micro Integrator instance"
+
+const deleteCmdLongDesc = "Delete users from a Micro Integrator instance in the environment specified by the flag (--environment, -e)"
+
+const deleteCmdExamples = utils.ProjectName + " " + utils.MiCmdLiteral + " " + deleteCmdLiteral + " " + "user" + " capp-tester -e dev"
+
+// DeleteCmd represents the delete command
+var DeleteCmd = &cobra.Command{
+	Use:     deleteCmdLiteral,
+	Short:   deleteCmdShortDesc,
+	Long:    deleteCmdLongDesc,
+	Example: deleteCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " called")
+		cmd.Help()
+	},
+}

--- a/import-export-cli/cmd/mi/delete/user.go
+++ b/import-export-cli/cmd/mi/delete/user.go
@@ -1,0 +1,75 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package delete
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var deleteUserCmdEnvironment string
+
+const deleteUserCmdLiteral = "user [user-name]"
+const deleteUserCmdShortDesc = "Delete a user from the Micro Integrator"
+
+const deleteUserCmdLongDesc = "Delete a user with the name specified by the command line argument [user-name] from a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var deleteUserCmdExamples = "To delete a user\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + deleteCmdLiteral + " user capp-tester -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var deleteUserCmd = &cobra.Command{
+	Use:     deleteUserCmdLiteral,
+	Short:   deleteUserCmdShortDesc,
+	Long:    deleteUserCmdLongDesc,
+	Example: deleteUserCmdExamples,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handledeleteUserCmdArguments(args)
+	},
+}
+
+func init() {
+	DeleteCmd.AddCommand(deleteUserCmd)
+	deleteUserCmd.Flags().StringVarP(&deleteUserCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	deleteUserCmd.MarkFlagRequired("environment")
+}
+
+func handledeleteUserCmdArguments(args []string) {
+	printDeleteCmdVerboseLog(deleteUserCmdLiteral)
+	credentials.HandleMissingCredentials(deleteUserCmdEnvironment)
+	executeDeleteUser(args[0])
+}
+
+func executeDeleteUser(userName string) {
+	resp, err := impl.DeleteMIUser(deleteUserCmdEnvironment, userName)
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"deleting user [ "+userName+" ]", err)
+	} else {
+		fmt.Println("Deleting user [ "+userName+" ] status:", resp)
+	}
+}
+
+func printDeleteCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " " + cmd + " called")
+}

--- a/import-export-cli/cmd/mi/mi.go
+++ b/import-export-cli/cmd/mi/mi.go
@@ -20,7 +20,10 @@ package mi
 
 import (
 	"github.com/spf13/cobra"
+	miAddCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/add"
+	miDeleteCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/delete"
 	miGetCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/get"
+	miUpdateCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/update"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -42,4 +45,7 @@ var MICmd = &cobra.Command{
 
 func init() {
 	MICmd.AddCommand(miGetCmd.GetCmd)
+	MICmd.AddCommand(miAddCmd.AddCmd)
+	MICmd.AddCommand(miDeleteCmd.DeleteCmd)
+	MICmd.AddCommand(miUpdateCmd.UpdateCmd)
 }

--- a/import-export-cli/cmd/mi/update/logLevel.go
+++ b/import-export-cli/cmd/mi/update/logLevel.go
@@ -1,0 +1,75 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var updateLogLevelCmdEnvironment string
+
+const updateLogLevelCmdLiteral = "log-level [logger-name] [log-level]"
+const updateLogLevelCmdShortDesc = "Update log level of a Logger in a Micro Integrator"
+
+const updateLogLevelCmdLongDesc = "Update the log level of a Logger named [logger-name] to [log-level] specified by the command line arguments in a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var updateLogLevelCmdExamples = "To update the log level\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + updateCmdLiteral + " log-level org-apache-coyote DEBUG -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var updateLogLevelCmd = &cobra.Command{
+	Use:     updateLogLevelCmdLiteral,
+	Short:   updateLogLevelCmdShortDesc,
+	Long:    updateLogLevelCmdLongDesc,
+	Example: updateLogLevelCmdExamples,
+	Args:    cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleupdateLogLevelCmdArguments(args)
+	},
+}
+
+func init() {
+	UpdateCmd.AddCommand(updateLogLevelCmd)
+	updateLogLevelCmd.Flags().StringVarP(&updateLogLevelCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	updateLogLevelCmd.MarkFlagRequired("environment")
+}
+
+func handleupdateLogLevelCmdArguments(args []string) {
+	printUpdateCmdVerboseLog("log-level")
+	credentials.HandleMissingCredentials(updateLogLevelCmdEnvironment)
+	executeUpdateLogger(args[0], args[1])
+}
+
+func executeUpdateLogger(loggerName, logLevel string) {
+	resp, err := impl.UpdateMILogger(updateLogLevelCmdEnvironment, loggerName, logLevel)
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"updating logger [ "+loggerName+" ] ", err)
+	} else {
+		fmt.Println(resp)
+	}
+}
+
+func printUpdateCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " " + cmd + " called")
+}

--- a/import-export-cli/cmd/mi/update/update.go
+++ b/import-export-cli/cmd/mi/update/update.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package update
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const updateCmdLiteral = "update"
+const updateCmdShortDesc = "Update log level of Loggers in a Micro Integrator instance"
+
+const updateCmdLongDesc = "Update log level of Loggers in a Micro Integrator instance in the environment specified by the flag (--environment, -e)"
+
+const updateCmdExamples = utils.ProjectName + " " + utils.MiCmdLiteral + " " + updateCmdLiteral + " " + "log-level" + " org-apache-coyote DEBUG -e dev"
+
+// UpdateCmd represents the update command
+var UpdateCmd = &cobra.Command{
+	Use:     updateCmdLiteral,
+	Short:   updateCmdShortDesc,
+	Long:    updateCmdLongDesc,
+	Example: updateCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " called")
+		cmd.Help()
+	},
+}

--- a/import-export-cli/docs/apictl_mi.md
+++ b/import-export-cli/docs/apictl_mi.md
@@ -26,7 +26,10 @@ apictl mi [flags]
 ### SEE ALSO
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi add](apictl_mi_add.md)	 - Add new users or loggers to a Micro Integrator instance
+* [apictl mi delete](apictl_mi_delete.md)	 - Delete users from a Micro Integrator instance
 * [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
 * [apictl mi login](apictl_mi_login.md)	 - Login to a Micro Integrator
 * [apictl mi logout](apictl_mi_logout.md)	 - Logout from a Micro Integrator
+* [apictl mi update](apictl_mi_update.md)	 - Update log level of Loggers in a Micro Integrator instance
 

--- a/import-export-cli/docs/apictl_mi_add.md
+++ b/import-export-cli/docs/apictl_mi_add.md
@@ -1,0 +1,38 @@
+## apictl mi add
+
+Add new users or loggers to a Micro Integrator instance
+
+### Synopsis
+
+Add new users or loggers to a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi add [flags]
+```
+
+### Examples
+
+```
+apictl mi add user capp-developer -e dev
+apictl mi add log-level synapse-api org.apache.synapse.rest.API DEBUG -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for add
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi add log-level](apictl_mi_add_log-level.md)	 - Add new Logger to a Micro Integrator
+* [apictl mi add user](apictl_mi_add_user.md)	 - Add new user to a Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_add_log-level.md
+++ b/import-export-cli/docs/apictl_mi_add_log-level.md
@@ -1,0 +1,38 @@
+## apictl mi add log-level
+
+Add new Logger to a Micro Integrator
+
+### Synopsis
+
+Add new Logger named [logger-name] to the [class-name] with log level [log-level] specified by the command line arguments to a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi add log-level [logger-name] [class-name] [log-level] [flags]
+```
+
+### Examples
+
+```
+To add a new logger
+  apictl mi add log-level synapse-api org.apache.synapse.rest.API DEBUG -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+  -h, --help                 help for log-level
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi add](apictl_mi_add.md)	 - Add new users or loggers to a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_add_user.md
+++ b/import-export-cli/docs/apictl_mi_add_user.md
@@ -1,0 +1,38 @@
+## apictl mi add user
+
+Add new user to a Micro Integrator
+
+### Synopsis
+
+Add a new user with the name specified by the command line argument [user-name] to a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi add user [user-name] [flags]
+```
+
+### Examples
+
+```
+To add a new user
+  apictl mi add user capp-tester -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+  -h, --help                 help for user
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi add](apictl_mi_add.md)	 - Add new users or loggers to a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_delete.md
+++ b/import-export-cli/docs/apictl_mi_delete.md
@@ -1,0 +1,36 @@
+## apictl mi delete
+
+Delete users from a Micro Integrator instance
+
+### Synopsis
+
+Delete users from a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi delete [flags]
+```
+
+### Examples
+
+```
+apictl mi delete user capp-tester -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi delete user](apictl_mi_delete_user.md)	 - Delete a user from the Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_delete_user.md
+++ b/import-export-cli/docs/apictl_mi_delete_user.md
@@ -1,0 +1,38 @@
+## apictl mi delete user
+
+Delete a user from the Micro Integrator
+
+### Synopsis
+
+Delete a user with the name specified by the command line argument [user-name] from a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi delete user [user-name] [flags]
+```
+
+### Examples
+
+```
+To delete a user
+  apictl mi delete user capp-tester -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+  -h, --help                 help for user
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi delete](apictl_mi_delete.md)	 - Delete users from a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_get_apis.md
+++ b/import-export-cli/docs/apictl_mi_get_apis.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for apis
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_composite-apps.md
+++ b/import-export-cli/docs/apictl_mi_get_composite-apps.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print composite apps using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for composite-apps
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_connectors.md
+++ b/import-export-cli/docs/apictl_mi_get_connectors.md
@@ -22,7 +22,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print connectors using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for connectors
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_data-services.md
+++ b/import-export-cli/docs/apictl_mi_get_data-services.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print data services using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for data-services
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_endpoints.md
+++ b/import-export-cli/docs/apictl_mi_get_endpoints.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print endpoints using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for endpoints
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_inbound-endpoints.md
+++ b/import-export-cli/docs/apictl_mi_get_inbound-endpoints.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print inbound endpoints using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for inbound-endpoints
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_local-entries.md
+++ b/import-export-cli/docs/apictl_mi_get_local-entries.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print local entries using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for local-entries
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_log-levels.md
+++ b/import-export-cli/docs/apictl_mi_get_log-levels.md
@@ -23,7 +23,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print log-levels using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for log-levels
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_logs.md
+++ b/import-export-cli/docs/apictl_mi_get_logs.md
@@ -26,7 +26,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print logs using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for logs
   -p, --path string          Path the file should be downloaded
 ```

--- a/import-export-cli/docs/apictl_mi_get_message-processors.md
+++ b/import-export-cli/docs/apictl_mi_get_message-processors.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print message processors using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for message-processors
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_message-stores.md
+++ b/import-export-cli/docs/apictl_mi_get_message-stores.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print message stores using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for message-stores
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_proxy-services.md
+++ b/import-export-cli/docs/apictl_mi_get_proxy-services.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print proxy services using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for proxy-services
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_sequences.md
+++ b/import-export-cli/docs/apictl_mi_get_sequences.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print sequences using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for sequences
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_tasks.md
+++ b/import-export-cli/docs/apictl_mi_get_tasks.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print tasks using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for tasks
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_templates.md
+++ b/import-export-cli/docs/apictl_mi_get_templates.md
@@ -27,7 +27,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print templates using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for templates
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_transaction-counts.md
+++ b/import-export-cli/docs/apictl_mi_get_transaction-counts.md
@@ -25,7 +25,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print transaction-counts using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for transaction-counts
 ```
 

--- a/import-export-cli/docs/apictl_mi_get_users.md
+++ b/import-export-cli/docs/apictl_mi_get_users.md
@@ -30,7 +30,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ```
   -e, --environment string   Environment to be searched
-      --format string        Pretty-print users using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+      --format string        Pretty-print using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for users
   -p, --pattern string       Filter users by regex
   -r, --role string          Filter users by role

--- a/import-export-cli/docs/apictl_mi_update.md
+++ b/import-export-cli/docs/apictl_mi_update.md
@@ -1,0 +1,36 @@
+## apictl mi update
+
+Update log level of Loggers in a Micro Integrator instance
+
+### Synopsis
+
+Update log level of Loggers in a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi update [flags]
+```
+
+### Examples
+
+```
+apictl mi update log-level org-apache-coyote DEBUG -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for update
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi update log-level](apictl_mi_update_log-level.md)	 - Update log level of a Logger in a Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_update_log-level.md
+++ b/import-export-cli/docs/apictl_mi_update_log-level.md
@@ -1,0 +1,38 @@
+## apictl mi update log-level
+
+Update log level of a Logger in a Micro Integrator
+
+### Synopsis
+
+Update the log level of a Logger named [logger-name] to [log-level] specified by the command line arguments in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi update log-level [logger-name] [log-level] [flags]
+```
+
+### Examples
+
+```
+To update the log level
+  apictl mi update log-level org-apache-coyote DEBUG -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to be searched
+  -h, --help                 help for log-level
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi update](apictl_mi_update.md)	 - Update log level of Loggers in a Micro Integrator instance
+

--- a/import-export-cli/mi/impl/logger.go
+++ b/import-export-cli/mi/impl/logger.go
@@ -1,0 +1,48 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// AddMILogger adds a new logger to the class logClass with the name loggerName and log level loggingLevel in the micro integrator in a given environment
+func AddMILogger(env, loggerName, logClass, loggingLevel string) (interface{}, error) {
+	body := make(map[string]string)
+	putNonEmptyValueToMap(body, "loggerName", loggerName)
+	putNonEmptyValueToMap(body, "loggingLevel", loggingLevel)
+	putNonEmptyValueToMap(body, "loggerClass", logClass)
+
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementLoggingResource, env, utils.MainConfigFilePath)
+	resp, err := addNewMILogger(url, body, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}
+
+// UpdateMILogger update the log level to loggingLevel of the logger with name loggerName in the micro integrator in a given environment
+func UpdateMILogger(env, loggerName, loggingLevel string) (interface{}, error) {
+	return AddMILogger(env, loggerName, "", loggingLevel)
+}
+
+func addNewMILogger(url string, body map[string]string, env string) (string, error) {
+	resp, err := invokePATCHRequestWithRetry(url, body, env)
+	return handleResponse(resp, err, url, "message", "Error")
+}

--- a/import-export-cli/mi/impl/user.go
+++ b/import-export-cli/mi/impl/user.go
@@ -1,0 +1,84 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"strings"
+
+	"github.com/renstrom/dedent"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// AddMIUser adds a new user to the micro integrator in a given environment
+func AddMIUser(env, userName, password, isAdmin string) (interface{}, error) {
+	isAdmin = resolveIsAdmin(isAdmin)
+	body := dedent.Dedent(`{
+		   "userId": "` + userName + `",
+		   "password": "` + password + `",
+		   "isAdmin": "` + isAdmin + `"
+	}`)
+
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementUserResource, env, utils.MainConfigFilePath)
+	resp, err := addNewMIUser(url, body, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}
+
+// DeleteMIUser deletes a user from a micro integrator in a given environment
+func DeleteMIUser(env, userName string) (interface{}, error) {
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementUserResource, env, utils.MainConfigFilePath) + "/" + userName
+	resp, err := deleteMIUser(url, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}
+
+func addNewMIUser(url, body, env string) (string, error) {
+	resp, err := invokePOSTRequestWithRetry(url, body, env)
+	return handleResponse(resp, err, url, "status", "Error")
+}
+
+func deleteMIUser(url, env string) (string, error) {
+	resp, err := invokeDELETERequestWithRetry(url, env)
+	return handleResponse(resp, err, url, "status", "Error")
+}
+
+func resolveIsAdmin(isAdminConsoleInput string) string {
+	if len(strings.TrimSpace(isAdminConsoleInput)) == 0 {
+		return "false"
+	}
+	yesResponses := []string{"y", "yes"}
+	if containsString(yesResponses, strings.TrimSpace(isAdminConsoleInput)) {
+		return "true"
+	}
+	return "false"
+}
+
+func containsString(slice []string, element string) bool {
+	for _, elem := range slice {
+		// case in-sensitive comparison
+		if strings.EqualFold(elem, element) {
+			return true
+		}
+	}
+	return false
+}

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -439,7 +439,7 @@
 </ul>
 <ul>
     <li>
-        <h4 id="login">mi login [environment]</h4>
+        <h4 id="mi-login">mi login [environment]</h4>
         <pre><code class="lang-bash">   Flags:
        Optional:
            --username, -u
@@ -455,7 +455,7 @@
 </ul>
 <ul>
     <li>
-        <h4 id="logout">mi logout [environment]</h4>
+        <h4 id="mi-logout">mi logout [environment]</h4>
         <pre><code class="lang-bash">   Examples:
        apictl mi logout dev
 </code></pre>
@@ -463,7 +463,7 @@
 </ul>
 <ul>
     <li>
-        <h4 id="get-apis">mi get apis [api-name]</h4>
+        <h4 id="mi-get-apis">mi get apis [api-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -475,7 +475,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-composite-apps">mi get composite-apps [app-name]</h4>
+        <h4 id="mi-get-composite-apps">mi get composite-apps [app-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -487,7 +487,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-connectors">mi get connectors</h4>
+        <h4 id="mi-get-connectors">mi get connectors</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -510,7 +510,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-endpoints">mi get endpoints [endpoint-name]</h4>
+        <h4 id="mi-get-endpoints">mi get endpoints [endpoint-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -522,7 +522,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-inbound-endpoints">mi get inbound-endpoints [inbound-name]</h4>
+        <h4 id="mi-get-inbound-endpoints">mi get inbound-endpoints [inbound-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -534,7 +534,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-local-entries">mi get local-entries [localentry-name]</h4>
+        <h4 id="mi-get-local-entries">mi get local-entries [localentry-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -546,7 +546,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-log-levels">mi get log-levels [logger-name]</h4>
+        <h4 id="mi-get-log-levels">mi get log-levels [logger-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -557,7 +557,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-logs">mi get logs [file-name]</h4>
+        <h4 id="mi-get-logs">mi get logs [file-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -570,7 +570,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-message-processors">mi get message-processors [messageprocessor-name]</h4>
+        <h4 id="mi-get-message-processors">mi get message-processors [messageprocessor-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -582,7 +582,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-message-stores">mi get message-stores [messagestore-name]</h4>
+        <h4 id="mi-get-message-stores">mi get message-stores [messagestore-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -594,7 +594,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-proxy-services">mi get proxy-services [proxy-name]</h4>
+        <h4 id="mi-get-proxy-services">mi get proxy-services [proxy-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -606,7 +606,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-sequences">mi get sequences [sequence-name]</h4>
+        <h4 id="mi-get-sequences">mi get sequences [sequence-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -618,7 +618,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-tasks">mi get tasks [task-name]</h4>
+        <h4 id="mi-get-tasks">mi get tasks [task-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -630,7 +630,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-templates">mi get templates [template-type] [template-name]</h4>
+        <h4 id="mi-get-templates">mi get templates [template-type] [template-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -643,7 +643,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-transaction-counts">mi get transaction-counts [year] [month]</h4>
+        <h4 id="mi-get-transaction-counts">mi get transaction-counts [year] [month]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -655,7 +655,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-transaction-reports">mi get transaction-reports [start] [end]</h4>
+        <h4 id="mi-get-transaction-reports">mi get transaction-reports [start] [end]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -668,7 +668,7 @@
 </code></pre>
     </li>
     <li>
-        <h4 id="get-users">mi get users [user-name]</h4>
+        <h4 id="mi-get-users">mi get users [user-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
               --environment, -e
@@ -680,6 +680,44 @@
           apictl mi get users -e dev
           apictl mi get users -r admin -e dev
           apictl mi get users -p mi -e dev
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="mi-add-user">mi add user [user-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi add user capp-tester -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-add-logger">mi add log-level [logger-name] [class-name] [log-level]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi add log-level synapse-api org.apache.synapse.rest.API DEBUG -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-update-logger">mi update log-level [logger-name] [log-level]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi update log-level org-apache-coyote DEBUG -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-delete-user">mi delete user [user-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi delete user capp-developer -e dev
 </code></pre>
     </li>
 </ul>

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -2693,6 +2693,218 @@ _apictl_mg()
     noun_aliases=()
 }
 
+_apictl_mi_add_help()
+{
+    last_command="apictl_mi_add_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_add_log-level()
+{
+    last_command="apictl_mi_add_log-level"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_add_user()
+{
+    last_command="apictl_mi_add_user"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_add()
+{
+    last_command="apictl_mi_add"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("log-level")
+    commands+=("user")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_delete_help()
+{
+    last_command="apictl_mi_delete_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_delete_user()
+{
+    last_command="apictl_mi_delete_user"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_delete()
+{
+    last_command="apictl_mi_delete"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("user")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_mi_get_apis()
 {
     last_command="apictl_mi_get_apis"
@@ -3577,6 +3789,94 @@ _apictl_mi_logout()
     noun_aliases=()
 }
 
+_apictl_mi_update_help()
+{
+    last_command="apictl_mi_update_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_update_log-level()
+{
+    last_command="apictl_mi_update_log-level"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_update()
+{
+    last_command="apictl_mi_update"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("log-level")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_mi()
 {
     last_command="apictl_mi"
@@ -3584,10 +3884,13 @@ _apictl_mi()
     command_aliases=()
 
     commands=()
+    commands+=("add")
+    commands+=("delete")
     commands+=("get")
     commands+=("help")
     commands+=("login")
     commands+=("logout")
+    commands+=("update")
 
     flags=()
     two_word_flags=()

--- a/import-export-cli/utils/utils.go
+++ b/import-export-cli/utils/utils.go
@@ -235,6 +235,28 @@ func InvokeDELETERequest(url string, headers map[string]string) (*resty.Response
 	return resp, err
 }
 
+// Invoke http-patch request using go-resty
+func InvokePATCHRequest(url string, headers map[string]string, body map[string]string) (*resty.Response, error) {
+	if Insecure {
+		resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) // To bypass errors in SSL certificates
+	} else {
+		resty.SetTLSClientConfig(GetTlsConfigWithCertificate())
+	}
+	if os.Getenv("HTTP_PROXY") != "" {
+		resty.SetProxy(os.Getenv("HTTP_PROXY"))
+	} else if os.Getenv("HTTPS_PROXY") != "" {
+		resty.SetProxy(os.Getenv("HTTPS_PROXY"))
+	} else if os.Getenv("http_proxy") != "" {
+		resty.SetProxy(os.Getenv("http_proxy"))
+	} else if os.Getenv("https_proxy") != "" {
+		resty.SetProxy(os.Getenv("https_proxy"))
+	}
+	resty.SetTimeout(time.Duration(HttpRequestTimeout) * time.Millisecond)
+	resp, err := resty.R().SetHeaders(headers).SetBody(body).Patch(url)
+
+	return resp, err
+}
+
 func PromptForUsername() string {
 	reader := bufio.NewReader(os.Stdin)
 


### PR DESCRIPTION
## Purpose
Update MI CLI tool and merge with APICTL
wso2/micro-integrator#1999

## Goals
- Add a new add command under mi alias to add users and loggers to MI instances
- Add a new update command under mi alias to update log levels of loggers in MI instances
- Add a new delete command under mi alias to delete users from MI instances

## Approach
- Created a new package called add inside the mi package
- Add the necessary sub-commands(user and log-level) inside that get package
- Created a new package called delete inside the mi package and add sub-command user inside that get package
- Created a new package called update inside the mi package and add sub-command log-level inside that get package

## User stories
- To add a new user to a MI instance
`apictl mi add user [user-name]`
- To add a new logger to a MI instance
`apictl mi add log-level [logger-name] [class-name] [log-level]`
- To update the log level of a logger in MI instance
`apictl mi update log-level [logger-name] [log-level]`
- To delete a user from a MI instance
`apictl mi delete user [user-name]`

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64