### PR TITLE
Refactor code and update usage for environment flag

### DIFF
--- a/import-export-cli/cmd/mi/add/logLevel.go
+++ b/import-export-cli/cmd/mi/add/logLevel.go
@@ -52,7 +52,7 @@ var addLogLevelCmd = &cobra.Command{
 
 func init() {
 	AddCmd.AddCommand(addLogLevelCmd)
-	addLogLevelCmd.Flags().StringVarP(&addLogLevelCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	addLogLevelCmd.Flags().StringVarP(&addLogLevelCmdEnvironment, "environment", "e", "", "Environment of the micro integrator to which a new logger should be added")
 	addLogLevelCmd.MarkFlagRequired("environment")
 }
 

--- a/import-export-cli/cmd/mi/add/logLevel.go
+++ b/import-export-cli/cmd/mi/add/logLevel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -35,7 +36,7 @@ const addLogLevelCmdShortDesc = "Add new Logger to a Micro Integrator"
 const addLogLevelCmdLongDesc = "Add new Logger named [logger-name] to the [class-name] with log level [log-level] specified by the command line arguments to a Micro Integrator in the environment specified by the flag --environment, -e"
 
 var addLogLevelCmdExamples = "To add a new logger\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " log-level synapse-api org.apache.synapse.rest.API DEBUG -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(addLogLevelCmdLiteral) + " synapse-api org.apache.synapse.rest.API DEBUG -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var addLogLevelCmd = &cobra.Command{
@@ -56,7 +57,7 @@ func init() {
 }
 
 func handleAddLogLevelCmdArguments(args []string) {
-	printAddCmdVerboseLog("log-level")
+	printAddCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(addLogLevelCmdLiteral))
 	credentials.HandleMissingCredentials(addLogLevelCmdEnvironment)
 	executeAddNewLogger(args[0], args[1], args[2])
 }

--- a/import-export-cli/cmd/mi/add/user.go
+++ b/import-export-cli/cmd/mi/add/user.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -39,7 +40,7 @@ const addUserCmdShortDesc = "Add new user to a Micro Integrator"
 const addUserCmdLongDesc = "Add a new user with the name specified by the command line argument [user-name] to a Micro Integrator in the environment specified by the flag --environment, -e"
 
 var addUserCmdExamples = "To add a new user\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " user capp-tester -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + addCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(addUserCmdLiteral) + " capp-tester -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var addUserCmd = &cobra.Command{
@@ -60,7 +61,7 @@ func init() {
 }
 
 func handleAddUserCmdArguments(args []string) {
-	printAddCmdVerboseLog("user")
+	printAddCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(addUserCmdLiteral))
 	credentials.HandleMissingCredentials(addUserCmdEnvironment)
 	startConsoleToAddUser(args[0])
 }

--- a/import-export-cli/cmd/mi/add/user.go
+++ b/import-export-cli/cmd/mi/add/user.go
@@ -56,7 +56,7 @@ var addUserCmd = &cobra.Command{
 
 func init() {
 	AddCmd.AddCommand(addUserCmd)
-	addUserCmd.Flags().StringVarP(&addUserCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	addUserCmd.Flags().StringVarP(&addUserCmdEnvironment, "environment", "e", "", "Environment of the micro integrator to which a new user should be added")
 	addUserCmd.MarkFlagRequired("environment")
 }
 

--- a/import-export-cli/cmd/mi/delete/user.go
+++ b/import-export-cli/cmd/mi/delete/user.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -35,7 +36,7 @@ const deleteUserCmdShortDesc = "Delete a user from the Micro Integrator"
 const deleteUserCmdLongDesc = "Delete a user with the name specified by the command line argument [user-name] from a Micro Integrator in the environment specified by the flag --environment, -e"
 
 var deleteUserCmdExamples = "To delete a user\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + deleteCmdLiteral + " user capp-tester -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + deleteCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(deleteUserCmdLiteral) + " capp-tester -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var deleteUserCmd = &cobra.Command{
@@ -56,7 +57,7 @@ func init() {
 }
 
 func handledeleteUserCmdArguments(args []string) {
-	printDeleteCmdVerboseLog(deleteUserCmdLiteral)
+	printDeleteCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(deleteUserCmdLiteral))
 	credentials.HandleMissingCredentials(deleteUserCmdEnvironment)
 	executeDeleteUser(args[0])
 }

--- a/import-export-cli/cmd/mi/delete/user.go
+++ b/import-export-cli/cmd/mi/delete/user.go
@@ -52,7 +52,7 @@ var deleteUserCmd = &cobra.Command{
 
 func init() {
 	DeleteCmd.AddCommand(deleteUserCmd)
-	deleteUserCmd.Flags().StringVarP(&deleteUserCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	deleteUserCmd.Flags().StringVarP(&deleteUserCmdEnvironment, "environment", "e", "", "Environment of the micro integrator from which a user should be deleted")
 	deleteUserCmd.MarkFlagRequired("environment")
 }
 

--- a/import-export-cli/cmd/mi/get/apis.go
+++ b/import-export-cli/cmd/mi/get/apis.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getIntegrationAPICmdEnvironment string
@@ -34,7 +35,7 @@ var getIntegrationAPICmd = &cobra.Command{
 	Use:     getIntegrationAPICmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactAPIs),
 	Long:    generateGetCmdLongDescForArtifact(artifactAPIs, "api-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactAPIs, getTrimmedCmdLiteral(getIntegrationAPICmdLiteral), "SampleIntegrationAPI"),
+	Example: generateGetCmdExamplesForArtifact(artifactAPIs, miUtils.GetTrimmedCmdLiteral(getIntegrationAPICmdLiteral), "SampleIntegrationAPI"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetIntegrationAPICmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetIntegrationAPICmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getIntegrationAPICmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getIntegrationAPICmdLiteral))
 	credentials.HandleMissingCredentials(getIntegrationAPICmdEnvironment)
 	if len(args) == 1 {
 		var IntegrationAPIName = args[0]

--- a/import-export-cli/cmd/mi/get/compositeApps.go
+++ b/import-export-cli/cmd/mi/get/compositeApps.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getApplicationCmdEnvironment string
@@ -34,7 +35,7 @@ var getApplicationCmd = &cobra.Command{
 	Use:     getApplicationCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactCompositeApps),
 	Long:    generateGetCmdLongDescForArtifact(artifactCompositeApps, "app-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactCompositeApps, getTrimmedCmdLiteral(getApplicationCmdLiteral), "SampleApp"),
+	Example: generateGetCmdExamplesForArtifact(artifactCompositeApps, miUtils.GetTrimmedCmdLiteral(getApplicationCmdLiteral), "SampleApp"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetApplicationCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetApplicationCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getApplicationCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getApplicationCmdLiteral))
 	credentials.HandleMissingCredentials(getApplicationCmdEnvironment)
 	if len(args) == 1 {
 		var appName = args[0]

--- a/import-export-cli/cmd/mi/get/dataservices.go
+++ b/import-export-cli/cmd/mi/get/dataservices.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getDataServiceCmdEnvironment string
@@ -34,7 +35,7 @@ var getDataServiceCmd = &cobra.Command{
 	Use:     getDataServiceCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactDataServices),
 	Long:    generateGetCmdLongDescForArtifact(artifactDataServices, "dataservice-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactDataServices, getTrimmedCmdLiteral(getDataServiceCmdLiteral), "SampleDataService"),
+	Example: generateGetCmdExamplesForArtifact(artifactDataServices, miUtils.GetTrimmedCmdLiteral(getDataServiceCmdLiteral), "SampleDataService"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetDataServiceCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetDataServiceCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getDataServiceCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getDataServiceCmdLiteral))
 	credentials.HandleMissingCredentials(getDataServiceCmdEnvironment)
 	if len(args) == 1 {
 		var dataServiceName = args[0]

--- a/import-export-cli/cmd/mi/get/endpoints.go
+++ b/import-export-cli/cmd/mi/get/endpoints.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getEndpointCmdEnvironment string
@@ -34,7 +35,7 @@ var getEndpointCmd = &cobra.Command{
 	Use:     getEndpointCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactEndpoints),
 	Long:    generateGetCmdLongDescForArtifact(artifactEndpoints, "endpoint-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactEndpoints, getTrimmedCmdLiteral(getEndpointCmdLiteral), "SampleEndpoint"),
+	Example: generateGetCmdExamplesForArtifact(artifactEndpoints, miUtils.GetTrimmedCmdLiteral(getEndpointCmdLiteral), "SampleEndpoint"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetEndpointCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetEndpointCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getEndpointCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getEndpointCmdLiteral))
 	credentials.HandleMissingCredentials(getEndpointCmdEnvironment)
 	if len(args) == 1 {
 		var EndpointName = args[0]

--- a/import-export-cli/cmd/mi/get/inboundendpoints.go
+++ b/import-export-cli/cmd/mi/get/inboundendpoints.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getInboundEndpointCmdEnvironment string
@@ -34,7 +35,7 @@ var getInboundEndpointCmd = &cobra.Command{
 	Use:     getInboundEndpointCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactInboundEndpoints),
 	Long:    generateGetCmdLongDescForArtifact(artifactInboundEndpoints, "inbound-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactInboundEndpoints, getTrimmedCmdLiteral(getInboundEndpointCmdLiteral), "SampleInboundEndpoint"),
+	Example: generateGetCmdExamplesForArtifact(artifactInboundEndpoints, miUtils.GetTrimmedCmdLiteral(getInboundEndpointCmdLiteral), "SampleInboundEndpoint"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetInboundEndpointCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetInboundEndpointCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getInboundEndpointCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getInboundEndpointCmdLiteral))
 	credentials.HandleMissingCredentials(getInboundEndpointCmdEnvironment)
 	if len(args) == 1 {
 		var inboundEndpointName = args[0]

--- a/import-export-cli/cmd/mi/get/localentries.go
+++ b/import-export-cli/cmd/mi/get/localentries.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getLocalEntryCmdEnvironment string
@@ -34,7 +35,7 @@ var getLocalEntryCmd = &cobra.Command{
 	Use:     getLocalEntryCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactLocalEntries),
 	Long:    generateGetCmdLongDescForArtifact(artifactLocalEntries, "localentry-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactLocalEntries, getTrimmedCmdLiteral(getLocalEntryCmdLiteral), "SampleLocalEntry"),
+	Example: generateGetCmdExamplesForArtifact(artifactLocalEntries, miUtils.GetTrimmedCmdLiteral(getLocalEntryCmdLiteral), "SampleLocalEntry"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetLocalEntryCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetLocalEntryCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLocalEntryCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getLocalEntryCmdLiteral))
 	credentials.HandleMissingCredentials(getLocalEntryCmdEnvironment)
 	if len(args) == 1 {
 		var LocalEntryName = args[0]

--- a/import-export-cli/cmd/mi/get/logLevels.go
+++ b/import-export-cli/cmd/mi/get/logLevels.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -34,7 +35,7 @@ const getLogLevelCmdShortDesc = "Get information about a Logger configured in a 
 const getLogLevelCmdLongDesc = "Get information about the Logger specified by command line argument [logger-name]\nconfigured in a Micro Integrator in the environment specified by the flag --environment, -e"
 
 var getLogLevelCmdExamples = "To get details about a specific logger\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogLevelCmdLiteral) + " org-apache-coyote -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getLogLevelCmdLiteral) + " org-apache-coyote -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var getLogLevelCmd = &cobra.Command{
@@ -55,7 +56,7 @@ func init() {
 }
 
 func handleGetLogLevelCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLogLevelCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getLogLevelCmdLiteral))
 	credentials.HandleMissingCredentials(getLogLevelCmdEnvironment)
 	var loggerName = args[0]
 	executeShowLogLevel(loggerName)

--- a/import-export-cli/cmd/mi/get/logs.go
+++ b/import-export-cli/cmd/mi/get/logs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -39,9 +40,9 @@ const getLogCmdLongDesc = "Download a log file by providing the file name and do
 
 var getLogCmdExamples = "Example:\n" +
 	"To list all the log files\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogCmdLiteral) + " -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getLogCmdLiteral) + " -e dev\n" +
 	"To download a selected log file\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getLogCmdLiteral) + " [file-name] -p [download-location] -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getLogCmdLiteral) + " [file-name] -p [download-location] -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var getLogCmd = &cobra.Command{
@@ -63,7 +64,7 @@ func init() {
 }
 
 func handleGetLogCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getLogCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getLogCmdLiteral))
 	credentials.HandleMissingCredentials(getLogCmdEnvironment)
 	if len(args) == 1 {
 		var logFileName = args[0]

--- a/import-export-cli/cmd/mi/get/messageprocessors.go
+++ b/import-export-cli/cmd/mi/get/messageprocessors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getMessageProcessorCmdEnvironment string
@@ -34,7 +35,7 @@ var getMessageProcessorCmd = &cobra.Command{
 	Use:     getMessageProcessorCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactMessageProcessors),
 	Long:    generateGetCmdLongDescForArtifact(artifactMessageProcessors, "messageprocessor-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactMessageProcessors, getTrimmedCmdLiteral(getMessageProcessorCmdLiteral), "TestMessageProcessor"),
+	Example: generateGetCmdExamplesForArtifact(artifactMessageProcessors, miUtils.GetTrimmedCmdLiteral(getMessageProcessorCmdLiteral), "TestMessageProcessor"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetMessageProcessorCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetMessageProcessorCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getMessageProcessorCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getMessageProcessorCmdLiteral))
 	credentials.HandleMissingCredentials(getMessageProcessorCmdEnvironment)
 	if len(args) == 1 {
 		var messageProcessorName = args[0]

--- a/import-export-cli/cmd/mi/get/messagestores.go
+++ b/import-export-cli/cmd/mi/get/messagestores.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getMessageStoreCmdEnvironment string
@@ -34,7 +35,7 @@ var getMessageStoreCmd = &cobra.Command{
 	Use:     getMessageStoreCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactMessageStores),
 	Long:    generateGetCmdLongDescForArtifact(artifactMessageStores, "messagestore-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactMessageStores, getTrimmedCmdLiteral(getMessageStoreCmdLiteral), "TestMessageStore"),
+	Example: generateGetCmdExamplesForArtifact(artifactMessageStores, miUtils.GetTrimmedCmdLiteral(getMessageStoreCmdLiteral), "TestMessageStore"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetMessageStoreCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetMessageStoreCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getMessageStoreCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getMessageStoreCmdLiteral))
 	credentials.HandleMissingCredentials(getMessageStoreCmdEnvironment)
 	if len(args) == 1 {
 		var messageStoreName = args[0]

--- a/import-export-cli/cmd/mi/get/proxyservices.go
+++ b/import-export-cli/cmd/mi/get/proxyservices.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getProxyServiceCmdEnvironment string
@@ -34,7 +35,7 @@ var getProxyServiceCmd = &cobra.Command{
 	Use:     getProxyServiceCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactProxyServices),
 	Long:    generateGetCmdLongDescForArtifact(artifactProxyServices, "proxy-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactProxyServices, getTrimmedCmdLiteral(getProxyServiceCmdLiteral), "SampleProxy"),
+	Example: generateGetCmdExamplesForArtifact(artifactProxyServices, miUtils.GetTrimmedCmdLiteral(getProxyServiceCmdLiteral), "SampleProxy"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetProxyServiceCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetProxyServiceCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getProxyServiceCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getProxyServiceCmdLiteral))
 	credentials.HandleMissingCredentials(getProxyServiceCmdEnvironment)
 	if len(args) == 1 {
 		var proxyServiceName = args[0]

--- a/import-export-cli/cmd/mi/get/sequences.go
+++ b/import-export-cli/cmd/mi/get/sequences.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getSequenceCmdEnvironment string
@@ -34,7 +35,7 @@ var getSequenceCmd = &cobra.Command{
 	Use:     getSequenceCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactSequences),
 	Long:    generateGetCmdLongDescForArtifact(artifactSequences, "sequence-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactSequences, getTrimmedCmdLiteral(getSequenceCmdLiteral), "SampleSequence"),
+	Example: generateGetCmdExamplesForArtifact(artifactSequences, miUtils.GetTrimmedCmdLiteral(getSequenceCmdLiteral), "SampleSequence"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetSequenceCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetSequenceCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getSequenceCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getSequenceCmdLiteral))
 	credentials.HandleMissingCredentials(getSequenceCmdEnvironment)
 	if len(args) == 1 {
 		var sequenceName = args[0]

--- a/import-export-cli/cmd/mi/get/tasks.go
+++ b/import-export-cli/cmd/mi/get/tasks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 )
 
 var getTaskCmdEnvironment string
@@ -34,7 +35,7 @@ var getTasksCmd = &cobra.Command{
 	Use:     getTaskCmdLiteral,
 	Short:   generateGetCmdShortDescForArtifact(artifactTasks),
 	Long:    generateGetCmdLongDescForArtifact(artifactTasks, "task-name"),
-	Example: generateGetCmdExamplesForArtifact(artifactTasks, getTrimmedCmdLiteral(getTaskCmdLiteral), "SampleTask"),
+	Example: generateGetCmdExamplesForArtifact(artifactTasks, miUtils.GetTrimmedCmdLiteral(getTaskCmdLiteral), "SampleTask"),
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetTaskCmdArguments(args)
@@ -48,7 +49,7 @@ func init() {
 }
 
 func handleGetTaskCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTaskCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getTaskCmdLiteral))
 	credentials.HandleMissingCredentials(getTaskCmdEnvironment)
 	if len(args) == 1 {
 		var taskName = args[0]

--- a/import-export-cli/cmd/mi/get/templates.go
+++ b/import-export-cli/cmd/mi/get/templates.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -41,11 +42,11 @@ const getTemplateCmdLongDesc = "Get information about the template specified by 
 	"If not specified, list all the templates in the environment specified by the flag --environment, -e"
 
 var getTemplateCmdExamples = "To list all the " + artifactTemplates + "\n" +
-	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " -e dev\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTemplateCmdLiteral) + " -e dev\n" +
 	"To get details about a specific template type\n" +
-	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType\n" +
 	"To get details about a specific template\n" +
-	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType TemplateName -e dev\n" +
+	utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTemplateCmdLiteral) + " TemplateType TemplateName -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 const endpointKey string = "endpoint"
@@ -80,7 +81,7 @@ func init() {
 }
 
 func handleGetTemplateCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTemplateCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getTemplateCmdLiteral))
 	credentials.HandleMissingCredentials(getTemplateCmdEnvironment)
 	if len(args) == 2 {
 		var templateType = args[0]

--- a/import-export-cli/cmd/mi/get/transactionCount.go
+++ b/import-export-cli/cmd/mi/get/transactionCount.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -38,9 +39,9 @@ const getTransactionCountCmdLongDesc = "Retrieve transaction count based on the 
 	"If year and month not provided, retrieve the count for the current year and month of Micro Integrator in the environment specified by the flag --environment, -e"
 
 var getTransactionCountCmdExamples = "To get the transaction count for the current month\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " -e dev\n" +
 	"To get the transaction count for a specific month\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " 2020 06 -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTransactionCountCmdLiteral) + " 2020 06 -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var getTransactionCountCmd = &cobra.Command{
@@ -67,7 +68,7 @@ func init() {
 }
 
 func handleGetTransactionCountCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTransactionCountCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getTransactionCountCmdLiteral))
 	credentials.HandleMissingCredentials(getTransactionCountCmdEnvironment)
 	if len(args) == 2 {
 		var year = args[0]

--- a/import-export-cli/cmd/mi/get/transactionReports.go
+++ b/import-export-cli/cmd/mi/get/transactionReports.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -40,11 +41,11 @@ const getTransactionReportCmdLongDesc = "Generate the transaction count summary 
 
 var getTransactionReportCmdExamples = "Example:\n" +
 	"To generate transaction count report consisting data within a specified time period at a specified location\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-05 2020-06 --path </dir_path> -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-05 2020-06 --path </dir_path> -e dev\n" +
 	"To generate transaction count report with data from a given month upto the current month at a specified location\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 -p </dir_path> -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 -p </dir_path> -e dev\n" +
 	"To generate transaction count report at the current location with data between 2020-01 and 2020-05\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 2020-05 -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getTransactionReportCmdLiteral) + " 2020-01 2020-05 -e dev\n" +
 	"NOTE: The [start] argument and the flag (--environment (-e)) is mandatory"
 
 var getTransactionReportCmd = &cobra.Command{
@@ -65,7 +66,7 @@ func init() {
 }
 
 func handleGetTransactionReportCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getTransactionReportCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getTransactionReportCmdLiteral))
 	credentials.HandleMissingCredentials(getTransactionReportCmdEnvironment)
 	var start = args[0]
 	var end = ""

--- a/import-export-cli/cmd/mi/get/users.go
+++ b/import-export-cli/cmd/mi/get/users.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -41,13 +42,13 @@ const getUserCmdLongDesc = "Get information about the users filtered by username
 
 var getUserCmdExamples = "Example:\n" +
 	"To list all the users\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getUserCmdLiteral) + " -e dev\n" +
 	"To get the list of users with specific role\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -r [role-name] -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getUserCmdLiteral) + " -r [role-name] -e dev\n" +
 	"To get the list of users with a username matching with the wild card Ex: \"*mi*\" matches with \"admin\"\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " -p [pattern] -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getUserCmdLiteral) + " -p [pattern] -e dev\n" +
 	"To get details about a user by providing the user-id\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + getTrimmedCmdLiteral(getUserCmdLiteral) + " [user-id] -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(getUserCmdLiteral) + " [user-id] -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var getUserCmd = &cobra.Command{
@@ -81,7 +82,7 @@ func init() {
 }
 
 func handleGetUserCmdArguments(args []string) {
-	printGetCmdVerboseLogForArtifact(getTrimmedCmdLiteral(getUserCmdLiteral))
+	printGetCmdVerboseLogForArtifact(miUtils.GetTrimmedCmdLiteral(getUserCmdLiteral))
 	credentials.HandleMissingCredentials(getUserCmdEnvironment)
 	if len(args) == 1 {
 		var userID = args[0]

--- a/import-export-cli/cmd/mi/get/utils.go
+++ b/import-export-cli/cmd/mi/get/utils.go
@@ -20,7 +20,6 @@ package get
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -40,11 +39,6 @@ func generateGetCmdExamplesForArtifact(resourceType, cmdLiteral, sampleResourceN
 		"To get details about a specific " + resourceType + "\n" +
 		"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + GetCmdLiteral + " " + cmdLiteral + " " + sampleResourceName + " -e dev\n" +
 		"NOTE: The flag (--environment (-e)) is mandatory"
-}
-
-func getTrimmedCmdLiteral(cmd string) string {
-	cmdParts := strings.Fields(cmd)
-	return cmdParts[0]
 }
 
 func printErrorForArtifact(artifactType, artifactName string, err error) {

--- a/import-export-cli/cmd/mi/update/logLevel.go
+++ b/import-export-cli/cmd/mi/update/logLevel.go
@@ -52,7 +52,7 @@ var updateLogLevelCmd = &cobra.Command{
 
 func init() {
 	UpdateCmd.AddCommand(updateLogLevelCmd)
-	updateLogLevelCmd.Flags().StringVarP(&updateLogLevelCmdEnvironment, "environment", "e", "", "Environment to be searched")
+	updateLogLevelCmd.Flags().StringVarP(&updateLogLevelCmdEnvironment, "environment", "e", "", "Environment of the micro integrator of which the logger should be updated")
 	updateLogLevelCmd.MarkFlagRequired("environment")
 }
 

--- a/import-export-cli/cmd/mi/update/logLevel.go
+++ b/import-export-cli/cmd/mi/update/logLevel.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
@@ -35,7 +36,7 @@ const updateLogLevelCmdShortDesc = "Update log level of a Logger in a Micro Inte
 const updateLogLevelCmdLongDesc = "Update the log level of a Logger named [logger-name] to [log-level] specified by the command line arguments in a Micro Integrator in the environment specified by the flag --environment, -e"
 
 var updateLogLevelCmdExamples = "To update the log level\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + updateCmdLiteral + " log-level org-apache-coyote DEBUG -e dev\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + updateCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(updateLogLevelCmdLiteral) + " org-apache-coyote DEBUG -e dev\n" +
 	"NOTE: The flag (--environment (-e)) is mandatory"
 
 var updateLogLevelCmd = &cobra.Command{
@@ -56,7 +57,7 @@ func init() {
 }
 
 func handleupdateLogLevelCmdArguments(args []string) {
-	printUpdateCmdVerboseLog("log-level")
+	printUpdateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(updateLogLevelCmdLiteral))
 	credentials.HandleMissingCredentials(updateLogLevelCmdEnvironment)
 	executeUpdateLogger(args[0], args[1])
 }

--- a/import-export-cli/docs/apictl_mi_add_log-level.md
+++ b/import-export-cli/docs/apictl_mi_add_log-level.md
@@ -21,7 +21,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 ### Options
 
 ```
-  -e, --environment string   Environment to be searched
+  -e, --environment string   Environment of the micro integrator to which a new logger should be added
   -h, --help                 help for log-level
 ```
 

--- a/import-export-cli/docs/apictl_mi_add_user.md
+++ b/import-export-cli/docs/apictl_mi_add_user.md
@@ -21,7 +21,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 ### Options
 
 ```
-  -e, --environment string   Environment to be searched
+  -e, --environment string   Environment of the micro integrator to which a new user should be added
   -h, --help                 help for user
 ```
 

--- a/import-export-cli/docs/apictl_mi_delete_user.md
+++ b/import-export-cli/docs/apictl_mi_delete_user.md
@@ -21,7 +21,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 ### Options
 
 ```
-  -e, --environment string   Environment to be searched
+  -e, --environment string   Environment of the micro integrator from which a user should be deleted
   -h, --help                 help for user
 ```
 

--- a/import-export-cli/docs/apictl_mi_update_log-level.md
+++ b/import-export-cli/docs/apictl_mi_update_log-level.md
@@ -21,7 +21,7 @@ NOTE: The flag (--environment (-e)) is mandatory
 ### Options
 
 ```
-  -e, --environment string   Environment to be searched
+  -e, --environment string   Environment of the micro integrator of which the logger should be updated
   -h, --help                 help for log-level
 ```
 

--- a/import-export-cli/mi/utils/utils.go
+++ b/import-export-cli/mi/utils/utils.go
@@ -1,0 +1,29 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package utils
+
+import (
+	"strings"
+)
+
+// GetTrimmedCmdLiteral returns the command without the arguments
+func GetTrimmedCmdLiteral(cmd string) string {
+	cmdParts := strings.Fields(cmd)
+	return cmdParts[0]
+}


### PR DESCRIPTION
## Purpose
- Move the `getTrimmedCmdLiteral` function from cmd/mi/get package to the mi/utils package.
- Update the usage message of the environment flag in mi add, mi update, and mi delete commands.

## Approach
- Create a utils file inside the mi/utils package.
- Move the `getTrimmedCmdLiteral` function to it.
- Make necessary changes to mi get, mi add, mi update, and mi delete commands.

## User stories
No Changes

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64