### PR TITLE
Fixes #586

### DIFF
--- a/import-export-cli/credentials/miCredentials.go
+++ b/import-export-cli/credentials/miCredentials.go
@@ -141,7 +141,10 @@ func RevokeAccessTokenForMI(env, token string) error {
 
 // RunMILogin prompt user to input MI management API username and password
 func RunMILogin(store Store, environment, username, password string) error {
-
+	if !utils.MIExistsInEnv(environment, utils.MainConfigFilePath) {
+		fmt.Println("MI does not exists in", environment, "Add it using add env")
+		os.Exit(1)
+	}
 	if username == "" {
 		fmt.Print("Username:")
 		scanner := bufio.NewScanner(os.Stdin)


### PR DESCRIPTION
## Purpose
Fixes #586

## Goals
Check wether there is a micro integrator in the environment when the mi login command is called

## User stories
Show the error message `MI does not exists in abc Add it using add env` instead of `Error occurred while login :  Get "//%2Fmanagement%2Flogin/management/login"`

## Test environment
Ubuntu 20.04.1 LTS
Go version go1.15 linux/amd64