### PR TITLE
Fixes wso2/product-apim-tooling#653

### DIFF
--- a/import-export-cli/cmd/login.go
+++ b/import-export-cli/cmd/login.go
@@ -90,8 +90,8 @@ var loginCmd = &cobra.Command{
 }
 
 func runLogin(store credentials.Store, environment, username, password string) error {
-	if !utils.EnvExistsInMainConfigFile(environment, utils.MainConfigFilePath) {
-		fmt.Println(environment, "does not exists. Add it using add env")
+	if !utils.APIMExistsInEnv(environment, utils.MainConfigFilePath) {
+		fmt.Println("APIM does not exists in", environment, "Add it using add env")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-apim-tooling/issues/653

## Goals
Instead of the error trace, this fix will show `APIM does not exist in the specified environment`