### PR TITLE
Change the params file name "api_params" to "params" for APICTL tasks

### DIFF
--- a/import-export-cli/cmd/deprecated/importAPI.go
+++ b/import-export-cli/cmd/deprecated/importAPI.go
@@ -86,7 +86,7 @@ func init() {
 		"Preserve existing provider of API after importing")
 	ImportAPICmdDeprecated.Flags().BoolVar(&importAPIUpdate, "update", false, "Update an "+
 		"existing API or create a new API")
-	ImportAPICmdDeprecated.Flags().StringVarP(&importAPIParamsFile, "params", "", utils.ParamFileAPI,
+	ImportAPICmdDeprecated.Flags().StringVarP(&importAPIParamsFile, "params", "", "",
 		"Provide a API Manager params file")
 	ImportAPICmdDeprecated.Flags().BoolVarP(&importAPISkipCleanup, "skipCleanup", "", false, "Leave "+
 		"all temporary files created during import process")

--- a/import-export-cli/cmd/genDeploymentDir.go
+++ b/import-export-cli/cmd/genDeploymentDir.go
@@ -20,13 +20,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/wso2/product-apim-tooling/import-export-cli/box"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/box"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 var genDeploymentDirDestination string
@@ -39,9 +40,9 @@ const GenDeploymentDirCmdShortDesc = "Generate a sample deployment directory"
 const GenDeploymentDirCmdLongDesc = `Generate a sample deployment directory based on the provided source artifact`
 
 const GenDeploymentDirCmdExamples = utils.ProjectName + ` ` + GenCmdLiteral + ` ` + GenDeploymentDirCmdLiteral + ` ` +
-	`-s  ~/PizzaShackAPI_1.0.0.zip
+	`-s ~/PizzaShackAPI_1.0.0.zip
 ` + utils.ProjectName + ` ` + GenCmdLiteral + ` ` + GenDeploymentDirCmdLiteral + ` ` +
-	`-s  ~/PizzaShackAPI_1.0.0.zip` + ` ` + ` -d /home/Deployment_repo/Dev`
+	`-s ~/PizzaShackAPI_1.0.0.zip` + ` ` + ` -d /home/Deployment_repo/Dev`
 
 // directories to be created
 var directories = []string{
@@ -86,7 +87,7 @@ func executeGenDeploymentDirCmd() error {
 
 	// Check whether the source is existed in the given location
 	if _, err := os.Stat(genDeploymentDirSource); os.IsNotExist(err) {
-		utils.HandleErrorAndContinue("Error retrieving the source file from the given path " + sourceDirectoryPath + " ", err)
+		utils.HandleErrorAndContinue("Error retrieving the source file from the given path "+sourceDirectoryPath+" ", err)
 	}
 	// Get the source artifact name
 	deploymentDirName = filepath.Base(genDeploymentDirSource)
@@ -102,7 +103,7 @@ func executeGenDeploymentDirCmd() error {
 		deploymentDirName = strings.Trim(path[0], "/")
 
 		// extract the new source file name after unzipping into the temp directory
-		sourceDirectoryPath = filepath.Join(tempDirPath,path[0])
+		sourceDirectoryPath = filepath.Join(tempDirPath, path[0])
 	} else {
 		sourceDirectoryPath = genDeploymentDirSource
 	}

--- a/import-export-cli/cmd/genDeploymentDir.go
+++ b/import-export-cli/cmd/genDeploymentDir.go
@@ -158,9 +158,9 @@ func executeGenDeploymentDirCmd() error {
 
 	// add sample api_params.yaml file to deployment directory
 	defaultParamsContent, _ := box.Get("/sample/api_params.yaml")
-	err = ioutil.WriteFile(filepath.Join(deploymentDirPath, "api_params.yaml"), defaultParamsContent, os.ModePerm)
+	err = ioutil.WriteFile(filepath.Join(deploymentDirPath, utils.ParamFile), defaultParamsContent, os.ModePerm)
 	if err != nil {
-		utils.HandleErrorAndExit("Error creating sample api_params.yaml file", err)
+		utils.HandleErrorAndExit("Error creating sample"+utils.ParamFile+" file", err)
 	}
 
 	// Generate required directories inside the deployment directory

--- a/import-export-cli/cmd/genDeploymentDir.go
+++ b/import-export-cli/cmd/genDeploymentDir.go
@@ -87,8 +87,12 @@ func executeGenDeploymentDirCmd() error {
 
 	// Check whether the source is existed in the given location
 	if _, err := os.Stat(genDeploymentDirSource); os.IsNotExist(err) {
-		utils.HandleErrorAndContinue("Error retrieving the source file from the given path "+sourceDirectoryPath+" ", err)
+		utils.HandleErrorAndContinue("Error retrieving the source file from the given path "+sourceDirectoryPath, err)
+		if err != nil {
+			return err
+		}
 	}
+
 	// Get the source artifact name
 	deploymentDirName = filepath.Base(genDeploymentDirSource)
 	if info, err := os.Stat(genDeploymentDirSource); err == nil && !info.IsDir() {

--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -96,7 +96,8 @@ func init() {
 		"revisions with each update")
 	ImportAPICmd.Flags().BoolVar(&importAPISkipDeployments, "skip-deployments", false, "Update only "+
 		"the working copy and skip deployment steps in import")
-	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", "", "Provide a API Manager params file")
+	ImportAPICmd.Flags().StringVarP(&importAPIParamsFile, "params", "", "", "Provide an API Manager params file "+
+		"or a directory generated using \"gen deployment-dir\" command")
 	ImportAPICmd.Flags().BoolVarP(&importAPISkipCleanup, "skip-cleanup", "", false, "Leave "+
 		"all temporary files created during import process")
 	// Mark required flags

--- a/import-export-cli/docs/apictl_gen_deployment-dir.md
+++ b/import-export-cli/docs/apictl_gen_deployment-dir.md
@@ -13,8 +13,8 @@ apictl gen deployment-dir [flags]
 ### Examples
 
 ```
-apictl gen deployment-dir -s  ~/PizzaShackAPI_1.0.0.zip
-apictl gen deployment-dir -s  ~/PizzaShackAPI_1.0.0.zip  -d /home/Deployment_repo/Dev
+apictl gen deployment-dir -s ~/PizzaShackAPI_1.0.0.zip
+apictl gen deployment-dir -s ~/PizzaShackAPI_1.0.0.zip  -d /home/Deployment_repo/Dev
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_import_api.md
+++ b/import-export-cli/docs/apictl_import_api.md
@@ -26,7 +26,7 @@ NOTE: Both the flags (--file (-f) and --environment (-e)) are mandatory
   -e, --environment string   Environment from the which the API should be imported
   -f, --file string          Name of the API to be imported
   -h, --help                 help for api
-      --params string        Provide a API Manager params file (default "api_params.yaml")
+      --params string        Provide an API Manager params file or a directory generated using "gen deployment-dir" command
       --preserve-provider    Preserve existing provider of API after importing (default true)
       --rotate-revision      Rotate the revisions with each update
       --skip-cleanup         Leave all temporary files created during import process

--- a/import-export-cli/impl/common.go
+++ b/import-export-cli/impl/common.go
@@ -53,6 +53,7 @@ func ExecuteNewFileUploadRequest(uri string, params map[string]string, paramName
 	return utils.InvokePOSTRequestWithFileAndQueryParams(params, uri, headers, paramName, path)
 }
 
+// TODO Remove this after finilazing what to do with vcs command
 // Include x_params.yaml (api_params.yaml, application_params.yaml, .. ) into the sourceZipFile and create a new
 //  new Zip file in the provided targetZipFile location. paramsFile needs to be one of the supported x_params.yaml.
 //  Eg.: api_params.yaml, application_params.yaml, api_product_params.yaml
@@ -74,6 +75,7 @@ func IncludeParamsFileToZip(sourceZipFile, targetZipFile, paramsFile string) err
 	return nil
 }
 
+// TODO Remove this after finilazing what to do with vcs command
 // Creates the initial api_params.yaml/api_product_params.yaml/application_params.yaml in the given file path
 //	The targetFile will be populated with environments and default import parameters for "vcs deploy".
 func ScaffoldParams(targetFile string) error {

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -98,11 +98,6 @@ func WriteToZip(exportAPIName, exportAPIVersion, exportAPIRevisionNumber, zipLoc
 		utils.HandleErrorAndExit("Error creating dir to store zip archive: "+zipLocationPath, err)
 	}
 	exportedFinalZip := filepath.Join(zipLocationPath, zipFilename)
-	// Add api_params.yaml file inside the zip and create a new zip file in exportedFinalZip location
-	err = IncludeParamsFileToZip(tempZipFile, exportedFinalZip, utils.ParamFileAPI)
-	if err != nil {
-		utils.HandleErrorAndExit("Error creating the final zip archive", err)
-	}
 
 	// Add api_meta.yaml file inside the zip and create a new zup file in exportedFinalZip location
 	metaData := utils.MetaData{

--- a/import-export-cli/impl/exportAPIProduct.go
+++ b/import-export-cli/impl/exportAPIProduct.go
@@ -87,11 +87,6 @@ func WriteAPIProductToZip(exportAPIProductName, exportAPIProductVersion, zipLoca
 		utils.HandleErrorAndExit("Error creating dir to store zip archive: "+zipLocationPath, err)
 	}
 	exportedFinalZip := filepath.Join(zipLocationPath, zipFilename)
-	// Add api_product_params.yaml file inside the zip and create a new zip file in exportedFinalZip location
-	err = IncludeParamsFileToZip(tempZipFile, exportedFinalZip, utils.ParamFileAPIProduct)
-	if err != nil {
-		utils.HandleErrorAndExit("Error creating the final zip archive", err)
-	}
 
 	// Add api_product_meta.yaml file inside the zip and create a new zup file in exportedFinalZip location
 	metaData := utils.MetaData{

--- a/import-export-cli/impl/exportApp.go
+++ b/import-export-cli/impl/exportApp.go
@@ -85,11 +85,6 @@ func WriteApplicationToZip(exportAppName, exportAppOwner, zipLocationPath string
 	}
 
 	exportedFinalZip := filepath.Join(zipLocationPath, zipFilename)
-	// Add application_params.yaml file inside the zip and create a new zip file in exportedFinalZip location
-	err = IncludeParamsFileToZip(tempZipFile, exportedFinalZip, utils.ParamFileApplication)
-	if err != nil {
-		utils.HandleErrorAndExit("Error creating the final zip archive", err)
-	}
 
 	// Add application_meta.yaml file inside the zip and create a new zup file in exportedFinalZip location
 	metaData := utils.MetaData{

--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -205,7 +205,7 @@ func ImportAPI(accessOAuthToken, publisherEndpoint, importEnvironment, importPat
 	}
 
 	if apiParamsPath != "" {
-		//Reading API params file and add configurations into temp artifact
+		//Reading params file of the API and add configurations into temp artifact
 		err := handleCustomizedParameters(apiFilePath, apiParamsPath, importEnvironment)
 		if err != nil {
 			return err
@@ -252,7 +252,7 @@ func envParamsFileProcess(importPath, paramsPath, importEnvironment string) erro
 	if err != nil {
 		return err
 	}
-	// check whether import environment is included in api params configuration
+	// check whether import environment is included in params configuration
 	envParams := apiParams.GetEnv(importEnvironment)
 	if envParams == nil {
 		return errors.New("Environment '" + importEnvironment + "' does not exist in " + paramsPath)
@@ -332,7 +332,7 @@ func envParamsDirectoryProcess(importPath, paramsPath, importEnvironment string)
 	return nil
 }
 
-// handleCustomizedParameters handles the configurations provided with apiParams file and the resources that needs to
+// handleCustomizedParameters handles the configurations provided with params file of the API and the resources that needs to
 // transfer to server side will bundle with the artifact to be imported.
 func handleCustomizedParameters(importPath, paramsPath, importEnvironment string) error {
 	utils.Logln(utils.LogPrefixInfo+"Loading parameters from", paramsPath)
@@ -343,7 +343,7 @@ func handleCustomizedParameters(importPath, paramsPath, importEnvironment string
 			return err
 		}
 	} else {
-		utils.Logln(utils.LogPrefixInfo+"Processing Params directory", paramsPath)
+		utils.Logln(utils.LogPrefixInfo+"Processing Params in the deployment directory", paramsPath)
 		err := envParamsDirectoryProcess(importPath, paramsPath, importEnvironment)
 		if err != nil {
 			return err
@@ -353,7 +353,7 @@ func handleCustomizedParameters(importPath, paramsPath, importEnvironment string
 	return nil
 }
 
-//Process env params and create a temp env_params.yaml in temp artifact
+// Process env params and create the intermediate_params.yaml file to pass to the server
 func handleEnvParams(tempDirectory string, destDirectory string, environmentParams *params.Environment) error {
 	// read api params from external parameters file
 	envParamsJson, err := jsoniter.Marshal(environmentParams.Config)
@@ -369,7 +369,7 @@ func handleEnvParams(tempDirectory string, destDirectory string, environmentPara
 	}
 
 	//over-write the api_params.file with latest configurations
-	apiParamsPath = filepath.Join(destDirectory, "api_params.yaml")
+	apiParamsPath = filepath.Join(destDirectory, utils.ParamsIntermediateFile)
 	utils.Logln(utils.LogPrefixInfo+"Adding the Params file into", apiParamsPath)
 	err = ioutil.WriteFile(apiParamsPath, paramsContent, 0644)
 	if err != nil {

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -3,11 +3,12 @@ package params
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"gopkg.in/yaml.v2"
 )
 
 // Configuration represents endpoint config
@@ -51,7 +52,7 @@ type APIIdentifier struct {
 }
 
 type Environment struct {
-	Name string `yaml:"name"`
+	Name   string                 `yaml:"name"`
 	Config map[string]interface{} `yaml:"configs"`
 }
 
@@ -158,7 +159,7 @@ func getEnvSubstitutedFileContent(path string) (string, error) {
 // directory is provided instead of yaml file.
 //	It returns an error or a valid ApiParams
 func LoadApiParamsFromDirectory(path string) (*ApiParams, error) {
-	paramsFilePath:= filepath.Join(path,utils.ParamFileAPI)
+	paramsFilePath := filepath.Join(path, utils.ParamFile)
 	fmt.Println(paramsFilePath)
 	fileContent, err := getEnvSubstitutedFileContent(paramsFilePath)
 	if err != nil {
@@ -178,7 +179,7 @@ func LoadApiParamsFromDirectory(path string) (*ApiParams, error) {
 // directory is provided instead of yaml file.
 //	It returns an error or a valid ApiProductParams
 func LoadApiProductParamsFromDirectory(path string) (*ApiProductParams, error) {
-	paramsFilePath:= filepath.Join(path,utils.ParamFileAPIProduct)
+	paramsFilePath := filepath.Join(path, utils.ParamFileAPIProduct)
 	fileContent, err := getEnvSubstitutedFileContent(paramsFilePath)
 	if err != nil {
 		return nil, err
@@ -197,7 +198,7 @@ func LoadApiProductParamsFromDirectory(path string) (*ApiProductParams, error) {
 // directory is provided instead of yaml file.
 //	It returns an error or a valid ApplicationParams
 func LoadApplicationParamsFromDirectory(path string) (*ApplicationParams, error) {
-	paramsFilePath:= filepath.Join(path,utils.ParamFileApplication)
+	paramsFilePath := filepath.Join(path, utils.ParamFileApplication)
 	fileContent, err := getEnvSubstitutedFileContent(paramsFilePath)
 	if err != nil {
 		return nil, err
@@ -211,6 +212,7 @@ func LoadApplicationParamsFromDirectory(path string) (*ApplicationParams, error)
 
 	return apiParams, err
 }
+
 // LoadApiParamsFromFile loads an API Project configuration YAML file located in path.
 //	It returns an error or a valid ApiParams
 func LoadApiParamsFromFile(path string) (*ApiParams, error) {

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -171,6 +171,7 @@ const (
 
 // project param files
 const ParamFile = "params.yaml"
+const ParamsIntermediateFile = "intermediate_params.yaml"
 
 const (
 	ParamFileAPI         = "api_params.yaml"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -170,6 +170,8 @@ const (
 )
 
 // project param files
+const ParamFile = "params.yaml"
+
 const (
 	ParamFileAPI         = "api_params.yaml"
 	ParamFileAPIProduct  = "api_product_params.yaml"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/541

## Goals
Provide a common filename for the params file.

## Approach
- Change the params file name generated via **apictl gen deployment-dir** to **params.yaml**.
- Renamed the file name to be passed to the server internally as **intermediate_params.yaml**.
- Removed the logic of adding params file to the exported zip files.

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/9992

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64