### PR TITLE
Add deployment_environments.yaml for apictl init while modifying the structures of other yaml files and the README.md

### DIFF
--- a/import-export-cli/box/resources/init/README.md
+++ b/import-export-cli/box/resources/init/README.md
@@ -4,6 +4,7 @@
 
 ```bash
 ├── api.yaml
+├── api_meta.yaml
 ├── deployment_environments.yaml
 ├── Client-certificates
 ├── Definitions

--- a/import-export-cli/box/resources/init/README.md
+++ b/import-export-cli/box/resources/init/README.md
@@ -4,6 +4,7 @@
 
 ```bash
 ├── api.yaml
+├── deployment_environments.yaml
 ├── Client-certificates
 ├── Definitions
 │   └── swagger.yaml

--- a/import-export-cli/box/resources/init/default_api.yaml
+++ b/import-export-cli/box/resources/init/default_api.yaml
@@ -1,5 +1,5 @@
 type: api
-version: v4
+version: v4.0.0
 data:
   name:
   context:

--- a/import-export-cli/box/resources/init/default_deployment_environments.yaml
+++ b/import-export-cli/box/resources/init/default_deployment_environments.yaml
@@ -1,0 +1,6 @@
+type: deployment_environments
+version: v4.0.0
+data:
+ -
+   displayOnDevportal: true
+   deploymentEnvironment: Production and Sandbox

--- a/import-export-cli/box/resources/init/sample-api.yaml
+++ b/import-export-cli/box/resources/init/sample-api.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 type: api # Type of the exported artifact using APICTL
-version: v4 # API Manager version
+version: v4.0.0 # API Manager version
 data: # Contains the meta data of the API
   name: PizzaShackAPI # Name of the API without Spaces [required] 
   description: This is a simple API for Pizza Shack online pizza delivery store. # Description of the API

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
@@ -93,10 +94,9 @@ func init() {
 		"existing API or create a new API")
 	ImportAPICmd.Flags().BoolVar(&importAPIRotateRevision, "rotate-revision", false, "Rotate the "+
 		"revisions with each update")
-	ImportAPICmd.Flags().BoolVar(&importAPISkipDeployments, "skip-deployments", false, "Update only " +
+	ImportAPICmd.Flags().BoolVar(&importAPISkipDeployments, "skip-deployments", false, "Update only "+
 		"the working copy and skip deployment steps in import")
-	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", utils.ParamFileAPI,
-		"Provide a API Manager params file")
+	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", "", "Provide a API Manager params file")
 	ImportAPICmd.Flags().BoolVarP(&importAPISkipCleanup, "skip-cleanup", "", false, "Leave "+
 		"all temporary files created during import process")
 	// Mark required flags

--- a/import-export-cli/cmd/init.go
+++ b/import-export-cli/cmd/init.go
@@ -22,11 +22,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/Jeffail/gabs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unicode"
+
+	"github.com/Jeffail/gabs"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/wso2/product-apim-tooling/import-export-cli/box"
@@ -253,6 +254,14 @@ func executeInitCmd() error {
 	apiJSONPath := filepath.Join(initCmdOutputDir, filepath.FromSlash("api.yaml"))
 	utils.Logln(utils.LogPrefixInfo + "Writing " + apiJSONPath)
 	err = ioutil.WriteFile(apiJSONPath, apiData, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	apimProjDeploymentEnvironmentsFilePath := filepath.Join(initCmdOutputDir, "deployment_environments.yaml")
+	utils.Logln(utils.LogPrefixInfo + "Writing " + apimProjDeploymentEnvironmentsFilePath)
+	deploymentEnvironments, _ := box.Get("/init/default_deployment_environments.yaml")
+	err = ioutil.WriteFile(apimProjDeploymentEnvironmentsFilePath, deploymentEnvironments, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -76,60 +76,6 @@ func resolveImportFilePath(file, defaultExportDirectory string) (string, error) 
 	return absPath, nil
 }
 
-// resolveAPIParamsPath resolves api_params.yaml path
-// First it will look at AbsolutePath of the import path (the last directory)
-// If not found it will look at current working directory
-// If a path is provided search ends looking up at that path
-func resolveAPIParamsPath(importPath, paramPath string) (string, error) {
-	utils.Logln(utils.LogPrefixInfo + "Scanning for parameters file")
-	if paramPath == utils.ParamFileAPI {
-		// look in importpath
-		if stat, err := os.Stat(importPath); err == nil && stat.IsDir() {
-			loc := filepath.Join(importPath, utils.ParamFileAPI)
-			utils.Logln(utils.LogPrefixInfo+"Scanning for", loc)
-			if info, err := os.Stat(loc); err == nil && !info.IsDir() {
-				// found api_params.yml in the importpath
-				return loc, nil
-			}
-		}
-
-		// look in the basepath of importPath
-		base := filepath.Dir(importPath)
-		fp := filepath.Join(base, utils.ParamFileAPI)
-		utils.Logln(utils.LogPrefixInfo+"Scanning for", fp)
-		if info, err := os.Stat(fp); err == nil && !info.IsDir() {
-			// found api_params.yml in the base path
-			return fp, nil
-		}
-
-		// look in the current working directory
-		wd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		utils.Logln(utils.LogPrefixInfo+"Scanning for", wd)
-		fp = filepath.Join(wd, utils.ParamFileAPI)
-		if info, err := os.Stat(fp); err == nil && !info.IsDir() {
-			// found api_params.yml in the cwd
-			return fp, nil
-		}
-
-		// no luck, it means paramPath is missing
-		return "", fmt.Errorf("could not find %s. Please check %s exists in basepath of "+
-			"import location or current working directory", utils.ParamFileAPI, utils.ParamFileAPI)
-	} else {
-		//If the environment parameters are provided in a file
-		if info, err := os.Stat(paramPath); err == nil && !info.IsDir() {
-			return paramPath, nil
-		}
-		//If the environment parameters are provided in a directory
-		if info, err := os.Stat(paramPath); err == nil && info.IsDir() {
-			return paramPath, nil
-		}
-		return "", fmt.Errorf("could not find %s", paramPath)
-	}
-}
-
 // resolveYamlOrJSON for a given filepath.
 // first it will look for the yaml file, if not will fallback for json
 // give filename without extension so resolver will resolve for file
@@ -258,14 +204,9 @@ func ImportAPI(accessOAuthToken, publisherEndpoint, importEnvironment, importPat
 		return err
 	}
 
-	utils.Logln(utils.LogPrefixInfo + "Attempting to process environment configurations directory or file")
-	paramsPath, err := resolveAPIParamsPath(resolvedAPIFilePath, apiParamsPath)
-	if err != nil && apiParamsPath != utils.ParamFileAPI && apiParamsPath != "" {
-		return err
-	}
-	if paramsPath != "" {
+	if apiParamsPath != "" {
 		//Reading API params file and add configurations into temp artifact
-		err := handleCustomizedParameters(apiFilePath, paramsPath, importEnvironment)
+		err := handleCustomizedParameters(apiFilePath, apiParamsPath, importEnvironment)
 		if err != nil {
 			return err
 		}
@@ -275,7 +216,7 @@ func ImportAPI(accessOAuthToken, publisherEndpoint, importEnvironment, importPat
 		loc := filepath.Join(apiFilePath, utils.DeploymentEnvFile)
 		utils.Logln(utils.LogPrefixInfo + "Removing the deployment environments file from " + loc)
 		err := utils.RemoveFileIfExists(loc)
-		if err!= nil {
+		if err != nil {
 			return err
 		}
 	}

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/ArtifactSet1/Doc1/document.yaml
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/ArtifactSet1/Doc1/document.yaml
@@ -1,5 +1,5 @@
 type: document
-version: v4
+version: v4.0.0
 data:
   documentId: 5d79aead-eeb3-43b9-84eb-51a965e383ed
   name: Doc1

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/ArtifactSet2/Doc2/document.yaml
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/ArtifactSet2/Doc2/document.yaml
@@ -1,5 +1,5 @@
 type: document
-version: v4
+version: v4.0.0
 data:
   documentId: 99343207-6374-4518-9ee2-91305feb2b69
   name: Doc2

--- a/import-export-cli/integration/testdata/sample-api.yaml
+++ b/import-export-cli/integration/testdata/sample-api.yaml
@@ -1,5 +1,5 @@
 type: api
-version: v4
+version: v4.0.0
 data:
   id: 28114236-515c-4f40-82e4-6a016e632008
   name: 4EBQLNWO5J3DTKXHAPI


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/637
Fixes: https://github.com/wso2/product-apim-tooling/issues/634

## Goals
Add deployment_environments.yaml for apictl init while modifying the structures of other yaml files and the README.md while also remove the consideration of the params file inside the current directory during an import.

## Approach
- Generate a default `deployment_envronment.yaml` during **_apictl init_**.
- Modified apictl init README.md by adding the `deployment_environments.yaml` and `api_meta.yaml` to the file structure.
- Modified the version "v4" to "v4.0.0" in all the .yaml files.
- Remove the code segment which considered the params file in the current directory during an API import.

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/9978

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64