### PR TITLE
Introducing the Bundle command

### DIFF
--- a/import-export-cli/cmd/bundle.go
+++ b/import-export-cli/cmd/bundle.go
@@ -1,0 +1,142 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+var bundleDestination string
+var bundleSource string
+
+// Get command related usage Info
+const BundleCmdLiteral = "bundle"
+const BundleCmdShortDesc = "Archive any project to zip format"
+
+const BundleCmdLongDesc = "Archive API, Application or API Product projects to a zip format. Bundle name will have " +
+	"project name, version and revision number (if there is any)"
+
+const BundleCmdExamples = utils.ProjectName + ` ` + BundleCmdLiteral + ` -s /home/prod/APIs/API1-1.0.0 -d /home/prod/Projects/
+` + utils.ProjectName + ` ` + BundleCmdLiteral + ` -s /home/prod/APIs/API1-1.0.0 
+NOTE: The flag (--source (-s) is mandatory.`
+
+
+// BundleCmd represents the bundle command
+var BundleCmd = &cobra.Command{
+	Use:     BundleCmdLiteral,
+	Short:   BundleCmdShortDesc,
+	Long:    BundleCmdLongDesc,
+	Example: BundleCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + BundleCmdLiteral + " called")
+
+		if stat, err := os.Stat(bundleSource); !os.IsNotExist(err) {
+			if !stat.IsDir() {
+				fmt.Printf("%s is not a directory\n", bundleSource)
+				os.Exit(1)
+			}
+		}
+
+		err := executeBundleCmd()
+		if err != nil {
+			utils.HandleErrorAndContinue("Error archiving the " + bundleSource, err)
+		}
+
+	},
+}
+
+func executeBundleCmd() error {
+	var bundleDirParent string
+
+	// Check the validity of destination path when it is given. if not given, use the working directory
+	if bundleDestination != "" {
+		err := os.MkdirAll(bundleDestination, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		p, err := filepath.Abs(bundleDestination)
+		if err != nil {
+			return err
+		}
+		bundleDirParent = p
+	} else {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		bundleDirParent = pwd
+	}
+
+	bundleName, err := generateBundleName(bundleSource)
+	if err != nil {
+		return err
+	}
+
+	name := filepath.Join(bundleDirParent, bundleName + utils.ZipFileSuffix)
+
+	err = utils.Zip(bundleSource, name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("The bundle for the " + bundleName + " is generated at " + bundleDirParent)
+	return nil
+}
+
+func generateBundleName(SourceDir string) (string, error) {
+	metaFileName, err := impl.GetFileLocationFromPattern(SourceDir, "*_meta.yaml")
+	if err != nil && err != io.EOF {
+		fmt.Println("Error reading the meta information.", err)
+	}
+	bundleName := filepath.Base(SourceDir)
+	if metaFileName != "" {
+		metaData, err := impl.LoadMetaInfoFromFile(metaFileName)
+		if err != nil {
+			return bundleName, err
+		}
+
+		bundleName = metaData.Name + "_" + metaData.Version
+		if metaData.Revision != "" {
+			bundleName += "_" + metaData.Revision
+		}
+	} else {
+		fmt.Println( "Source directory name will be used for the bundle name.")
+	}
+
+	return bundleName, nil
+}
+
+
+
+
+// init using Cobra
+func init() {
+	RootCmd.AddCommand(BundleCmd)
+	BundleCmd.Flags().StringVarP(&bundleDestination, "destination", "d", "", "Path of "+
+		"the directory where the bundle should be generated")
+	BundleCmd.Flags().StringVarP(&bundleSource, "source", "s", "", "Path of "+
+		"the source directory to bundle")
+	_ = BundleCmd.MarkFlagRequired("source")
+}

--- a/import-export-cli/cmd/bundle.go
+++ b/import-export-cli/cmd/bundle.go
@@ -33,7 +33,7 @@ var bundleSource string
 
 // Get command related usage Info
 const BundleCmdLiteral = "bundle"
-const BundleCmdShortDesc = "Archive any project to zip format"
+const BundleCmdShortDesc = "Archive any source project artifact to zip format"
 
 const BundleCmdLongDesc = "Archive API, Application or API Product projects to a zip format. Bundle name will have " +
 	"project name, version and revision number (if there is any)"

--- a/import-export-cli/cmd/bundle.go
+++ b/import-export-cli/cmd/bundle.go
@@ -40,8 +40,7 @@ const BundleCmdLongDesc = "Archive API, Application or API Product projects to a
 
 const BundleCmdExamples = utils.ProjectName + ` ` + BundleCmdLiteral + ` -s /home/prod/APIs/API1-1.0.0 -d /home/prod/Projects/
 ` + utils.ProjectName + ` ` + BundleCmdLiteral + ` -s /home/prod/APIs/API1-1.0.0 
-NOTE: The flag (--source (-s) is mandatory.`
-
+NOTE: The flag (--source (-s)) is mandatory.`
 
 // BundleCmd represents the bundle command
 var BundleCmd = &cobra.Command{
@@ -63,7 +62,6 @@ var BundleCmd = &cobra.Command{
 		if err != nil {
 			utils.HandleErrorAndContinue("Error archiving the " + bundleSource, err)
 		}
-
 	},
 }
 
@@ -94,14 +92,13 @@ func executeBundleCmd() error {
 		return err
 	}
 
-	name := filepath.Join(bundleDirParent, bundleName + utils.ZipFileSuffix)
-
-	err = utils.Zip(bundleSource, name)
+	bundleLocation := filepath.Join(bundleDirParent, bundleName + utils.ZipFileSuffix)
+	err = utils.Zip(bundleSource, bundleLocation)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("The bundle for the " + bundleName + " is generated at " + bundleDirParent)
+	fmt.Println("The bundle for the " + bundleName + " is generated at " + bundleLocation)
 	return nil
 }
 
@@ -122,14 +119,11 @@ func generateBundleName(SourceDir string) (string, error) {
 			bundleName += "_" + metaData.Revision
 		}
 	} else {
-		fmt.Println( "Source directory name will be used for the bundle name.")
+		fmt.Println( "Meta information for the Project is not found. Source directory name will be used as the bundle name.")
 	}
 
 	return bundleName, nil
 }
-
-
-
 
 // init using Cobra
 func init() {

--- a/import-export-cli/cmd/bundle.go
+++ b/import-export-cli/cmd/bundle.go
@@ -60,7 +60,7 @@ var BundleCmd = &cobra.Command{
 
 		err := executeBundleCmd()
 		if err != nil {
-			utils.HandleErrorAndContinue("Error archiving the " + bundleSource, err)
+			utils.HandleErrorAndContinue("Error archiving the "+bundleSource, err)
 		}
 	},
 }
@@ -92,7 +92,7 @@ func executeBundleCmd() error {
 		return err
 	}
 
-	bundleLocation := filepath.Join(bundleDirParent, bundleName + utils.ZipFileSuffix)
+	bundleLocation := filepath.Join(bundleDirParent, bundleName+utils.ZipFileSuffix)
 	err = utils.Zip(bundleSource, bundleLocation)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func generateBundleName(SourceDir string) (string, error) {
 			bundleName += "_" + metaData.Revision
 		}
 	} else {
-		fmt.Println( "Meta information for the Project is not found. Source directory name will be used as the bundle name.")
+		fmt.Println("Meta information for the Project is not found. Source directory name will be used as the bundle name.")
 	}
 
 	return bundleName, nil

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -22,7 +22,7 @@ apictl [flags]
 ### SEE ALSO
 
 * [apictl add](apictl_add.md)	 - Add Environment to Config file
-* [apictl bundle](apictl_bundle.md)	 - Archive any project to zip format
+* [apictl bundle](apictl_bundle.md)	 - Archive any source project artifact to zip format
 * [apictl change-status](apictl_change-status.md)	 - Change Status of an API
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
 * [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -22,6 +22,7 @@ apictl [flags]
 ### SEE ALSO
 
 * [apictl add](apictl_add.md)	 - Add Environment to Config file
+* [apictl bundle](apictl_bundle.md)	 - Archive any project to zip format
 * [apictl change-status](apictl_change-status.md)	 - Change Status of an API
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
 * [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment

--- a/import-export-cli/docs/apictl_bundle.md
+++ b/import-export-cli/docs/apictl_bundle.md
@@ -1,0 +1,39 @@
+## apictl bundle
+
+Archive any project to zip format
+
+### Synopsis
+
+Archive API, Application or API Product projects to a zip format. Bundle name will have project name, version and revision number (if there is any)
+
+```
+apictl bundle [flags]
+```
+
+### Examples
+
+```
+apictl bundle -s /home/prod/APIs/API1-1.0.0 -d /home/prod/Projects/
+apictl bundle -s /home/prod/APIs/API1-1.0.0 
+NOTE: The flag (--source (-s)) is mandatory.
+```
+
+### Options
+
+```
+  -d, --destination string   Path of the directory where the bundle should be generated
+  -h, --help                 help for bundle
+  -s, --source string        Path of the source directory to bundle
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -202,10 +202,11 @@ func GetFileContent(path string) (string, error) {
 	return string(data), nil
 }
 
-//Find the path for a file matching the provided patter. If that file is not found in the root directory, an empty string
+//Find the path for a file matching the provided pattern. If that file is not found in the root directory, an empty string
 //will be returned
-func GetFileLocationFromPattern(root, pattern string) (match string, err error) {
-	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+func GetFileLocationFromPattern(root, pattern string) (string, error) {
+	var match string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -223,5 +224,5 @@ func GetFileLocationFromPattern(root, pattern string) (match string, err error) 
 		}
 		return nil
 	})
-	return
+	return match, err
 }

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -21,6 +21,7 @@ package impl
 import (
 	"bytes"
 	"errors"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -28,7 +29,6 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
-	"gopkg.in/yaml.v2"
 
 	"github.com/Jeffail/gabs"
 	jsoniter "github.com/json-iterator/go"

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -216,7 +216,7 @@ func GetFileLocationFromPattern(root, pattern string) (match string, err error) 
 		if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {
 			return err
 		} else if matched {
-			match, err= filepath.Abs(path);
+			match, err = filepath.Abs(path)
 			if err != nil {
 				return err
 			}

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -172,22 +172,21 @@ func IncludeMetaFileToZip(sourceZipFile, targetZipFile, metaFile string, metaDat
 	return nil
 }
 
+//Load the x_meta.yaml file in the provided path and return
 func LoadMetaInfoFromFile(path string) (*utils.MetaData, error) {
-
 	fileContent, err := GetFileContent(path)
 	if err != nil {
 		return nil, err
 	}
-
 	metaInfo := &utils.MetaData{}
 	err = yaml.Unmarshal([]byte(fileContent), &metaInfo)
 	if err != nil {
 		return nil, err
 	}
-
 	return metaInfo, err
 }
 
+//Read the file content from the provided path
 func GetFileContent(path string) (string, error) {
 	r, err := os.Open(path)
 	defer func() {
@@ -196,15 +195,15 @@ func GetFileContent(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
 		return "", err
 	}
-
 	return string(data), nil
 }
 
+//Find the path for a file matching the provided patter. If that file is not found in the root directory, an empty string
+//will be returned
 func GetFileLocationFromPattern(root, pattern string) (match string, err error) {
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -439,6 +439,20 @@
 </ul>
 <ul>
     <li>
+        <h4 id="bundle">gen deployment-dir</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --source, -s
+       Optional:
+           --destination, -d
+   Examples:
+       apictl bundle -s  ~/PizzaShackAPI_1.0.0
+       apictl bundle -s /home/prod/APIs/API1-1.0.0 -d /home/prod/Projects/
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
         <h4 id="mi-login">mi login [environment]</h4>
         <pre><code class="lang-bash">   Flags:
        Optional:

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -461,6 +461,47 @@ _apictl_add()
     noun_aliases=()
 }
 
+_apictl_bundle()
+{
+    last_command="apictl_bundle"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--destination=")
+    two_word_flags+=("--destination")
+    two_word_flags+=("-d")
+    local_nonpersistent_flags+=("--destination")
+    local_nonpersistent_flags+=("--destination=")
+    local_nonpersistent_flags+=("-d")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--source=")
+    two_word_flags+=("--source")
+    two_word_flags+=("-s")
+    local_nonpersistent_flags+=("--source")
+    local_nonpersistent_flags+=("--source=")
+    local_nonpersistent_flags+=("-s")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--source=")
+    must_have_one_flag+=("-s")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_change-status_api()
 {
     last_command="apictl_change-status_api"
@@ -4547,6 +4588,7 @@ _apictl_root_command()
 
     commands=()
     commands+=("add")
+    commands+=("bundle")
     commands+=("change-status")
     commands+=("delete")
     commands+=("export")


### PR DESCRIPTION
## Purpose
Introduce the apictl bundle command to archive an API, API product or application project. The bundle file name will be `<project_Name>_<project_version>_<revision_number>.zip` from the api_meta.yaml|api_product_meta.yaml|application_meta.yaml file. If meta file is not found, the source directory name will be used.


## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/578

## Approach
#### **Command**

> _**apictl bundle [flags]**_


#### Examples

`apictl bundle -s /User/apis/dev/API1-1 -d /User/apis/prod/`




