### PR TITLE
Add command to update HashiCorp secretId in MI

### DIFF
--- a/import-export-cli/cmd/mi/update/hashiCorpVault.go
+++ b/import-export-cli/cmd/mi/update/hashiCorpVault.go
@@ -1,0 +1,72 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	impl "github.com/wso2/product-apim-tooling/import-export-cli/mi/impl"
+	miUtils "github.com/wso2/product-apim-tooling/import-export-cli/mi/utils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var updateHashiCorpSecretCmdEnvironment string
+
+const updateHashiCorpSecretCmdLiteral = "hashicorp-secret [secret-id]"
+const updateHashiCorpSecretCmdShortDesc = "Update the secret ID of HashiCorp configuration in a Micro Integrator"
+
+const updateHashiCorpSecretCmdLongDesc = "Update the secret ID of the HashiCorp configuration in a Micro Integrator in the environment specified by the flag --environment, -e"
+
+var updateHashiCorpSecretCmdExamples = "To update the secret ID\n" +
+	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + updateCmdLiteral + " " + miUtils.GetTrimmedCmdLiteral(updateHashiCorpSecretCmdLiteral) + " new_secret_id -e dev\n" +
+	"NOTE: The flag (--environment (-e)) is mandatory"
+
+var updateHashiCorpSecretCmd = &cobra.Command{
+	Use:     updateHashiCorpSecretCmdLiteral,
+	Short:   updateHashiCorpSecretCmdShortDesc,
+	Long:    updateHashiCorpSecretCmdLongDesc,
+	Example: updateHashiCorpSecretCmdExamples,
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		handleUpdateHashiCorpSecretCmdArguments(args)
+	},
+}
+
+func init() {
+	UpdateCmd.AddCommand(updateHashiCorpSecretCmd)
+	updateHashiCorpSecretCmd.Flags().StringVarP(&updateHashiCorpSecretCmdEnvironment, "environment", "e", "", "Environment of the micro integrator of which the HashiCorp secret ID should be updated")
+	updateHashiCorpSecretCmd.MarkFlagRequired("environment")
+}
+
+func handleUpdateHashiCorpSecretCmdArguments(args []string) {
+	printUpdateCmdVerboseLog(miUtils.GetTrimmedCmdLiteral(updateHashiCorpSecretCmdLiteral))
+	credentials.HandleMissingCredentials(updateHashiCorpSecretCmdEnvironment)
+	executeUpdateHashiCorpSecretID(args[0])
+}
+
+func executeUpdateHashiCorpSecretID(hashiCorpSecretID string) {
+	resp, err := impl.UpdateHashiCorpSecretID(updateHashiCorpSecretCmdEnvironment, hashiCorpSecretID)
+	if err != nil {
+		fmt.Println(utils.LogPrefixError+"updating secretID of HashiCorp configuration.", err)
+	} else {
+		fmt.Println(resp)
+	}
+}

--- a/import-export-cli/cmd/mi/update/logLevel.go
+++ b/import-export-cli/cmd/mi/update/logLevel.go
@@ -70,7 +70,3 @@ func executeUpdateLogger(loggerName, logLevel string) {
 		fmt.Println(resp)
 	}
 }
-
-func printUpdateCmdVerboseLog(cmd string) {
-	utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " " + cmd + " called")
-}

--- a/import-export-cli/cmd/mi/update/update.go
+++ b/import-export-cli/cmd/mi/update/update.go
@@ -41,3 +41,7 @@ var UpdateCmd = &cobra.Command{
 		cmd.Help()
 	},
 }
+
+func printUpdateCmdVerboseLog(cmd string) {
+	utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " " + cmd + " called")
+}

--- a/import-export-cli/docs/apictl_mi_update.md
+++ b/import-export-cli/docs/apictl_mi_update.md
@@ -32,5 +32,6 @@ apictl mi update log-level org-apache-coyote DEBUG -e dev
 ### SEE ALSO
 
 * [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
+* [apictl mi update hashicorp-secret](apictl_mi_update_hashicorp-secret.md)	 - Update the secret ID of HashiCorp configuration in a Micro Integrator
 * [apictl mi update log-level](apictl_mi_update_log-level.md)	 - Update log level of a Logger in a Micro Integrator
 

--- a/import-export-cli/docs/apictl_mi_update_hashicorp-secret.md
+++ b/import-export-cli/docs/apictl_mi_update_hashicorp-secret.md
@@ -1,0 +1,38 @@
+## apictl mi update hashicorp-secret
+
+Update the secret ID of HashiCorp configuration in a Micro Integrator
+
+### Synopsis
+
+Update the secret ID of the HashiCorp configuration in a Micro Integrator in the environment specified by the flag --environment, -e
+
+```
+apictl mi update hashicorp-secret [secret-id] [flags]
+```
+
+### Examples
+
+```
+To update the secret ID
+  apictl mi update hashicorp-secret new_secret_id -e dev
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the micro integrator of which the HashiCorp secret ID should be updated
+  -h, --help                 help for hashicorp-secret
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl mi update](apictl_mi_update.md)	 - Update log level of Loggers in a Micro Integrator instance
+

--- a/import-export-cli/mi/impl/common.go
+++ b/import-export-cli/mi/impl/common.go
@@ -110,10 +110,10 @@ func handleResponse(resp *resty.Response, err error, url, messageTag, errorTag s
 		return "", errors.New(resp.Status())
 	}
 	data := unmarshalJSONToStringMap(resp.Body())
-	if resp.StatusCode() == http.StatusOK {
+	if data[messageTag] != "" {
 		return data[messageTag], nil
 	}
-	return data[errorTag], errors.New(resp.Status())
+	return "", errors.New(data[errorTag])
 }
 
 func retryHTTPCall(attempts int, env string, f func(string) (*resty.Response, error)) (*resty.Response, error) {

--- a/import-export-cli/mi/impl/endpoint.go
+++ b/import-export-cli/mi/impl/endpoint.go
@@ -34,9 +34,5 @@ func DeactivateEndpoint(env, endpointName string) (interface{}, error) {
 
 func updateEndpointState(env, endpointName, state string) (interface{}, error) {
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementEndpointResource, env, utils.MainConfigFilePath)
-	resp, err := updateArtifactState(url, endpointName, state, env)
-	if err != nil {
-		return nil, createErrorWithResponseBody(resp, err)
-	}
-	return resp, nil
+	return updateArtifactState(url, endpointName, state, env)
 }

--- a/import-export-cli/mi/impl/hashiCorpVault.go
+++ b/import-export-cli/mi/impl/hashiCorpVault.go
@@ -22,17 +22,15 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-// ActivateProxy activates a proxy service deployed in the micro integrator in a given environment
-func ActivateProxy(env, proxyName string) (interface{}, error) {
-	return updateProxySerivceState(env, proxyName, "active")
+// UpdateHashiCorpSecretID updates the secretID of the HashiCorp vault configuration in the micro integrator in a given environment
+func UpdateHashiCorpSecretID(env, secretID string) (interface{}, error) {
+	body := `{"secretId":"` + secretID + `"}`
+	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementExternalVaultsResource, env, utils.MainConfigFilePath) + "/" +
+		utils.MiManagementExternalVaultHashiCorpResource
+	return updateHarshiCorpSecret(env, url, body)
 }
 
-// DeactivateProxy deactivates a proxy service deployed in the micro integrator in a given environment
-func DeactivateProxy(env, proxyName string) (interface{}, error) {
-	return updateProxySerivceState(env, proxyName, "inactive")
-}
-
-func updateProxySerivceState(env, proxyName, state string) (interface{}, error) {
-	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementProxyServiceResource, env, utils.MainConfigFilePath)
-	return updateArtifactState(url, proxyName, state, env)
+func updateHarshiCorpSecret(env, url, body string) (string, error) {
+	resp, err := invokePOSTRequestWithRetry(env, url, body)
+	return handleResponse(resp, err, url, "Message", "Error")
 }

--- a/import-export-cli/mi/impl/logger.go
+++ b/import-export-cli/mi/impl/logger.go
@@ -30,11 +30,7 @@ func AddMILogger(env, loggerName, logClass, loggingLevel string) (interface{}, e
 	putNonEmptyValueToMap(body, "loggerClass", logClass)
 
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementLoggingResource, env, utils.MainConfigFilePath)
-	resp, err := addNewMILogger(url, body, env)
-	if err != nil {
-		return nil, createErrorWithResponseBody(resp, err)
-	}
-	return resp, nil
+	return addNewMILogger(url, body, env)
 }
 
 // UpdateMILogger update the log level to loggingLevel of the logger with name loggerName in the micro integrator in a given environment

--- a/import-export-cli/mi/impl/messageProcessor.go
+++ b/import-export-cli/mi/impl/messageProcessor.go
@@ -34,9 +34,5 @@ func DeactivateMessageProcessor(env, messageProcessorName string) (interface{}, 
 
 func updateMessageProcessorSerivceState(env, messageProcessorName, state string) (interface{}, error) {
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementMessageProcessorResource, env, utils.MainConfigFilePath)
-	resp, err := updateArtifactState(url, messageProcessorName, state, env)
-	if err != nil {
-		return nil, createErrorWithResponseBody(resp, err)
-	}
-	return resp, nil
+	return updateArtifactState(url, messageProcessorName, state, env)
 }

--- a/import-export-cli/mi/impl/user.go
+++ b/import-export-cli/mi/impl/user.go
@@ -39,21 +39,13 @@ func AddMIUser(env, userName, password, isAdmin string) (interface{}, error) {
 		IsAdmin:  isAdmin,
 	}
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementUserResource, env, utils.MainConfigFilePath)
-	resp, err := addNewMIUser(env, url, body)
-	if err != nil {
-		return nil, createErrorWithResponseBody(resp, err)
-	}
-	return resp, nil
+	return addNewMIUser(env, url, body)
 }
 
 // DeleteMIUser deletes a user from a micro integrator in a given environment
 func DeleteMIUser(env, userName string) (interface{}, error) {
 	url := utils.GetMIManagementEndpointOfResource(utils.MiManagementUserResource, env, utils.MainConfigFilePath) + "/" + userName
-	resp, err := deleteMIUser(url, env)
-	if err != nil {
-		return nil, createErrorWithResponseBody(resp, err)
-	}
-	return resp, nil
+	return deleteMIUser(url, env)
 }
 
 func addNewMIUser(env, url string, body interface{}) (string, error) {

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -726,6 +726,15 @@
 </code></pre>
     </li>
     <li>
+        <h4 id="mi-update-hashicorp">mi update hashicorp-secret [secret-id]</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required:
+              --environment, -e
+      Examples:
+          apictl mi update hashicorp-secret secret_id -e dev
+</code></pre>
+    </li>
+    <li>
         <h4 id="mi-delete-user">mi delete user [user-name]</h4>
         <pre><code class="lang-bash">      Flags:
           Required:

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -4150,6 +4150,41 @@ _apictl_mi_logout()
     noun_aliases=()
 }
 
+_apictl_mi_update_hashicorp-secret()
+{
+    last_command="apictl_mi_update_hashicorp-secret"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_mi_update_help()
 {
     last_command="apictl_mi_update_help"
@@ -4216,6 +4251,7 @@ _apictl_mi_update()
     command_aliases=()
 
     commands=()
+    commands+=("hashicorp-secret")
     commands+=("help")
     commands+=("log-level")
 

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -211,5 +211,7 @@ const MiManagementUserResource = "users"
 const MiManagementTransactionResource = "transactions"
 const MiManagementTransactionCountResource = "count"
 const MiManagementTransactionReportResource = "report"
+const MiManagementExternalVaultsResource = "external-vaults"
+const MiManagementExternalVaultHashiCorpResource = "hashicorp"
 
 const ZipFileSuffix = ".zip"


### PR DESCRIPTION
## Purpose
Update MI CLI tool and merge with APICTL
wso2/micro-integrator#1999

## Goals
- Add a new command as mi update hashicorp-secret

## User stories
- To update the secret ID of HashiCorp configuration
`apictl mi update hashicorp-secret <secret_id>`


## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64