### PR TITLE
Modify integration tests to be compatible with 4.0.0

### DIFF
--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -746,7 +746,7 @@ func TestDeleteApiWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
 	api = testutils.AddAPIWithoutCleaning(t, dev, adminUser, adminPassword)
 
 	// Create and Deploy Revision of the above API
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
@@ -779,13 +779,13 @@ func TestExportApisWithExportApisCommand(t *testing.T) {
 	var apisAdded = 0
 	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
 		api = testutils.AddAPI(t, dev, tenantAdminUsername, tenantAdminPassword)
-		testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
+		testutils.CreateAndDeployAPIRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 		apisAdded++
 	}
 
 	// This will be the API that will be deleted by apictl, so no need to do cleaning
 	api = testutils.AddAPIWithoutCleaning(t, dev, tenantAdminUsername, tenantAdminPassword)
-	testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
@@ -974,7 +974,7 @@ func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionWithAdminSuperTenantUse
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
 	// Create and Deploy Revision of the above API
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, adminUsername, adminPassword, api.ID)
 
@@ -1018,7 +1018,7 @@ func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionDevopsSuperTenantUser(t
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
 	// Create and Deploy Revision of the above API
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, devopsUsername, devopsPassword, api.ID)
 

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -735,12 +735,18 @@ func TestDeleteApiWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
 	adminUser := superAdminUser
 	adminPassword := superAdminPassword
 
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
 	dev := GetDevClient()
 
 	var api *apim.API
 
 	// This will be the API that will be deleted by apictl, so no need to do cleaning
 	api = testutils.AddAPIWithoutCleaning(t, dev, adminUser, adminPassword)
+
+	// Create and Deploy Revision of the above API
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
@@ -773,11 +779,13 @@ func TestExportApisWithExportApisCommand(t *testing.T) {
 	var apisAdded = 0
 	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
 		api = testutils.AddAPI(t, dev, tenantAdminUsername, tenantAdminPassword)
+		testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 		apisAdded++
 	}
 
 	// This will be the API that will be deleted by apictl, so no need to do cleaning
 	api = testutils.AddAPIWithoutCleaning(t, dev, tenantAdminUsername, tenantAdminPassword)
+	testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
@@ -957,9 +965,16 @@ func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionWithAdminSuperTenantUse
 	apiCreator := creator.UserName
 	apiCreatorPassword := creator.Password
 
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
 	dev := GetDevClient()
+
 	// Add the API to env
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	// Create and Deploy Revision of the above API
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, adminUsername, adminPassword, api.ID)
 
@@ -994,9 +1009,16 @@ func TestChangeLifeCycleStatusOfApiWithActiveSubscriptionDevopsSuperTenantUser(t
 	apiCreator := creator.UserName
 	apiCreatorPassword := creator.Password
 
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
 	dev := GetDevClient()
+
 	// Add the API to env
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	// Create and Deploy Revision of the above API
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, devopsUsername, devopsPassword, api.ID)
 

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -610,9 +610,9 @@ func (instance *Client) AddAPIProductFromJSON(t *testing.T, path string, usernam
 
 // CreateAPIRevision : Create API revision
 func (instance *Client) CreateAPIRevision(apiID string) *APIRevision {
-	apiProductsURL := instance.publisherRestURL + "/apis/" + apiID + "/revisions"
+	revisioningURL := instance.publisherRestURL + "/apis/" + apiID + "/revisions"
 
-	request := base.CreatePost(apiProductsURL, bytes.NewBuffer([]byte("{ \"description\": \"\" }")))
+	request := base.CreatePost(revisioningURL, bytes.NewBuffer([]byte("{ \"description\": \"\" }")))
 
 	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
 
@@ -632,7 +632,7 @@ func (instance *Client) CreateAPIRevision(apiID string) *APIRevision {
 
 // DeployAPIRevision : Deploy API revision
 func (instance *Client) DeployAPIRevision(t *testing.T, apiID string, revision *APIRevision) {
-	apisURL := instance.publisherRestURL + "/apis/" + apiID + "/deploy-revision"
+	deployURL := instance.publisherRestURL + "/apis/" + apiID + "/deploy-revision"
 
 	deploymentInfoArray := []APIRevisionDeployment{}
 	deploymentInfo := APIRevisionDeployment{}
@@ -647,7 +647,7 @@ func (instance *Client) DeployAPIRevision(t *testing.T, apiID string, revision *
 		t.Fatal(err)
 	}
 
-	request := base.CreatePost(apisURL, bytes.NewBuffer(data))
+	request := base.CreatePost(deployURL, bytes.NewBuffer(data))
 
 	values := url.Values{}
 	values.Add("revisionId", revision.ID)
@@ -667,9 +667,9 @@ func (instance *Client) DeployAPIRevision(t *testing.T, apiID string, revision *
 
 // CreateAPIProductRevision : Create API Product revision
 func (instance *Client) CreateAPIProductRevision(apiProductID string) *APIRevision {
-	apiProductsURL := instance.publisherRestURL + "/api-products/" + apiProductID + "/revisions"
+	revisioningURL := instance.publisherRestURL + "/api-products/" + apiProductID + "/revisions"
 
-	request := base.CreatePost(apiProductsURL, bytes.NewBuffer([]byte("{ \"description\": \"\" }")))
+	request := base.CreatePost(revisioningURL, bytes.NewBuffer([]byte("{ \"description\": \"\" }")))
 
 	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
 
@@ -689,7 +689,7 @@ func (instance *Client) CreateAPIProductRevision(apiProductID string) *APIRevisi
 
 // DeployAPIProductRevision : Deploy API Product revision
 func (instance *Client) DeployAPIProductRevision(t *testing.T, apiProductID string, revision *APIRevision) {
-	apiProductsURL := instance.publisherRestURL + "/api-products/" + apiProductID + "/deploy-revision"
+	deployURL := instance.publisherRestURL + "/api-products/" + apiProductID + "/deploy-revision"
 
 	deploymentInfoArray := []APIRevisionDeployment{}
 	deploymentInfo := APIRevisionDeployment{}
@@ -704,7 +704,7 @@ func (instance *Client) DeployAPIProductRevision(t *testing.T, apiProductID stri
 		t.Fatal(err)
 	}
 
-	request := base.CreatePost(apiProductsURL, bytes.NewBuffer(data))
+	request := base.CreatePost(deployURL, bytes.NewBuffer(data))
 
 	values := url.Values{}
 	values.Add("revisionId", revision.ID)

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -116,11 +116,13 @@ func TestExportApisWithExportApisCommandDeprecated(t *testing.T) {
 	var apisAdded = 0
 	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
 		api = testutils.AddAPI(t, dev, tenantAdminUsername, tenantAdminPassword)
+		testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 		apisAdded++
 	}
 
 	// This will be the API that will be deleted by apictl, so no need to do cleaning
 	api = testutils.AddAPIWithoutCleaning(t, dev, tenantAdminUsername, tenantAdminPassword)
+	testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
@@ -264,6 +266,8 @@ func TestGetKeysAdminSuperTenantUserDeprecated(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -116,13 +116,13 @@ func TestExportApisWithExportApisCommandDeprecated(t *testing.T) {
 	var apisAdded = 0
 	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
 		api = testutils.AddAPI(t, dev, tenantAdminUsername, tenantAdminPassword)
-		testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
+		testutils.CreateAndDeployAPIRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 		apisAdded++
 	}
 
 	// This will be the API that will be deleted by apictl, so no need to do cleaning
 	api = testutils.AddAPIWithoutCleaning(t, dev, tenantAdminUsername, tenantAdminPassword)
-	testutils.CreateAndDeployRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, tenantAdminUsername, tenantAdminPassword, api.ID)
 
 	args := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
@@ -267,7 +267,7 @@ func TestGetKeysAdminSuperTenantUserDeprecated(t *testing.T) {
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 )
 
-func TestEnvironmentSpecificParamsEndpoint(t *testing.T) {
+func TestXyz(t *testing.T) {
 	superTenantAdminUsername := superAdminUser
 	superTenantAdminPassword := superAdminPassword
 
@@ -64,6 +64,8 @@ func TestEnvironmentSpecificParamsEndpoint(t *testing.T) {
 	same := "override_with_same_value"
 	apiCopy.SetProductionURL(same)
 	importedAPICopy.SetProductionURL(same)
+	apiCopy.SetSandboxURL(same)
+	importedAPICopy.SetSandboxURL(same)
 
 	testutils.ValidateAPIsEqual(t, &apiCopy, &importedAPICopy)
 }
@@ -113,10 +115,8 @@ func TestEnvironmentSpecificParamsEndpointRetryTimeout(t *testing.T) {
 	importedAPICopy := apim.CopyAPI(importedAPI)
 
 	same := "override_with_same_value"
-	apiCopy.SetProductionURL(same)
-	importedAPICopy.SetProductionURL(same)
-	apiCopy.SetProductionConfig(map[interface{}]interface{}{})
-	importedAPICopy.SetProductionConfig(map[interface{}]interface{}{})
+	apiCopy.EndpointConfig = same
+	importedAPICopy.EndpointConfig = same
 
 	testutils.ValidateAPIsEqual(t, &apiCopy, &importedAPICopy)
 }

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 )
 
-func TestXyz(t *testing.T) {
+func TestEnvironmentSpecificParamsEndpoint(t *testing.T) {
 	superTenantAdminUsername := superAdminUser
 	superTenantAdminPassword := superAdminPassword
 

--- a/import-export-cli/integration/getkeys_test.go
+++ b/import-export-cli/integration/getkeys_test.go
@@ -81,7 +81,7 @@ func TestGetKeysAdminSuperTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
@@ -107,7 +107,7 @@ func TestGetKeysConsecutivelyAdminSuperTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
@@ -136,7 +136,7 @@ func TestGetKeysAdminTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
-	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
+	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 

--- a/import-export-cli/integration/getkeys_test.go
+++ b/import-export-cli/integration/getkeys_test.go
@@ -81,6 +81,7 @@ func TestGetKeysAdminSuperTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
@@ -106,6 +107,7 @@ func TestGetKeysConsecutivelyAdminSuperTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
@@ -134,6 +136,7 @@ func TestGetKeysAdminTenantUser(t *testing.T) {
 	dev := GetDevClient()
 
 	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.CreateAndDeployRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
 
 	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
@@ -297,6 +300,9 @@ func TestGetKeysForAPIProductAdminSuperTenantUser(t *testing.T) {
 	// Add the API Product to env1
 	apiProduct := testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
 
+	// Create and Deploy API Product Revision
+	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
+
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},
 		ApiProduct: apiProduct,
@@ -335,6 +341,9 @@ func TestGetKeysForAPIProductAdminTenantUser(t *testing.T) {
 	// Add the API Product to env1
 	apiProduct := testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
 
+	// Create and Deploy API Product Revision
+	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
+
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},
 		ApiProduct: apiProduct,
@@ -372,6 +381,9 @@ func TestGetKeysConsecutivelyForAPIProductAdminSuperTenantUser(t *testing.T) {
 
 	// Add the API Product to env1
 	apiProduct := testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+
+	// Create and Deploy API Product Revision
+	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
 
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},

--- a/import-export-cli/integration/testdata/api_params_endpoint.yaml
+++ b/import-export-cli/integration/testdata/api_params_endpoint.yaml
@@ -4,3 +4,5 @@ environments:
         endpoints:
             production:
                 url: 'https://prod.wso2.com'
+            sandbox:
+                url: 'https://sand.wso2.com'

--- a/import-export-cli/integration/testdata/api_params_security_basic.yaml
+++ b/import-export-cli/integration/testdata/api_params_security_basic.yaml
@@ -4,6 +4,8 @@ environments:
         endpoints:
             production:
                 url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
+            sandbox:
+                url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
         security:
             enabled: true
             type: basic

--- a/import-export-cli/integration/testdata/api_params_security_digest.yaml
+++ b/import-export-cli/integration/testdata/api_params_security_digest.yaml
@@ -4,6 +4,8 @@ environments:
         endpoints:
             production:
                 url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
+            sandbox:
+                url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
         security:
             enabled: true
             type: digest

--- a/import-export-cli/integration/testdata/api_params_security_false.yaml
+++ b/import-export-cli/integration/testdata/api_params_security_false.yaml
@@ -4,5 +4,7 @@ environments:
         endpoints:
             production:
                 url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
+            sandbox:
+                url: 'https://localhost:9443/am/sample/pizzashack/v1/api/'
         security:
             enabled: false

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -44,6 +44,24 @@ func AddAPIProductFromJSONWithoutCleaning(t *testing.T, client *apim.Client, use
 	return apiProduct
 }
 
+func AddAPIProductFromJSON(t *testing.T, client *apim.Client, username string, password string, apisList map[string]*apim.API) *apim.APIProduct {
+	client.Login(username, password)
+	path := "testdata/SampleAPIProduct.json"
+	doClean := true
+	id := client.AddAPIProductFromJSON(t, path, username, password, apisList, doClean)
+
+	base.WaitForIndexing()
+
+	apiProduct := client.GetAPIProduct(id)
+	return apiProduct
+}
+
+func CreateAndDeployAPIProductRevision(t *testing.T, client *apim.Client, username, password, apiProductID string) {
+	client.Login(username, password)
+	revision := client.CreateAPIProductRevision(apiProductID)
+	client.DeployAPIProductRevision(t, apiProductID, revision)
+}
+
 func getAPIProduct(t *testing.T, client *apim.Client, name string, username string, password string) *apim.APIProduct {
 	if username == adminservices.DevopsUsername {
 		client.Login(adminservices.AdminUsername, adminservices.AdminPassword)

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -43,7 +43,7 @@ func AddAPI(t *testing.T, client *apim.Client, username string, password string)
 	return api
 }
 
-func CreateAndDeployRevision(t *testing.T, client *apim.Client, username, password, apiID string) {
+func CreateAndDeployAPIRevision(t *testing.T, client *apim.Client, username, password, apiID string) {
 	client.Login(username, password)
 	revision := client.CreateAPIRevision(apiID)
 	client.DeployAPIRevision(t, apiID, revision)

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -43,6 +43,12 @@ func AddAPI(t *testing.T, client *apim.Client, username string, password string)
 	return api
 }
 
+func CreateAndDeployRevision(t *testing.T, client *apim.Client, username, password, apiID string) {
+	client.Login(username, password)
+	revision := client.CreateAPIRevision(apiID)
+	client.DeployAPIRevision(t, apiID, revision)
+}
+
 func AddAPIWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.API {
 	client.Login(username, password)
 	api := client.GenerateSampleAPIData(username)
@@ -87,18 +93,6 @@ func AddAPIFromOpenAPIDefinitionToTwoEnvs(t *testing.T, client1 *apim.Client, cl
 	api2 := client2.GetAPI(id2)
 
 	return api1, api2
-}
-
-func AddAPIProductFromJSON(t *testing.T, client *apim.Client, username string, password string, apisList map[string]*apim.API) *apim.APIProduct {
-	client.Login(username, password)
-	path := "testdata/SampleAPIProduct.json"
-	doClean := true
-	id := client.AddAPIProductFromJSON(t, path, username, password, apisList, doClean)
-
-	base.WaitForIndexing()
-
-	apiProduct := client.GetAPIProduct(id)
-	return apiProduct
 }
 
 func GetAPI(t *testing.T, client *apim.Client, name string, username string, password string) *apim.API {
@@ -402,6 +396,9 @@ func ReadAPIParams(t *testing.T, apiParamsPath string) *APIParams {
 func ValidateAPIImport(t *testing.T, args *ApiImportExportTestArgs) {
 	t.Helper()
 
+	// Add env2
+	base.SetupEnv(t, args.DestAPIM.GetEnvName(), args.DestAPIM.GetApimURL(), args.DestAPIM.GetTokenURL())
+
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
@@ -419,6 +416,9 @@ func ValidateAPIImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 func ValidateAPIImportFailure(t *testing.T, args *ApiImportExportTestArgs) {
 	t.Helper()
+
+	// Add env2
+	base.SetupEnv(t, args.DestAPIM.GetEnvName(), args.DestAPIM.GetApimURL(), args.DestAPIM.GetTokenURL())
 
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
@@ -628,7 +628,7 @@ func ImportApiFromProjectWithUpdate(t *testing.T, projectName string, client *ap
 }
 
 func ExportApisWithOneCommand(t *testing.T, args *InitTestArgs) (string, error) {
-	output, error := base.Execute(t, "export", "apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force", "--verbose")
+	output, error := base.Execute(t, "export", "apis", "-e", args.SrcAPIM.GetEnvName(), "-k", "--force", "--verbose", "--all")
 	return output, error
 }
 

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -57,7 +57,7 @@ func ListApps(t *testing.T, env string) []string {
 }
 
 func ListAppsWithOwner(t *testing.T, env string, owner string) []string {
-	response, _ := base.Execute(t, "gets", "apps", "-e", env, "-k", "--owner", owner)
+	response, _ := base.Execute(t, "get", "apps", "-e", env, "-k", "--owner", owner)
 
 	return base.GetRowsFromTableResponse(response)
 }


### PR DESCRIPTION
## Purpose
The main purpose is to add the step/functionality to create and deploy API revisions when running the tests. Apart from that, minor changes have been done to match with APIM 4.0.0 use cases.