### PR TITLE
Add commands to activate and deactivate endpoints, message processors and proxy services in MI instances

### DIFF
--- a/import-export-cli/cmd/mi/activate/activate.go
+++ b/import-export-cli/cmd/mi/activate/activate.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package activate
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const activateCmdLiteral = "activate"
+const activateCmdShortDesc = "Activate artifacts deployed in a Micro Integrator instance"
+
+const activateCmdLongDesc = "Activate artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)"
+
+const activateCmdExamples = utils.ProjectName + " " + utils.MiCmdLiteral + " " + activateCmdLiteral + " " + "endpoint" + " TestEP -e dev"
+
+// ActivateCmd represents the activate command
+var ActivateCmd = &cobra.Command{
+	Use:     activateCmdLiteral,
+	Short:   activateCmdShortDesc,
+	Long:    activateCmdLongDesc,
+	Example: activateCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + activateCmdLiteral + " called")
+		cmd.Help()
+	},
+}

--- a/import-export-cli/cmd/mi/activate/endpoint.go
+++ b/import-export-cli/cmd/mi/activate/endpoint.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package activate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var activateEndpointCmdEnvironment string
+
+const artifactEndpoint = "endpoint"
+const activateEndpointCmdLiteral = "endpoint [endpoint-name]"
+
+var activateEndpointCmd = &cobra.Command{
+	Use:     activateEndpointCmdLiteral,
+	Short:   generateActivateCmdShortDescForArtifact(artifactEndpoint),
+	Long:    generateActivateCmdLongDescForArtifact(artifactEndpoint, "endpoint-name"),
+	Example: generateActivateCmdExamplesForArtifact(artifactEndpoint, miUtils.GetTrimmedCmdLiteral(activateEndpointCmdLiteral), "TestEP"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleActivateEndpointCmdArguments(args)
+	},
+}
+
+func init() {
+	ActivateCmd.AddCommand(activateEndpointCmd)
+	setEnvFlag(activateEndpointCmd, &activateEndpointCmdEnvironment, artifactEndpoint)
+}
+
+func handleActivateEndpointCmdArguments(args []string) {
+	printActivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(activateEndpointCmdLiteral))
+	credentials.HandleMissingCredentials(activateEndpointCmdEnvironment)
+	executeActivateEndpoint(args[0])
+}
+
+func executeActivateEndpoint(endpointName string) {
+	resp, err := impl.ActivateEndpoint(activateEndpointCmdEnvironment, endpointName)
+	if err != nil {
+		printErrorForArtifact(artifactEndpoint, endpointName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/activate/messageprocessor.go
+++ b/import-export-cli/cmd/mi/activate/messageprocessor.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package activate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var activateMessageProcessorCmdEnvironment string
+
+const artifactMessageProcessor = "message processor"
+const activateMessageProcessorCmdLiteral = "message-processor [messageprocessor-name]"
+
+var activateMessageProcessorCmd = &cobra.Command{
+	Use:     activateMessageProcessorCmdLiteral,
+	Short:   generateActivateCmdShortDescForArtifact(artifactMessageProcessor),
+	Long:    generateActivateCmdLongDescForArtifact(artifactMessageProcessor, "messageprocessor-name"),
+	Example: generateActivateCmdExamplesForArtifact(artifactMessageProcessor, miUtils.GetTrimmedCmdLiteral(activateMessageProcessorCmdLiteral), "TestMessageProcessor"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleActivateMessageProcessorCmdArguments(args)
+	},
+}
+
+func init() {
+	ActivateCmd.AddCommand(activateMessageProcessorCmd)
+	setEnvFlag(activateMessageProcessorCmd, &activateMessageProcessorCmdEnvironment, artifactMessageProcessor)
+}
+
+func handleActivateMessageProcessorCmdArguments(args []string) {
+	printActivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(activateMessageProcessorCmdLiteral))
+	credentials.HandleMissingCredentials(activateMessageProcessorCmdEnvironment)
+	executeActivateMessageProcessor(args[0])
+}
+
+func executeActivateMessageProcessor(messageProcessorName string) {
+	resp, err := impl.ActivateMessageProcessor(activateMessageProcessorCmdEnvironment, messageProcessorName)
+	if err != nil {
+		printErrorForArtifact(artifactMessageProcessor, messageProcessorName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/activate/proxyservice.go
+++ b/import-export-cli/cmd/mi/activate/proxyservice.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package activate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var activateProxyCmdEnvironment string
+
+const artifactProxy = "proxy service"
+const activateProxyCmdLiteral = "proxy-service [proxy-name]"
+
+var activateProxyCmd = &cobra.Command{
+	Use:     activateProxyCmdLiteral,
+	Short:   generateActivateCmdShortDescForArtifact(artifactProxy),
+	Long:    generateActivateCmdLongDescForArtifact(artifactProxy, "proxy-name"),
+	Example: generateActivateCmdExamplesForArtifact(artifactProxy, miUtils.GetTrimmedCmdLiteral(activateProxyCmdLiteral), "SampleProxy"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleActivateProxyCmdArguments(args)
+	},
+}
+
+func init() {
+	ActivateCmd.AddCommand(activateProxyCmd)
+	setEnvFlag(activateProxyCmd, &activateProxyCmdEnvironment, artifactProxy)
+}
+
+func handleActivateProxyCmdArguments(args []string) {
+	printActivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(activateProxyCmdLiteral))
+	credentials.HandleMissingCredentials(activateProxyCmdEnvironment)
+	executeActivateProxy(args[0])
+}
+
+func executeActivateProxy(proxyName string) {
+	resp, err := impl.ActivateProxy(activateProxyCmdEnvironment, proxyName)
+	if err != nil {
+		printErrorForArtifact(artifactProxy, proxyName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/activate/utils.go
+++ b/import-export-cli/cmd/mi/activate/utils.go
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package activate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+func generateActivateCmdShortDescForArtifact(artifact string) string {
+	return "Activate a " + artifact + " deployed in a Micro Integrator"
+}
+
+func generateActivateCmdLongDescForArtifact(artifact, argument string) string {
+	return "Activate the " + artifact + " specified by the command line argument [" + argument + "] deployed in a Micro Integrator in the environment specified by the flag --environment, -e"
+}
+
+func generateActivateCmdExamplesForArtifact(artifact, cmdLiteral, sampleResourceName string) string {
+	return "To activate a " + artifact + "\n" +
+		"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + activateCmdLiteral + " " + cmdLiteral + " " + sampleResourceName + " -e dev\n" +
+		"NOTE: The flag (--environment (-e)) is mandatory"
+}
+
+func printErrorForArtifact(artifactType, artifactName string, err error) {
+	fmt.Println(utils.LogPrefixError+"Activating "+artifactType+" [ "+artifactName+" ]", err)
+}
+
+func printActivateCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + activateCmdLiteral + " " + cmd + " called")
+}
+
+func setEnvFlag(cmd *cobra.Command, param *string, artifactType string) {
+	cmd.Flags().StringVarP(param, "environment", "e", "", "Environment of the micro integrator in which the "+artifactType+" should be activated")
+	cmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/mi/deactivate/deactivate.go
+++ b/import-export-cli/cmd/mi/deactivate/deactivate.go
@@ -1,0 +1,43 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deactivate
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const deactivateCmdLiteral = "deactivate"
+const deactivateCmdShortDesc = "Deactivate artifacts deployed in a Micro Integrator instance"
+
+const deactivateCmdLongDesc = "Deactivate artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)"
+
+const deactivateCmdExamples = utils.ProjectName + " " + utils.MiCmdLiteral + " " + deactivateCmdLiteral + " " + "endpoint" + " TestEP -e dev"
+
+// DeactivateCmd represents the deactivate command
+var DeactivateCmd = &cobra.Command{
+	Use:     deactivateCmdLiteral,
+	Short:   deactivateCmdShortDesc,
+	Long:    deactivateCmdLongDesc,
+	Example: deactivateCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + deactivateCmdLiteral + " called")
+		cmd.Help()
+	},
+}

--- a/import-export-cli/cmd/mi/deactivate/endpoint.go
+++ b/import-export-cli/cmd/mi/deactivate/endpoint.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deactivate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var deactivateEndpointCmdEnvironment string
+
+const artifactEndpoint = "endpoint"
+const deactivateEndpointCmdLiteral = "endpoint [endpoint-name]"
+
+var deactivateEndpointCmd = &cobra.Command{
+	Use:     deactivateEndpointCmdLiteral,
+	Short:   generateDeactivateCmdShortDescForArtifact(artifactEndpoint),
+	Long:    generateDeactivateCmdLongDescForArtifact(artifactEndpoint, "endpoint-name"),
+	Example: generateDeactivateCmdExamplesForArtifact(artifactEndpoint, miUtils.GetTrimmedCmdLiteral(deactivateEndpointCmdLiteral), "TestEP"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleDeactivateEndpointCmdArguments(args)
+	},
+}
+
+func init() {
+	DeactivateCmd.AddCommand(deactivateEndpointCmd)
+	setEnvFlag(deactivateEndpointCmd, &deactivateEndpointCmdEnvironment, artifactEndpoint)
+}
+
+func handleDeactivateEndpointCmdArguments(args []string) {
+	printDeactivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(deactivateEndpointCmdLiteral))
+	credentials.HandleMissingCredentials(deactivateEndpointCmdEnvironment)
+	executeDeactivateEndpoint(args[0])
+}
+
+func executeDeactivateEndpoint(endpointName string) {
+	resp, err := impl.DeactivateEndpoint(deactivateEndpointCmdEnvironment, endpointName)
+	if err != nil {
+		printErrorForArtifact(artifactEndpoint, endpointName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/deactivate/messageprocessor.go
+++ b/import-export-cli/cmd/mi/deactivate/messageprocessor.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deactivate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var deactivateMessageProcessorCmdEnvironment string
+
+const artifactMessageProcessor = "message processor"
+const deactivateMessageProcessorCmdLiteral = "message-processor [messageprocessor-name]"
+
+var deactivateMessageProcessorCmd = &cobra.Command{
+	Use:     deactivateMessageProcessorCmdLiteral,
+	Short:   generateDeactivateCmdShortDescForArtifact(artifactMessageProcessor),
+	Long:    generateDeactivateCmdLongDescForArtifact(artifactMessageProcessor, "messageprocessor-name"),
+	Example: generateDeactivateCmdExamplesForArtifact(artifactMessageProcessor, miUtils.GetTrimmedCmdLiteral(deactivateMessageProcessorCmdLiteral), "TestMessageProcessor"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleDeactivateMessageProcessorCmdArguments(args)
+	},
+}
+
+func init() {
+	DeactivateCmd.AddCommand(deactivateMessageProcessorCmd)
+	setEnvFlag(deactivateMessageProcessorCmd, &deactivateMessageProcessorCmdEnvironment, artifactMessageProcessor)
+}
+
+func handleDeactivateMessageProcessorCmdArguments(args []string) {
+	printDeactivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(deactivateMessageProcessorCmdLiteral))
+	credentials.HandleMissingCredentials(deactivateMessageProcessorCmdEnvironment)
+	executeDeactivateMessageProcessor(args[0])
+}
+
+func executeDeactivateMessageProcessor(messageProcessorName string) {
+	resp, err := impl.DeactivateMessageProcessor(deactivateMessageProcessorCmdEnvironment, messageProcessorName)
+	if err != nil {
+		printErrorForArtifact(artifactMessageProcessor, messageProcessorName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/deactivate/proxyservice.go
+++ b/import-export-cli/cmd/mi/deactivate/proxyservice.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deactivate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+)
+
+var deactivateProxyCmdEnvironment string
+
+const artifactProxy = "proxy service"
+const deactivateProxyCmdLiteral = "proxy-service [proxy-name]"
+
+var deactivateProxyCmd = &cobra.Command{
+	Use:     deactivateProxyCmdLiteral,
+	Short:   generateDeactivateCmdShortDescForArtifact(artifactProxy),
+	Long:    generateDeactivateCmdLongDescForArtifact(artifactProxy, "proxy-name"),
+	Example: generateDeactivateCmdExamplesForArtifact(artifactProxy, miUtils.GetTrimmedCmdLiteral(deactivateProxyCmdLiteral), "SampleProxy"),
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleDeactivateProxyCmdArguments(args)
+	},
+}
+
+func init() {
+	DeactivateCmd.AddCommand(deactivateProxyCmd)
+	setEnvFlag(deactivateProxyCmd, &deactivateProxyCmdEnvironment, artifactProxy)
+}
+
+func handleDeactivateProxyCmdArguments(args []string) {
+	printDeactivateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(deactivateProxyCmdLiteral))
+	credentials.HandleMissingCredentials(deactivateProxyCmdEnvironment)
+	executeDeactivateProxy(args[0])
+}
+
+func executeDeactivateProxy(proxyName string) {
+	resp, err := impl.DeactivateProxy(deactivateProxyCmdEnvironment, proxyName)
+	if err != nil {
+		printErrorForArtifact(artifactProxy, proxyName, err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/deactivate/utils.go
+++ b/import-export-cli/cmd/mi/deactivate/utils.go
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package deactivate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+func generateDeactivateCmdShortDescForArtifact(artifact string) string {
+	return "Deactivate a " + artifact + " deployed in a Micro Integrator"
+}
+
+func generateDeactivateCmdLongDescForArtifact(artifact, argument string) string {
+	return "Deactivate the " + artifact + " specified by the command line argument [" + argument + "] deployed in a Micro Integrator in the environment specified by the flag --environment, -e"
+}
+
+func generateDeactivateCmdExamplesForArtifact(artifact, cmdLiteral, sampleResourceName string) string {
+	return "To deactivate a " + artifact + "\n" +
+		"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + deactivateCmdLiteral + " " + cmdLiteral + " " + sampleResourceName + " -e dev\n" +
+		"NOTE: The flag (--environment (-e)) is mandatory"
+}
+
+func printErrorForArtifact(artifactType, artifactName string, err error) {
+	fmt.Println(utils.LogPrefixError+"Deactivating "+artifactType+" [ "+artifactName+" ]", err)
+}
+
+func printDeactivateCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + deactivateCmdLiteral + " " + cmd + " called")
+}
+
+func setEnvFlag(cmd *cobra.Command, param *string, artifactType string) {
+	cmd.Flags().StringVarP(param, "environment", "e", "", "Environment of the micro integrator in which the "+artifactType+" should be deactivated")
+	cmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/mi/mi.go
+++ b/import-export-cli/cmd/mi/mi.go
@@ -20,7 +20,9 @@ package mi
 
 import (
 	"github.com/spf13/cobra"
+	miActivateCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/activate"
 	miAddCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/add"
+	miDeactivateCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/deactivate"
 	miDeleteCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/delete"
 	miGetCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/get"
 	miUpdateCmd "github.com/wso2/product-apim-tooling/import-export-cli/cmd/mi/update"
@@ -48,4 +50,6 @@ func init() {
 	MICmd.AddCommand(miAddCmd.AddCmd)
 	MICmd.AddCommand(miDeleteCmd.DeleteCmd)
 	MICmd.AddCommand(miUpdateCmd.UpdateCmd)
+	MICmd.AddCommand(miActivateCmd.ActivateCmd)
+	MICmd.AddCommand(miDeactivateCmd.DeactivateCmd)
 }

--- a/import-export-cli/docs/apictl_mi.md
+++ b/import-export-cli/docs/apictl_mi.md
@@ -26,7 +26,9 @@ apictl mi [flags]
 ### SEE ALSO
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl mi activate](apictl_mi_activate.md)	 - Activate artifacts deployed in a Micro Integrator instance
 * [apictl mi add](apictl_mi_add.md)	 - Add new users or loggers to a Micro Integrator instance
+* [apictl mi deactivate](apictl_mi_deactivate.md)	 - Deactivate artifacts deployed in a Micro Integrator instance
 * [apictl mi delete](apictl_mi_delete.md)	 - Delete users from a Micro Integrator instance
 * [apictl mi get](apictl_mi_get.md)	 - Get information about artifacts deployed in a Micro Integrator instance
 * [apictl mi login](apictl_mi_login.md)	 - Login to a Micro Integrator

--- a/import-export-cli/docs/apictl_mi_activate.md
+++ b/import-export-cli/docs/apictl_mi_activate.md
@@ -1,0 +1,38 @@
+## apictl mi activate
+
+Activate artifacts deployed in a Micro Integrator instance
+
+### Synopsis
+
+Activate artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi activate [flags]
+```
+
+### Examples
+
+```
+apictl mi activate endpoint TestEP -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for activate
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi activate endpoint](apictl_mi_activate_endpoint.md)	 - Activate a endpoint deployed in a Micro Integrator
+* [apictl mi activate message-processor](apictl_mi_activate_message-processor.md)	 - Activate a message processor deployed in a Micro Integrator
+* [apictl mi activate proxy-service](apictl_mi_activate_proxy-service.md)	 - Activate a proxy service deployed in a Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_activate_endpoint.md
+++ b/import-export-cli/docs/apictl_mi_activate_endpoint.md
@@ -1,0 +1,38 @@
+## apictl mi activate endpoint
+
+Activate a endpoint deployed in a Micro Integrator
+
+### Synopsis
+
+Activate the endpoint specified by the command line argument [endpoint-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi activate endpoint [endpoint-name] [flags]
+```
+
+### Examples
+
+```
+To activate a endpoint
+  apictl mi activate endpoint TestEP -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the endpoint should be activated
+  -h, --help                 help for endpoint
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi activate](apictl_mi_activate.md)	 - Activate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_activate_message-processor.md
+++ b/import-export-cli/docs/apictl_mi_activate_message-processor.md
@@ -1,0 +1,38 @@
+## apictl mi activate message-processor
+
+Activate a message processor deployed in a Micro Integrator
+
+### Synopsis
+
+Activate the message processor specified by the command line argument [messageprocessor-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi activate message-processor [messageprocessor-name] [flags]
+```
+
+### Examples
+
+```
+To activate a message processor
+  apictl mi activate message-processor TestMessageProcessor -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the message processor should be activated
+  -h, --help                 help for message-processor
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi activate](apictl_mi_activate.md)	 - Activate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_activate_proxy-service.md
+++ b/import-export-cli/docs/apictl_mi_activate_proxy-service.md
@@ -1,0 +1,38 @@
+## apictl mi activate proxy-service
+
+Activate a proxy service deployed in a Micro Integrator
+
+### Synopsis
+
+Activate the proxy service specified by the command line argument [proxy-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi activate proxy-service [proxy-name] [flags]
+```
+
+### Examples
+
+```
+To activate a proxy service
+  apictl mi activate proxy-service SampleProxy -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the proxy service should be activated
+  -h, --help                 help for proxy-service
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi activate](apictl_mi_activate.md)	 - Activate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_deactivate.md
+++ b/import-export-cli/docs/apictl_mi_deactivate.md
@@ -1,0 +1,38 @@
+## apictl mi deactivate
+
+Deactivate artifacts deployed in a Micro Integrator instance
+
+### Synopsis
+
+Deactivate artifacts deployed in a Micro Integrator instance in the environment specified by the flag (--environment, -e)
+
+```
+apictl mi deactivate [flags]
+```
+
+### Examples
+
+```
+apictl mi deactivate endpoint TestEP -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for deactivate
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi deactivate endpoint](apictl_mi_deactivate_endpoint.md)	 - Deactivate a endpoint deployed in a Micro Integrator
+* [apictl mi deactivate message-processor](apictl_mi_deactivate_message-processor.md)	 - Deactivate a message processor deployed in a Micro Integrator
+* [apictl mi deactivate proxy-service](apictl_mi_deactivate_proxy-service.md)	 - Deactivate a proxy service deployed in a Micro Integrator
+

--- a/import-export-cli/docs/apictl_mi_deactivate_endpoint.md
+++ b/import-export-cli/docs/apictl_mi_deactivate_endpoint.md
@@ -1,0 +1,38 @@
+## apictl mi deactivate endpoint
+
+Deactivate a endpoint deployed in a Micro Integrator
+
+### Synopsis
+
+Deactivate the endpoint specified by the command line argument [endpoint-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi deactivate endpoint [endpoint-name] [flags]
+```
+
+### Examples
+
+```
+To deactivate a endpoint
+  apictl mi deactivate endpoint TestEP -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the endpoint should be deactivated
+  -h, --help                 help for endpoint
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi deactivate](apictl_mi_deactivate.md)	 - Deactivate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_deactivate_message-processor.md
+++ b/import-export-cli/docs/apictl_mi_deactivate_message-processor.md
@@ -1,0 +1,38 @@
+## apictl mi deactivate message-processor
+
+Deactivate a message processor deployed in a Micro Integrator
+
+### Synopsis
+
+Deactivate the message processor specified by the command line argument [messageprocessor-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi deactivate message-processor [messageprocessor-name] [flags]
+```
+
+### Examples
+
+```
+To deactivate a message processor
+  apictl mi deactivate message-processor TestMessageProcessor -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the message processor should be deactivated
+  -h, --help                 help for message-processor
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi deactivate](apictl_mi_deactivate.md)	 - Deactivate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/docs/apictl_mi_deactivate_proxy-service.md
+++ b/import-export-cli/docs/apictl_mi_deactivate_proxy-service.md
@@ -1,0 +1,38 @@
+## apictl mi deactivate proxy-service
+
+Deactivate a proxy service deployed in a Micro Integrator
+
+### Synopsis
+
+Deactivate the proxy service specified by the command line argument [proxy-name] deployed in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi deactivate proxy-service [proxy-name] [flags]
+```
+
+### Examples
+
+```
+To deactivate a proxy service
+  apictl mi deactivate proxy-service SampleProxy -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator in which the proxy service should be deactivated
+  -h, --help                 help for proxy-service
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi deactivate](apictl_mi_deactivate.md)	 - Deactivate artifacts deployed in a Micro Integrator instance
+

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -21,8 +21,6 @@ package impl
 import (
 	"bytes"
 	"errors"
-	"github.com/Jeffail/gabs"
-	jsoniter "github.com/json-iterator/go"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -30,6 +28,9 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/Jeffail/gabs"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/go-resty/resty"
 	"github.com/wso2/product-apim-tooling/import-export-cli/box"
@@ -75,7 +76,7 @@ func ExecuteNewFileUploadRequest(uri string, params map[string]string, paramName
 	headers[utils.HeaderAccept] = "application/json"
 	headers[utils.HeaderConnection] = utils.HeaderValueKeepAlive
 
-	resp, err := utils.InvokePOSTRequestWithBytes(uri, headers, body.Bytes())
+	resp, err := utils.InvokePOSTRequest(uri, headers, body.Bytes())
 
 	return resp, err
 }

--- a/import-export-cli/impl/importApp.go
+++ b/import-export-cli/impl/importApp.go
@@ -196,7 +196,7 @@ func NewAppFileUploadRequest(uri string, params map[string]string, paramName, pa
 	headers[utils.HeaderAccept] = "*/*"
 	headers[utils.HeaderConnection] = utils.HeaderValueKeepAlive
 
-	resp, err := utils.InvokePOSTRequestWithBytes(uri, headers, body.Bytes())
+	resp, err := utils.InvokePOSTRequest(uri, headers, body.Bytes())
 
 	return resp, err
 }

--- a/import-export-cli/mi/impl/common.go
+++ b/import-export-cli/mi/impl/common.go
@@ -28,7 +28,6 @@ import (
 	"text/template"
 
 	"github.com/go-resty/resty"
-	"github.com/renstrom/dedent"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -36,6 +35,11 @@ import (
 
 // miHTTPRetryCount default retry count for HTTP calls
 const miHTTPRetryCount = 2
+
+type updateArtifactRequestBody struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
 
 // unmarshalData unmarshal data from the response to the respective struct
 // @param url: url of rest api
@@ -144,7 +148,7 @@ func invokePATCHRequestWithRetry(url string, body map[string]string, env string)
 	})
 }
 
-func invokePOSTRequestWithRetry(url, body, env string) (*resty.Response, error) {
+func invokePOSTRequestWithRetry(env, url string, body interface{}) (*resty.Response, error) {
 	return retryHTTPCall(miHTTPRetryCount, env, func(accessToken string) (*resty.Response, error) {
 		headers := make(map[string]string)
 		headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
@@ -240,10 +244,10 @@ func createErrorWithResponseBody(resp string, err error) error {
 }
 
 func updateArtifactState(url, artifactName, state, env string) (string, error) {
-	body := dedent.Dedent(`{
-		"name": "` + artifactName + `",
-		"status": "` + state + `"
-	}`)
-	resp, err := invokePOSTRequestWithRetry(url, body, env)
+	body := updateArtifactRequestBody{
+		Name:   artifactName,
+		Status: state,
+	}
+	resp, err := invokePOSTRequestWithRetry(env, url, body)
 	return handleResponse(resp, err, url, "Message", "Error")
 }

--- a/import-export-cli/mi/impl/common.go
+++ b/import-export-cli/mi/impl/common.go
@@ -28,6 +28,7 @@ import (
 	"text/template"
 
 	"github.com/go-resty/resty"
+	"github.com/renstrom/dedent"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/formatter"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
@@ -236,4 +237,13 @@ func createErrorWithResponseBody(resp string, err error) error {
 		}
 	}
 	return err
+}
+
+func updateArtifactState(url, artifactName, state, env string) (string, error) {
+	body := dedent.Dedent(`{
+		"name": "` + artifactName + `",
+		"status": "` + state + `"
+	}`)
+	resp, err := invokePOSTRequestWithRetry(url, body, env)
+	return handleResponse(resp, err, url, "Message", "Error")
 }

--- a/import-export-cli/mi/impl/endpoint.go
+++ b/import-export-cli/mi/impl/endpoint.go
@@ -1,0 +1,42 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// ActivateEndpoint activates an endpoint deployed in the micro integrator in a given environment
+func ActivateEndpoint(env, endpointName string) (interface{}, error) {
+	return updateEndpointState(env, endpointName, "active")
+}
+
+// DeactivateEndpoint deactivates an endpoint deployed in the micro integrator in a given environment
+func DeactivateEndpoint(env, endpointName string) (interface{}, error) {
+	return updateEndpointState(env, endpointName, "inactive")
+}
+
+func updateEndpointState(env, endpointName, state string) (interface{}, error) {
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementEndpointResource, env, utils.MainConfigFilePath)
+	resp, err := updateArtifactState(url, endpointName, state, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}

--- a/import-export-cli/mi/impl/messageProcessor.go
+++ b/import-export-cli/mi/impl/messageProcessor.go
@@ -1,0 +1,42 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// ActivateMessageProcessor activates a message processor deployed in the micro integrator in a given environment
+func ActivateMessageProcessor(env, messageProcessorName string) (interface{}, error) {
+	return updateMessageProcessorSerivceState(env, messageProcessorName, "active")
+}
+
+// DeactivateMessageProcessor deactivates a message processor service deployed in the micro integrator in a given environment
+func DeactivateMessageProcessor(env, messageProcessorName string) (interface{}, error) {
+	return updateMessageProcessorSerivceState(env, messageProcessorName, "inactive")
+}
+
+func updateMessageProcessorSerivceState(env, messageProcessorName, state string) (interface{}, error) {
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementMessageProcessorResource, env, utils.MainConfigFilePath)
+	resp, err := updateArtifactState(url, messageProcessorName, state, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}

--- a/import-export-cli/mi/impl/proxyService.go
+++ b/import-export-cli/mi/impl/proxyService.go
@@ -1,0 +1,42 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// ActivateProxy activates a proxy service deployed in the micro integrator in a given environment
+func ActivateProxy(env, proxyName string) (interface{}, error) {
+	return updateProxySerivceState(env, proxyName, "active")
+}
+
+// DeactivateProxy deactivates a proxy service deployed in the micro integrator in a given environment
+func DeactivateProxy(env, proxyName string) (interface{}, error) {
+	return updateProxySerivceState(env, proxyName, "inactive")
+}
+
+func updateProxySerivceState(env, proxyName, state string) (interface{}, error) {
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementProxyServiceResource, env, utils.MainConfigFilePath)
+	resp, err := updateArtifactState(url, proxyName, state, env)
+	if err != nil {
+		return nil, createErrorWithResponseBody(resp, err)
+	}
+	return resp, nil
+}

--- a/import-export-cli/mi/impl/user.go
+++ b/import-export-cli/mi/impl/user.go
@@ -21,21 +21,25 @@ package impl
 import (
 	"strings"
 
-	"github.com/renstrom/dedent"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
+
+type newUserRequestBody struct {
+	UserID   string `json:"userID"`
+	Password string `json:"password"`
+	IsAdmin  string `json:"isAdmin"`
+}
 
 // AddMIUser adds a new user to the micro integrator in a given environment
 func AddMIUser(env, userName, password, isAdmin string) (interface{}, error) {
 	isAdmin = resolveIsAdmin(isAdmin)
-	body := dedent.Dedent(`{
-		   "userId": "` + userName + `",
-		   "password": "` + password + `",
-		   "isAdmin": "` + isAdmin + `"
-	}`)
-
+	body := newUserRequestBody{
+		UserID:   userName,
+		Password: password,
+		IsAdmin:  isAdmin,
+	}
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementUserResource, env, utils.MainConfigFilePath)
-	resp, err := addNewMIUser(url, body, env)
+	resp, err := addNewMIUser(env, url, body)
 	if err != nil {
 		return nil, createErrorWithResponseBody(resp, err)
 	}
@@ -52,8 +56,8 @@ func DeleteMIUser(env, userName string) (interface{}, error) {
 	return resp, nil
 }
 
-func addNewMIUser(url, body, env string) (string, error) {
-	resp, err := invokePOSTRequestWithRetry(url, body, env)
+func addNewMIUser(env, url string, body interface{}) (string, error) {
+	resp, err := invokePOSTRequestWithRetry(env, url, body)
 	return handleResponse(resp, err, url, "status", "Error")
 }
 

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -721,3 +721,61 @@
 </code></pre>
     </li>
 </ul>
+<ul>
+    <li>
+        <h4 id="mi-activate-endpoint">mi activate endpoint [endpoint-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi activate endpoint TestEP -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-activate-proxy-service">mi activate proxy-service [proxy-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi activate proxy-service SampleProxy -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-activate-message-processor">mi activate message-processor [messageprocessor-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi activate message-processor TestMessageProcessor -e dev
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="mi-deactivate-endpoint">mi deactivate endpoint [endpoint-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi deactivate endpoint TestEP -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-deactivate-proxy-service">mi deactivate proxy-service [proxy-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi deactivate proxy-service SampleProxy -e dev
+</code></pre>
+    </li>
+    <li>
+        <h4 id="mi-deactivate-message-processor">mi deactivate message-processor [messageprocessor-name]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi deactivate message-processor TestMessageProcessor -e dev
+</code></pre>
+    </li>
+</ul>

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -2693,6 +2693,166 @@ _apictl_mg()
     noun_aliases=()
 }
 
+_apictl_mi_activate_endpoint()
+{
+    last_command="apictl_mi_activate_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_activate_help()
+{
+    last_command="apictl_mi_activate_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_activate_message-processor()
+{
+    last_command="apictl_mi_activate_message-processor"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_activate_proxy-service()
+{
+    last_command="apictl_mi_activate_proxy-service"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_activate()
+{
+    last_command="apictl_mi_activate"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("endpoint")
+    commands+=("help")
+    commands+=("message-processor")
+    commands+=("proxy-service")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_mi_add_help()
 {
     last_command="apictl_mi_add_help"
@@ -2797,6 +2957,166 @@ _apictl_mi_add()
     commands+=("help")
     commands+=("log-level")
     commands+=("user")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_deactivate_endpoint()
+{
+    last_command="apictl_mi_deactivate_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_deactivate_help()
+{
+    last_command="apictl_mi_deactivate_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_mi_deactivate_message-processor()
+{
+    last_command="apictl_mi_deactivate_message-processor"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_deactivate_proxy-service()
+{
+    last_command="apictl_mi_deactivate_proxy-service"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_mi_deactivate()
+{
+    last_command="apictl_mi_deactivate"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("endpoint")
+    commands+=("help")
+    commands+=("message-processor")
+    commands+=("proxy-service")
 
     flags=()
     two_word_flags=()
@@ -3884,7 +4204,9 @@ _apictl_mi()
     command_aliases=()
 
     commands=()
+    commands+=("activate")
     commands+=("add")
+    commands+=("deactivate")
     commands+=("delete")
     commands+=("get")
     commands+=("help")

--- a/import-export-cli/utils/utils.go
+++ b/import-export-cli/utils/utils.go
@@ -33,30 +33,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// Invoke http-post request using go-resty
-func InvokePOSTRequest(url string, headers map[string]string, body string) (*resty.Response, error) {
-	if Insecure {
-		resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) // To bypass errors in SSL certificates
-	} else {
-		resty.SetTLSClientConfig(GetTlsConfigWithCertificate())
-	}
-	if os.Getenv("HTTP_PROXY") != "" {
-		resty.SetProxy(os.Getenv("HTTP_PROXY"))
-	} else if os.Getenv("HTTPS_PROXY") != "" {
-		resty.SetProxy(os.Getenv("HTTPS_PROXY"))
-	} else if os.Getenv("http_proxy") != "" {
-		resty.SetProxy(os.Getenv("http_proxy"))
-	} else if os.Getenv("https_proxy") != "" {
-		resty.SetProxy(os.Getenv("https_proxy"))
-	}
-	resty.SetTimeout(time.Duration(HttpRequestTimeout) * time.Millisecond)
-	resp, err := resty.R().SetHeaders(headers).SetBody(body).Post(url)
-
-	return resp, err
-}
-
-// Invoke http-post request using go-resty with byte[] body
-func InvokePOSTRequestWithBytes(url string, headers map[string]string, body []byte) (*resty.Response, error) {
+func InvokePOSTRequest(url string, headers map[string]string, body interface{}) (*resty.Response, error) {
 	if Insecure {
 		resty.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) // To bypass errors in SSL certificates
 	} else {


### PR DESCRIPTION
## Purpose
Update MI CLI tool and merge with APICTL
wso2/micro-integrator#1999

## Goals
- Add a new activate command under mi alias to activate endpoints, message processors, and proxy services in MI instances
- Add a new deactivate command under mi alias to deactivate endpoints, message processors, and proxy services in MI instances

## Approach
- Created a new package called activate inside the mi package
- Add the necessary sub-commands(endpoints, message processors, and proxy services) inside that get package
- Created a new package called deactivate inside the mi package
- Add the necessary sub-commands(endpoints, message processors, and proxy services) inside that get package

## User stories
- To activate an endpoint
`apictl mi activate endpoint [endpoint-name]`
- To activate a message processor
`apictl mi activate message-processor [message-processor-name]`
- To activate a proxy service
`apictl mi activate proxy-service [proxy-name]`

- To deactivate an endpoint
`apictl mi deactivate endpoint [endpoint-name]`
- To deactivate a message processor
`apictl mi deactivate message-processor [message-processor-name]`
- To deactivate a proxy service
`apictl mi deactivate proxy-service [proxy-name]`

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64