### PR TITLE
URL encode lifecycle state action during changing the status

### DIFF
--- a/import-export-cli/impl/changeAPIStatus.go
+++ b/import-export-cli/impl/changeAPIStatus.go
@@ -19,8 +19,6 @@
 package impl
 
 import (
-	"net/url"
-
 	"github.com/go-resty/resty/v2"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
@@ -44,16 +42,20 @@ func changeAPIStatus(changeAPIStatusEndpoint, stateChangeAction, name, version, 
 	changeAPIStatusEndpoint = utils.AppendSlashToString(changeAPIStatusEndpoint)
 	apiId, err := GetAPIId(accessToken, environment, name, version, provider)
 	if err != nil {
-		utils.HandleErrorAndExit("Error while getting API Id for state change ", err)
+		utils.HandleErrorAndExit("Error while gettingurl API Id for state change ", err)
 	}
-	requestURL := changeAPIStatusEndpoint + "change-lifecycle?action=" + url.QueryEscape(stateChangeAction) + "&apiId=" + apiId
-	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", requestURL)
+	url := changeAPIStatusEndpoint + "change-lifecycle"
+	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", url)
+
+	queryParams := make(map[string]string)
+	queryParams[utils.LifeCycleAction] = stateChangeAction
+	queryParams[utils.ApiId] = apiId
+
 	headers := make(map[string]string)
 	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 
-	resp, err := utils.InvokePOSTRequest(requestURL, headers, "")
-
+	resp, err := utils.InvokePOSTRequestWithQueryParam(queryParams, url, headers, "")
 	if err != nil {
 		return nil, err
 	}

--- a/import-export-cli/impl/changeAPIStatus.go
+++ b/import-export-cli/impl/changeAPIStatus.go
@@ -42,7 +42,7 @@ func changeAPIStatus(changeAPIStatusEndpoint, stateChangeAction, name, version, 
 	changeAPIStatusEndpoint = utils.AppendSlashToString(changeAPIStatusEndpoint)
 	apiId, err := GetAPIId(accessToken, environment, name, version, provider)
 	if err != nil {
-		utils.HandleErrorAndExit("Error while gettingurl API Id for state change ", err)
+		utils.HandleErrorAndExit("Error while getting API Id for state change ", err)
 	}
 	url := changeAPIStatusEndpoint + "change-lifecycle"
 	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", url)

--- a/import-export-cli/impl/changeAPIStatus.go
+++ b/import-export-cli/impl/changeAPIStatus.go
@@ -19,6 +19,8 @@
 package impl
 
 import (
+	"net/url"
+
 	"github.com/go-resty/resty/v2"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
@@ -44,13 +46,13 @@ func changeAPIStatus(changeAPIStatusEndpoint, stateChangeAction, name, version, 
 	if err != nil {
 		utils.HandleErrorAndExit("Error while getting API Id for state change ", err)
 	}
-	url := changeAPIStatusEndpoint + "change-lifecycle?action=" + stateChangeAction + "&apiId=" + apiId
-	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", url)
+	requestURL := changeAPIStatusEndpoint + "change-lifecycle?action=" + url.QueryEscape(stateChangeAction) + "&apiId=" + apiId
+	utils.Logln(utils.LogPrefixInfo+"APIStateChange: URL:", requestURL)
 	headers := make(map[string]string)
 	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 
-	resp, err := utils.InvokePOSTRequest(url, headers, "")
+	resp, err := utils.InvokePOSTRequest(requestURL, headers, "")
 
 	if err != nil {
 		return nil, err

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -150,6 +150,8 @@ const ApiId = "apiId"
 const DefaultCliApp = "default-apictl-app"
 const DefaultTokenType = "JWT"
 
+const LifeCycleAction = "action"
+
 var ValidInitialStates = []string{"CREATED", "PUBLISHED"}
 
 var EnvReplaceFilePaths = []string{


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/638

## Goals
Encoding the lifecycle state action before sending the request to change the status of an API.

## Approach
- Earlier the request URL was like ```https://localhost:9443/api/am/publisher/v2/apis/change-lifecycle?action=Demote to Created&apiId=0097d0f5-5041-4019-b085-3c7da808137b```. This worked with ```github.com/go-resty/resty```.
- After changing to ```github.com/go-resty/resty/v2```, the function named **InvokePOSTRequestWithQueryParam** should be used to pass the query params. 

## User stories
Users can change the lifecycle state of an API without a problem.

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64