### PR TITLE
Added the deploy and undeploy commands

### DIFF
--- a/import-export-cli/cmd/deploy.go
+++ b/import-export-cli/cmd/deploy.go
@@ -30,9 +30,9 @@ const deployCmdShortDesc = "Deploy an API/API Product in a gateway environment"
 const deployCmdLongDesc = `Deploy an API/API Product available in the environment specified by flag (--environment, -e)
 to the gateway specified by flag (--gateway, -g)`
 
-const deployCmdExamples = utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
-` + utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -e dev
-` + utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n LeasingAPIProduct -e dev`
+const deployCmdExamples = utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 -e dev
+` + utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 Label2 Label3 -e production
+` + utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 2 -r admin -g Label1 -e production --hide-on-devportal`
 
 // DeployCmd represents the deploy command
 var DeployCmd = &cobra.Command{

--- a/import-export-cli/cmd/deploy.go
+++ b/import-export-cli/cmd/deploy.go
@@ -1,0 +1,52 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Deploy command related usage Info
+const DeployCmdLiteral = "deploy"
+const deployCmdShortDesc = "Deploy an API/API Product in a gateway environment"
+
+const deployCmdLongDesc = `Deploy an API/API Product available in the environment specified by flag (--environment, -e)
+to the gateway specified by flag (--gateway, -g)`
+
+const deployCmdExamples = utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -e dev
+` + utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n LeasingAPIProduct -e dev`
+
+// DeployCmd represents the deploy command
+var DeployCmd = &cobra.Command{
+	Use:     DeployCmdLiteral,
+	Short:   deployCmdShortDesc,
+	Long:    deployCmdLongDesc,
+	Example: deployCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + DeployCmdLiteral + " called")
+
+	},
+}
+
+// init using Cobra
+func init() {
+	RootCmd.AddCommand(DeployCmd)
+}

--- a/import-export-cli/cmd/deployAPI.go
+++ b/import-export-cli/cmd/deployAPI.go
@@ -1,0 +1,94 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var deployAPIName string
+var deployAPIVersion string
+var deployRevisionNum string
+var deployProvider string
+var deployAPIEnvironment string
+var deployAPIGateway string
+
+// DeployAPI command related usage info
+const DeployAPICmdLiteral = "api"
+const deployAPICmdShortDesc = "Deploy API"
+
+const deployAPICmdLongDesc = "Deploy an API to the given gateway environment"
+
+const deployAPICmdExamples = utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -g Label1 -e dev
+` + utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 6 -r admin -g Label1 -e production
+` + utils.ProjectName + ` ` + DeployCmdLiteral + ` ` + DeployAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 2 -r admin -g Label1 -e production
+NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e) --gateway (-g) ) are mandatory. 
+If --rev is not provided, working copy of the API will create a new revision and deploy to the provided gateway.`
+
+// DeployAPICmd represents the deploy API command
+var DeployAPICmd = &cobra.Command{
+	Use: DeployAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> " +
+		"--gateway <gateway-environment> --environment <environment-from-which-the-api-should-be-deployed>)",
+	Short:   deployAPICmdShortDesc,
+	Long:    deployAPICmdLongDesc,
+	Example: deployAPICmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + ExportAPICmdLiteral + " called")
+		if exportRevisionNum == "" {
+			fmt.Println("A Revision number is not provided. Working copy will be deployed to the gateway.")
+		}
+
+		cred, err := GetCredentials(CmdExportEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+
+		executeDeployAPICmd(cred)
+	},
+}
+
+func executeDeployAPICmd(credential credentials.Credential) {
+
+}
+
+// init using Cobra
+func init() {
+	DeployCmd.AddCommand(DeployAPICmd)
+	DeployAPICmd.Flags().StringVarP(&deployAPIName, "name", "n", "",
+		"Name of the API to be exported")
+	DeployAPICmd.Flags().StringVarP(&deployAPIVersion, "version", "v", "",
+		"Version of the API to be exported")
+	DeployAPICmd.Flags().StringVarP(&deployProvider, "provider", "r", "",
+		"Provider of the API")
+	DeployAPICmd.Flags().StringVarP(&deployAPIGateway, "gateway", "g", "",
+		"Gateway which the API has to be deployed")
+	DeployAPICmd.Flags().StringVarP(&deployRevisionNum, "rev", "", "",
+		"Revision number of the API to be exported")
+	DeployAPICmd.Flags().StringVarP(&deployAPIEnvironment, "environment", "e",
+		"", "Environment to which the API should be deployed")
+	_ = ExportAPICmd.MarkFlagRequired("name")
+	_ = ExportAPICmd.MarkFlagRequired("version")
+	_ = ExportAPICmd.MarkFlagRequired("gateway")
+	_ = ExportAPICmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/undeploy.go
+++ b/import-export-cli/cmd/undeploy.go
@@ -1,0 +1,52 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Undeploy command related usage Info
+const UndeployCmdLiteral = "undeploy"
+const undeployCmdShortDesc = "Undeploy an API/API Product from a gateway environment"
+
+const undeployCmdLongDesc = `Undeploy an API/API Product available in the environment specified by flag (--environment, -e)
+from the gateway specified by flag (--gateway, -g)`
+
+const undeployCmdExamples = utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -g Label1 Label2 -e dev
+` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -e dev
+` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n LeasingAPIProduct -e dev`
+
+// UndeployCmd represents the undeploy command
+var UndeployCmd = &cobra.Command{
+	Use:     UndeployCmdLiteral,
+	Short:   undeployCmdShortDesc,
+	Long:    undeployCmdLongDesc,
+	Example: undeployCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + DeployCmdLiteral + " called")
+
+	},
+}
+
+// init using Cobra
+func init() {
+	RootCmd.AddCommand(UndeployCmd)
+}

--- a/import-export-cli/cmd/undeployAPI.go
+++ b/import-export-cli/cmd/undeployAPI.go
@@ -95,7 +95,6 @@ func executeUndeployAPICmd(credential credentials.Credential, deployments []util
 
 }
 
-
 // init using Cobra
 func init() {
 	UndeployCmd.AddCommand(UndeployAPICmd)

--- a/import-export-cli/cmd/undeployAPI.go
+++ b/import-export-cli/cmd/undeployAPI.go
@@ -1,0 +1,120 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"net/http"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var undeployAPIName string
+var undeployAPIVersion string
+var undeployRevisionNum string
+var undeployProvider string
+var undeployAPIEnvironment string
+var undeployAPIGateway string
+var undeployAllGateways bool
+
+// UndeployAPICmd command related usage info
+const UndeployAPICmdLiteral = "api"
+const undeployAPICmdShortDesc = "Undeploy API"
+
+const undeployAPICmdLongDesc = "Undeploy an API to the given gateway environment"
+
+const undeployAPICmdExamples = utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -g Label1 -e dev
+` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 6 --all-gateways -e production
+` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n FacebookAPI -v 2.1.0 --rev 2 -g Label1 -e production
+NOTE: All the 4 flags (--name (-n), --version (-v), --rev, --environment (-e) and one from --gateway (-g) or --all-gateways) are mandatory.`
+
+// UndeployAPICmd represents the deploy API command
+var UndeployAPICmd = &cobra.Command{
+	Use: UndeployAPICmdLiteral + " (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> " +
+		"--rev <revision-number-of-the-api> --gateway <gateway-environment> " +
+		"--environment <environment-from-which-the-api-should-be-undeployed>)",
+	Short:   undeployAPICmdShortDesc,
+	Long:    undeployAPICmdLongDesc,
+	Example: undeployAPICmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + UndeployAPICmdLiteral + " called")
+		if undeployAPIGateway != "" || undeployAllGateways {
+			gateways := impl.GenerateGatewayArray(args, undeployAPIGateway, true)
+
+			cred, err := GetCredentials(undeployAPIEnvironment)
+			if err != nil {
+				utils.HandleErrorAndExit("Error getting credentials", err)
+			}
+			executeUndeployAPICmd(cred, gateways)
+		} else {
+			fmt.Println("Invalid Arguments. Atleast one gateway environment or --all-gateways " +
+				"flag should be provided to undeploy the revision")
+		}
+	},
+}
+
+func executeUndeployAPICmd(credential credentials.Credential, deployments []utils.Deployment) {
+	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, undeployAPIEnvironment)
+	if preCommandErr == nil {
+		resp, err := impl.ReflectDeploymentChangeInGatewayEnv("undeploy-revision", accessToken,
+			undeployAPIEnvironment, undeployAPIName, undeployAPIVersion, undeployProvider, undeployRevisionNum, deployments,
+			undeployAllGateways)
+		if err != nil {
+			utils.HandleErrorAndExit("Error while undeploying the API", err)
+		}
+		// Print info on response
+		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
+		if resp.StatusCode() == http.StatusCreated {
+			fmt.Println(apiNameForStateChange + " API artifact successfully undeployed from the gateway!")
+		} else {
+			fmt.Println("Error while undeploying the  API: ", resp.Status(), "\n", string(resp.Body()))
+		}
+	} else {
+		fmt.Println("Error getting OAuth tokens to undeploy the API:" + preCommandErr.Error())
+	}
+
+}
+
+
+// init using Cobra
+func init() {
+	UndeployCmd.AddCommand(UndeployAPICmd)
+	UndeployAPICmd.Flags().StringVarP(&undeployAPIName, "name", "n", "",
+		"Name of the API to be exported")
+	UndeployAPICmd.Flags().StringVarP(&undeployAPIVersion, "version", "v", "",
+		"Version of the API to be exported")
+	UndeployAPICmd.Flags().StringVarP(&undeployProvider, "provider", "r", "",
+		"Provider of the API")
+	UndeployAPICmd.Flags().StringVarP(&undeployAPIGateway, "gateway", "g", "",
+		"Gateway which the revision has to be undeployed")
+	UndeployAPICmd.Flags().StringVarP(&undeployRevisionNum, "rev", "", "",
+		"Revision number of the API to undeploy")
+	UndeployAPICmd.Flags().BoolVar(&undeployAllGateways, "all-gateways", false,
+		"Undeploy the revision from all the deployed gateways at once")
+	UndeployAPICmd.Flags().StringVarP(&undeployAPIEnvironment, "environment", "e",
+		"", "Environment of which the API should be undeployed")
+	_ = UndeployAPICmd.MarkFlagRequired("name")
+	_ = UndeployAPICmd.MarkFlagRequired("version")
+	_ = UndeployAPICmd.MarkFlagRequired("rev")
+	_ = UndeployAPICmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/vcs.go
+++ b/import-export-cli/cmd/vcs.go
@@ -30,7 +30,7 @@ const vcsCmdLongDesc = `Checks status and deploys projects to the specified envi
 use this command, 'git' must be installed in the system.'`
 const vcsCmdExamples = utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsInitCmdLiteral + `
 ` + utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsStatusCmdLiteral + ` -e dev
-` + utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + deployCmdLiteral + ` -e dev`
+` + utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsDeployCmdLiteral + ` -e dev`
 
 // vcsCmd represents the vcs command
 var VCSCmd = &cobra.Command{

--- a/import-export-cli/cmd/vcsDeploy.go
+++ b/import-export-cli/cmd/vcsDeploy.go
@@ -32,24 +32,24 @@ var flagVCSDeployEnvName string    // name of the environment the project change
 var flagVCSDeploySkipRollback bool // specifies whether rolling back on error needs to be avoided
 
 // deploy command related usage Info
-const deployCmdLiteral = "deploy"
-const deployCmdShortDesc = "Deploys projects to the specified environment"
-const deployCmdLongDesc = `Deploys projects to the specified environment specified by --environment(-e). 
+const vcsDeployCmdLiteral = "deploy"
+const vcsDeployCmdShortDesc = "Deploys projects to the specified environment"
+const vcsDeployCmdLongDesc = `Deploys projects to the specified environment specified by --environment(-e). 
 Only the changed projects compared to the revision at the last successful deployment will be deployed. 
 If any project(s) got failed during the deployment, by default, the operation will rollback the environment to the last successful state. If this needs to be avoided, use --skipRollback=true
 NOTE: --environment (-e) flag is mandatory`
 
-const deployCmdExamples = utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + deployCmdLiteral + ` -e dev
-` + utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + deployCmdLiteral + ` -e dev --skipRollback=true`
+const vcsDeployCmdExamples = utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsDeployCmdLiteral + ` -e dev
+` + utils.ProjectName + ` ` + vcsCmdLiteral + ` ` + vcsDeployCmdLiteral + ` -e dev --skipRollback=true`
 
 // deployCmd represents the deploy command
-var DeployCmd = &cobra.Command{
-	Use:     deployCmdLiteral,
-	Short:   deployCmdShortDesc,
-	Long:    deployCmdLongDesc,
-	Example: deployCmdExamples,
+var vcsDeployCmd = &cobra.Command{
+	Use:     vcsDeployCmdLiteral,
+	Short:   vcsDeployCmdShortDesc,
+	Long:    vcsDeployCmdLongDesc,
+	Example: vcsDeployCmdExamples,
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.Logln(utils.LogPrefixInfo + deployCmdLiteral + " called")
+		utils.Logln(utils.LogPrefixInfo + vcsDeployCmdLiteral + " called")
 		if !utils.EnvExistsInMainConfigFile(flagVCSDeployEnvName, utils.MainConfigFilePath) {
 			fmt.Println(flagVCSDeployEnvName, "does not exists. Add it using add env")
 			os.Exit(1)
@@ -77,12 +77,12 @@ var DeployCmd = &cobra.Command{
 }
 
 func init() {
-	VCSCmd.AddCommand(DeployCmd)
+	VCSCmd.AddCommand(vcsDeployCmd)
 
-	DeployCmd.Flags().StringVarP(&flagVCSDeployEnvName, "environment", "e", "", "Name of the "+
+	vcsDeployCmd.Flags().StringVarP(&flagVCSDeployEnvName, "environment", "e", "", "Name of the "+
 		"environment to deploy the project(s)")
-	DeployCmd.Flags().BoolVarP(&flagVCSDeploySkipRollback, "skipRollback", "", false,
+	vcsDeployCmd.Flags().BoolVarP(&flagVCSDeploySkipRollback, "skipRollback", "", false,
 		"Specifies whether rolling back to the last successful revision during an error situation should be skipped")
 
-	_ = DeployCmd.MarkFlagRequired("environment")
+	_ = vcsDeployCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -25,6 +25,7 @@ apictl [flags]
 * [apictl bundle](apictl_bundle.md)	 - Archive any source project artifact to zip format
 * [apictl change-status](apictl_change-status.md)	 - Change Status of an API
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
+* [apictl deploy](apictl_deploy.md)	 - Deploy an API/API Product in a gateway environment
 * [apictl export](apictl_export.md)	 - Export an API/API Product/Application in an environment
 * [apictl gen](apictl_gen.md)	 - Generate deployment directory for VM and K8S operator
 * [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications in an environment or Get the environments
@@ -38,6 +39,7 @@ apictl [flags]
 * [apictl remove](apictl_remove.md)	 - Remove an environment
 * [apictl secret](apictl_secret.md)	 - Manage sensitive information
 * [apictl set](apictl_set.md)	 - Set configuration parameters
+* [apictl undeploy](apictl_undeploy.md)	 - Undeploy an API/API Product from a gateway environment
 * [apictl vcs](apictl_vcs.md)	 - Checks status and deploys projects
 * [apictl version](apictl_version.md)	 - Display Version on current apictl
 

--- a/import-export-cli/docs/apictl_deploy.md
+++ b/import-export-cli/docs/apictl_deploy.md
@@ -1,0 +1,39 @@
+## apictl deploy
+
+Deploy an API/API Product in a gateway environment
+
+### Synopsis
+
+Deploy an API/API Product available in the environment specified by flag (--environment, -e)
+to the gateway specified by flag (--gateway, -g)
+
+```
+apictl deploy [flags]
+```
+
+### Examples
+
+```
+apictl deploy api -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 -e dev
+apictl deploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 Label2 Label3 -e production
+apictl export api-product -n FacebookAPI -v 2.1.0 --rev 2 -r admin -g Label1 -e production --hide-on-devportal
+```
+
+### Options
+
+```
+  -h, --help   help for deploy
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl deploy api](apictl_deploy_api.md)	 - Deploy API
+

--- a/import-export-cli/docs/apictl_deploy_api.md
+++ b/import-export-cli/docs/apictl_deploy_api.md
@@ -1,0 +1,45 @@
+## apictl deploy api
+
+Deploy API
+
+### Synopsis
+
+Deploy an API to the given gateway environment
+
+```
+apictl deploy api (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --rev <revision_number> --gateway <gateway-environment> --environment <environment-from-which-the-api-should-be-deployed>) [flags]
+```
+
+### Examples
+
+```
+apictl deploy api -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 -e dev
+apictl deploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 Label2 Label3 -e production
+apictl deploy api -n FacebookAPI -v 2.1.0 --rev 2 -r admin -g Label1 -e production --hide-on-devportal
+NOTE: All the 5 flags (--name (-n), --version (-v) , --rev and --gateway (-g) --environment (-e)) are mandatory.
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to which the API should be deployed
+  -g, --gateway string       Gateways which the revision has to be deployed
+  -h, --help                 help for api
+      --hide-on-devportal    Hide the gateway environment on devportal
+  -n, --name string          Name of the API to be deployed
+  -r, --provider string      Provider of the API
+      --rev string           Revision number of the API to be deployed
+  -v, --version string       Version of the API to be deployed
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl deploy](apictl_deploy.md)	 - Deploy an API/API Product in a gateway environment
+

--- a/import-export-cli/docs/apictl_undeploy.md
+++ b/import-export-cli/docs/apictl_undeploy.md
@@ -1,0 +1,39 @@
+## apictl undeploy
+
+Undeploy an API/API Product from a gateway environment
+
+### Synopsis
+
+Undeploy an API/API Product available in the environment specified by flag (--environment, -e)
+from the gateway specified by flag (--gateway, -g)
+
+```
+apictl undeploy [flags]
+```
+
+### Examples
+
+```
+apictl undeploy api -n TwitterAPI -v 1.0.0 -r admin -g Label1 Label2 -e dev
+apictl undeploy api -e dev
+apictl undeploy api -n LeasingAPIProduct -e dev
+```
+
+### Options
+
+```
+  -h, --help   help for undeploy
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl undeploy api](apictl_undeploy_api.md)	 - Undeploy API
+

--- a/import-export-cli/docs/apictl_undeploy_api.md
+++ b/import-export-cli/docs/apictl_undeploy_api.md
@@ -1,0 +1,45 @@
+## apictl undeploy api
+
+Undeploy API
+
+### Synopsis
+
+Undeploy an API to the given gateway environment
+
+```
+apictl undeploy api (--name <name-of-the-api> --version <version-of-the-api> --provider <provider-of-the-api> --rev <revision-number-of-the-api> --gateway <gateway-environment> --environment <environment-from-which-the-api-should-be-undeployed>) [flags]
+```
+
+### Examples
+
+```
+apictl undeploy api -n TwitterAPI -v 1.0.0 -r admin -g Label1 -e dev
+apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 6 --all-gateways -e production
+apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 2 -g Label1 -e production
+NOTE: All the 4 flags (--name (-n), --version (-v), --rev, --environment (-e) and one from --gateway (-g) or --all-gateways) are mandatory.
+```
+
+### Options
+
+```
+      --all-gateways         Undeploy the revision from all the deployed gateways at once
+  -e, --environment string   Environment of which the API should be undeployed
+  -g, --gateway string       Gateway which the revision has to be undeployed
+  -h, --help                 help for api
+  -n, --name string          Name of the API to be exported
+  -r, --provider string      Provider of the API
+      --rev string           Revision number of the API to undeploy
+  -v, --version string       Version of the API to be exported
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl undeploy](apictl_undeploy.md)	 - Undeploy an API/API Product from a gateway environment
+

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -830,6 +830,131 @@ _apictl_delete()
     noun_aliases=()
 }
 
+_apictl_deploy_api()
+{
+    last_command="apictl_deploy_api"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--gateway=")
+    two_word_flags+=("--gateway")
+    two_word_flags+=("-g")
+    local_nonpersistent_flags+=("--gateway")
+    local_nonpersistent_flags+=("--gateway=")
+    local_nonpersistent_flags+=("-g")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--hide-on-devportal")
+    local_nonpersistent_flags+=("--hide-on-devportal")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--provider=")
+    two_word_flags+=("--provider")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
+    local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
+    flags+=("--rev=")
+    two_word_flags+=("--rev")
+    local_nonpersistent_flags+=("--rev")
+    local_nonpersistent_flags+=("--rev=")
+    flags+=("--version=")
+    two_word_flags+=("--version")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+    local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--gateway=")
+    must_have_one_flag+=("-g")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--rev=")
+    must_have_one_flag+=("--version=")
+    must_have_one_flag+=("-v")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_deploy_help()
+{
+    last_command="apictl_deploy_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_deploy()
+{
+    last_command="apictl_deploy"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_export_api()
 {
     last_command="apictl_export_api"
@@ -4595,6 +4720,129 @@ _apictl_set()
     noun_aliases=()
 }
 
+_apictl_undeploy_api()
+{
+    last_command="apictl_undeploy_api"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all-gateways")
+    local_nonpersistent_flags+=("--all-gateways")
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--gateway=")
+    two_word_flags+=("--gateway")
+    two_word_flags+=("-g")
+    local_nonpersistent_flags+=("--gateway")
+    local_nonpersistent_flags+=("--gateway=")
+    local_nonpersistent_flags+=("-g")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--provider=")
+    two_word_flags+=("--provider")
+    two_word_flags+=("-r")
+    local_nonpersistent_flags+=("--provider")
+    local_nonpersistent_flags+=("--provider=")
+    local_nonpersistent_flags+=("-r")
+    flags+=("--rev=")
+    two_word_flags+=("--rev")
+    local_nonpersistent_flags+=("--rev")
+    local_nonpersistent_flags+=("--rev=")
+    flags+=("--version=")
+    two_word_flags+=("--version")
+    two_word_flags+=("-v")
+    local_nonpersistent_flags+=("--version")
+    local_nonpersistent_flags+=("--version=")
+    local_nonpersistent_flags+=("-v")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--rev=")
+    must_have_one_flag+=("--version=")
+    must_have_one_flag+=("-v")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_undeploy_help()
+{
+    last_command="apictl_undeploy_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_undeploy()
+{
+    last_command="apictl_undeploy"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_vcs_deploy()
 {
     last_command="apictl_vcs_deploy"
@@ -4791,6 +5039,7 @@ _apictl_root_command()
     commands+=("bundle")
     commands+=("change-status")
     commands+=("delete")
+    commands+=("deploy")
     commands+=("export")
     commands+=("gen")
     commands+=("get")
@@ -4805,6 +5054,7 @@ _apictl_root_command()
     commands+=("remove")
     commands+=("secret")
     commands+=("set")
+    commands+=("undeploy")
     commands+=("vcs")
     commands+=("version")
 

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -368,5 +368,6 @@ type Revisions struct {
 }
 
 type Deployment struct {
-	Name string `json:"name"`
+	Name               string `json:"name"`
+	DisplayOnDevportal bool   `json:"displayOnDevportal"`
 }


### PR DESCRIPTION
## Purpose
Added the support to deploy and undeploy revisions through ctl. This is achieved with the introduction of two commands, deploy and undeploy.

```apictl deploy api -e dev -n PizzaAPI -v 1.0.0 --rev 1```
```apictl undeploy api -e dev -n PizzaAPI -v 1.0.0 --rev 1```

Related issue: #601