### PR TITLE
Add integration tests for "gen deployment-dir" commands with API and API Product params with deployment directories

### DIFF
--- a/import-export-cli/cmd/exportAPIProduct.go
+++ b/import-export-cli/cmd/exportAPIProduct.go
@@ -39,7 +39,6 @@ var exportAPIProductFormat string
 var runningExportAPIProductCommand bool
 var exportAPIProductLatestRevision bool
 
-
 // ExportAPIProduct command related usage info
 const ExportAPIProductCmdLiteral = "api-product"
 const exportAPIProductCmdShortDesc = "Export API Product"
@@ -47,7 +46,7 @@ const exportAPIProductCmdShortDesc = "Export API Product"
 const exportAPIProductCmdLongDesc = "Export an API Product in an environment"
 
 const exportAPIProductCmdExamples = utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n LeasingAPIProduct -e dev
-` + utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n CreditAPIProduct -v 1.0.0 -r admin -e production
+` + utils.ProjectName + ` ` + ExportCmdLiteral + ` ` + ExportAPIProductCmdLiteral + ` -n CreditAPIProduct -r admin -e production
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory`
 
 // ExportAPIProductCmd represents the exportAPIProduct command
@@ -80,7 +79,7 @@ func executeExportAPIProductCmd(credential credentials.Credential, exportDirecto
 
 	if preCommandErr == nil {
 		if exportAPIProductVersion == "" {
-			// If the user has not specified the version, use the version as 1.0.0
+			// Since the user cannot specify the version, use the version as 1.0.0
 			exportAPIProductVersion = utils.DefaultApiProductVersion
 		}
 		resp, err := impl.ExportAPIProductFromEnv(accessToken, exportAPIProductName, exportAPIProductVersion,

--- a/import-export-cli/cmd/genDeploymentDir.go
+++ b/import-export-cli/cmd/genDeploymentDir.go
@@ -55,7 +55,7 @@ const GenDeploymentDirCmdExamples = utils.ProjectName + ` ` + GenCmdLiteral + ` 
 
 // directories to be created
 var directories = []string{
-	"certificates",
+	utils.DeploymentCertificatesDirectory,
 }
 
 // createDeploymentContentDirectories will create directories in current working directory
@@ -103,7 +103,7 @@ func executeGenDeploymentDirCmd() error {
 	}
 
 	// Get the source artifact name
-	deploymentDirName = filepath.Base(genDeploymentDirSource)
+	deploymentDirName = utils.DeploymentDirPrefix + filepath.Base(genDeploymentDirSource)
 	if info, err := os.Stat(genDeploymentDirSource); err == nil && !info.IsDir() {
 
 		//extract zip to a temp directory
@@ -113,7 +113,7 @@ func executeGenDeploymentDirCmd() error {
 			return err
 		}
 		// if artifact is given as zip the extracted file name will contains "/" character. It should be removed
-		deploymentDirName = strings.Trim(path[0], "/")
+		deploymentDirName = utils.DeploymentDirPrefix + strings.Trim(path[0], "/")
 
 		// extract the new source file name after unzipping into the temp directory
 		sourceDirectoryPath = filepath.Join(tempDirPath, path[0])

--- a/import-export-cli/cmd/init.go
+++ b/import-export-cli/cmd/init.go
@@ -59,17 +59,17 @@ apictl init MyAwesomeAPI --oas ./swagger.yaml -d definition.yaml`
 
 // directories to be created
 var dirs = []string{
-	"Definitions",
-	"Image",
-	"Docs",
-	"Sequences",
-	"Sequences/fault-sequence",
-	"Sequences/in-sequence",
-	"Sequences/out-sequence",
-	"Client-certificates",
-	"Endpoint-certificates",
-	"Interceptors",
-	"libs",
+	utils.InitProjectDefinitions,
+	utils.InitProjectImage,
+	utils.InitProjectDocs,
+	utils.InitProjectSequences,
+	utils.InitProjectSequencesFault,
+	utils.InitProjectSequencesIn,
+	utils.InitProjectSequencesOut,
+	utils.InitProjectClientCertificates,
+	utils.InitProjectClientCertificates,
+	utils.InitProjectInterceptors,
+	utils.InitProjectLibs,
 }
 
 // createDirectories will create dirs in current working directory

--- a/import-export-cli/docs/apictl_export_api-product.md
+++ b/import-export-cli/docs/apictl_export_api-product.md
@@ -14,7 +14,7 @@ apictl export api-product (--name <name-of-the-api-product> --provider <provider
 
 ```
 apictl export api-product -n LeasingAPIProduct -e dev
-apictl export api-product -n CreditAPIProduct -v 1.0.0 -r admin -e production
+apictl export api-product -n CreditAPIProduct -r admin -e production
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory
 ```
 

--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -524,7 +524,7 @@ func TestExportImportApiProductCrossTenantUserWithImportApis(t *testing.T) {
 
 	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
 	args.CtlUser = tenantAdminUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 }
 
 // Export an API Product with its dependent APIs from one environment and import to another environment freshly as cross tenant user
@@ -554,7 +554,7 @@ func TestExportImportApiProductCrossTenantDevopsWithImportApis(t *testing.T) {
 
 	// Import the API Product with the dependent APIs to env2 as tenant user with Internal/devops role across domains
 	args.CtlUser = tenantDevopsUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 }
 
 // Export an API Product with its dependent APIs from one environment as super tenant admin and import to another environment freshly
@@ -584,7 +584,7 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApiProduct(t *testing.T)
 
 	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
 	args.CtlUser = tenantAdminUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 
 	// Set the --update-api-product flag to update the existing API Product while importing
 	// and make the importApisFlag false
@@ -622,7 +622,7 @@ func TestExportImportApiProductCrossTenantDevopsWithUpdateApiProduct(t *testing.
 
 	// Import the API Product with the dependent APIs to env2 as tenant user with Internal/devops role across domains
 	args.CtlUser = tenantDevopsUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 
 	// Set the --update-api-product flag to update the existing API Product while importing
 	// and make the importApisFlag false
@@ -661,7 +661,7 @@ func TestExportImportApiProductCrossTenantUserWithUpdateApisAndApiProduct(t *tes
 
 	// Import the API Product with the dependent APIs to env2 as tenant admin across domains
 	args.CtlUser = tenantAdminUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 
 	// Set the --update-api-product flag to update the existing API Product while importing
 	// and make the importApisFlag false
@@ -700,7 +700,7 @@ func TestExportImportApiProductCrossTenantDevopsWithUpdateApisAndApiProduct(t *t
 
 	// Import the API Product with the dependent APIs to env2 as tenant user with Internal/devops role across domains
 	args.CtlUser = tenantDevopsUser
-	testutils.ValidateAPIProductImport(t, args)
+	testutils.ValidateAPIProductImport(t, args, false)
 
 	// Set the --update-api-product flag to update the existing API Product while importing
 	// and make the importApisFlag false

--- a/import-export-cli/integration/apim/CertificatesDTO.go
+++ b/import-export-cli/integration/apim/CertificatesDTO.go
@@ -1,0 +1,31 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apim
+
+// Certificates : Certificates DTO
+type Certificates struct {
+	Count int            `json:"count"`
+	List  []CertMetadata `json:"certificates"`
+}
+
+// CertMetadata : CertMetadata DTO
+type CertMetadata struct {
+	Alias    string `json:"alias"`
+	Endpoint string `json:"endpoint"`
+}

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -1274,6 +1274,40 @@ func (instance *Client) DeleteAllAPIProducts() {
 	}
 }
 
+// RemoveAllEndpointCerts : Remove All Endpoint Certs from the Truststore
+func (instance *Client) RemoveAllEndpointCerts() {
+	apisGetURL := instance.publisherRestURL + "/endpoint-certificates"
+
+	request := base.CreateGet(apisGetURL)
+
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+	base.LogRequest("apim.RemoveAllEndpointCerts() getting Certs", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
+	base.ValidateAndLogResponse("apim.RemoveAllEndpointCerts() getting Certs", response, 200)
+
+	var certificatesResponse Certificates
+	json.NewDecoder(response.Body).Decode(&certificatesResponse)
+
+	for _, certificate := range certificatesResponse.List {
+		certificatesDeleteURL := instance.publisherRestURL + "/endpoint-certificates/" + certificate.Alias
+		request = base.CreateDelete(certificatesDeleteURL)
+
+		base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+		base.LogRequest("apim.RemoveAllEndpointCerts() deleting Certs", request)
+
+		response = base.SendHTTPRequest(request)
+		defer response.Body.Close()
+
+		base.ValidateAndLogResponse("apim.RemoveAllEndpointCerts() deleting Certs", response, 200)
+	}
+}
+
 func generateSampleAPIOperations() []APIOperations {
 	op1 := APIOperations{}
 	op1.Target = "/order/{orderId}"

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -34,6 +34,8 @@ import (
 	"time"
 
 	"log"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 // logTransport : Flag which determines if http transport level requests and responses are logged
@@ -132,7 +134,7 @@ func MILogin(t *testing.T, env string, username string, password string) {
 // IsAPIArchiveExists : Returns true if exported application archive exists on file system, else returns false
 //
 func IsAPIArchiveExists(t *testing.T, path string, name string, version string) bool {
-	file := constructAPIFilePath(path, name, version)
+	file := ConstructAPIFilePath(path, name, version)
 
 	t.Log("base.IsAPIArchiveExists() - archive file path:", file)
 
@@ -146,7 +148,7 @@ func IsAPIArchiveExists(t *testing.T, path string, name string, version string) 
 // RemoveAPIArchive : Remove exported api archive from file system
 //
 func RemoveAPIArchive(t *testing.T, path string, name string, version string) {
-	file := constructAPIFilePath(path, name, version)
+	file := ConstructAPIFilePath(path, name, version)
 
 	t.Log("base.RemoveAPIArchive() - archive file path:", file)
 
@@ -161,15 +163,21 @@ func RemoveAPIArchive(t *testing.T, path string, name string, version string) {
 
 // GetAPIArchiveFilePath : Get API archive file path
 func GetAPIArchiveFilePath(t *testing.T, path string, name string, version string) string {
-	file := constructAPIFilePath(path, name, version)
+	file := ConstructAPIFilePath(path, name, version)
 
 	t.Log("base.GetAPIArchiveFilePath() - archive file path:", file)
 
 	return file
 }
 
-func constructAPIFilePath(path string, name string, version string) string {
+// ConstructAPIFilePath : Construct API file path from name and version
+func ConstructAPIFilePath(path, name, version string) string {
 	return filepath.Join(path, name+"_"+version+".zip")
+}
+
+// ConstructAPIDeploymentDirectoryPath : Construct the deployment directory path of an API from name and version
+func ConstructAPIDeploymentDirectoryPath(path, name, version string) string {
+	return filepath.Join(path, "/", utils.DeploymentDirPrefix+name+"-"+version)
 }
 
 // IsApplicationArchiveExists : Returns true if exported application archive exists on file system, else returns false

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -3,10 +3,10 @@
 # host - host name of APIM instance  
 # offset - port offset of APIM instance
 environments:
-- name: DEVELOPMENT
+- name: development
   host: localhost
   offset: 0
-- name: PRODUCTION
+- name: production
   host: localhost
   offset: 1
 # duration tests will wait to allow APIM solr indexes to be updated

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -211,6 +211,8 @@ func TestEnvironmentSpecificParamsEndpointSecurityBasic(t *testing.T) {
 	testutils.ValidateEndpointSecurityDefinition(t, api, apiParams, importedAPI)
 }
 
+// Export an API from one environment and generate the deployment directory for that. Import it to another environment with the params
+// and certificates. Validate the imported API with the used params. Again, re-export it to validate the certs.
 func TestExportApiGenDeploymentDirImport(t *testing.T) {
 	devopsUsername := devops.UserName
 	devopsPassword := devops.Password

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -247,15 +247,15 @@ func TestExportApiGenDeploymentDirImport(t *testing.T) {
 
 	// Move dummay params file of an API to the created deployment directory
 	srcPathForParamsFile, _ := filepath.Abs(testutils.APIFullParamsFile)
-	destPathForParamsFile := args.ParamsFile + "/" + utils.ParamFile
+	destPathForParamsFile := args.ParamsFile + string(os.PathSeparator) + utils.ParamFile
 	utils.CopyFile(srcPathForParamsFile, destPathForParamsFile)
 
 	srcPathForCertificatesDirectory, _ := filepath.Abs(testutils.CertificatesDirectoryPath)
-	utils.CopyDirectoryContents(srcPathForCertificatesDirectory, args.ParamsFile+"/"+utils.DeploymentCertificatesDirectory)
+	utils.CopyDirectoryContents(srcPathForCertificatesDirectory, args.ParamsFile+string(os.PathSeparator)+utils.DeploymentCertificatesDirectory)
 
 	importedAPI := testutils.GetImportedAPI(t, args)
 
-	apiParams := testutils.ReadParams(t, args.ParamsFile+"/"+utils.ParamFile)
+	apiParams := testutils.ReadParams(t, args.ParamsFile+string(os.PathSeparator)+utils.ParamFile)
 	testutils.ValidateParamsWithoutCerts(t, apiParams, importedAPI, nil, importedAPI.Policies,
 		importedAPI.GatewayEnvironments)
 
@@ -318,15 +318,15 @@ func TestExportApiProductGenDeploymentDirImport(t *testing.T) {
 
 	// Move dummay params file of an API Product to the created deployment directory
 	srcPathForParamsFile, _ := filepath.Abs(testutils.APIProductFullParamsFile)
-	destPathForParamsFile := args.ParamsFile + "/" + utils.ParamFile
+	destPathForParamsFile := args.ParamsFile + string(os.PathSeparator) + utils.ParamFile
 	utils.CopyFile(srcPathForParamsFile, destPathForParamsFile)
 
 	srcPathForCertificatesDirectory, _ := filepath.Abs(testutils.CertificatesDirectoryPath)
-	utils.CopyDirectoryContents(srcPathForCertificatesDirectory, args.ParamsFile+"/"+utils.DeploymentCertificatesDirectory)
+	utils.CopyDirectoryContents(srcPathForCertificatesDirectory, args.ParamsFile+string(os.PathSeparator)+utils.DeploymentCertificatesDirectory)
 
 	importedAPIProduct := testutils.ValidateAPIProductImport(t, args, true)
 
-	apiProductParams := testutils.ReadParams(t, args.ParamsFile+"/"+utils.ParamFile)
+	apiProductParams := testutils.ReadParams(t, args.ParamsFile+string(os.PathSeparator)+utils.ParamFile)
 	testutils.ValidateParamsWithoutCerts(t, apiProductParams, nil, importedAPIProduct, importedAPIProduct.Policies,
 		importedAPIProduct.GatewayEnvironments)
 

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -121,7 +121,6 @@ func readConfigs() {
 	yaml.NewDecoder(reader).Decode(&yamlConfig)
 
 	for _, env := range yamlConfig.Environments {
-		resolveEnvVariables(&env)
 		envs[env.Name] = env
 	}
 
@@ -137,26 +136,6 @@ func readConfigs() {
 
 	if len(envs) != 2 {
 		base.Fatal("Expected number of Envs have not been configured for intergration tests")
-	}
-}
-
-func resolveEnvVariables(env *Environment) {
-	host := os.Getenv(env.Name + "_" + "HOST")
-
-	if host != "" {
-		env.Host = host
-	}
-
-	offset := os.Getenv(env.Name + "_" + "OFFSET")
-
-	if offset != "" {
-		value, err := strconv.Atoi(offset)
-
-		if err != nil {
-			base.Fatal(err)
-		}
-
-		env.Offset = value
 	}
 }
 

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -159,6 +159,7 @@ func cleanupAPIM() {
 	deleteApps()
 	deleteApiProducts()
 	deleteApis()
+	removeEndpointCerts()
 }
 
 func initTenants(host string, offset int) {
@@ -301,6 +302,18 @@ func deleteApiProducts() {
 		for _, client := range apimClients {
 			client.Login(tenant.AdminUserName+"@"+tenant.Domain, tenant.AdminPassword)
 			client.DeleteAllAPIProducts()
+		}
+	}
+}
+
+func removeEndpointCerts() {
+	for _, client := range apimClients {
+		client.Login(superAdminUser, superAdminPassword)
+		client.RemoveAllEndpointCerts()
+
+		for _, tenant := range tenants {
+			client.Login(tenant.AdminUserName+"@"+tenant.Domain, tenant.AdminPassword)
+			client.RemoveAllEndpointCerts()
 		}
 	}
 }

--- a/import-export-cli/integration/integration_test.go
+++ b/import-export-cli/integration/integration_test.go
@@ -80,11 +80,11 @@ var (
 )
 
 func GetDevClient() *apim.Client {
-	return apimClients["DEVELOPMENT"]
+	return apimClients["development"]
 }
 
 func GetProdClient() *apim.Client {
-	return apimClients["PRODUCTION"]
+	return apimClients["production"]
 }
 
 func TestMain(m *testing.M) {

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/alice.crt
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/alice.crt
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=FR, ST=Alsace, L=Strasbourg, O=www.freelan.org, OU=freelan, CN=Freelan Sample Certificate Authority/emailAddress=contact@freelan.org
+        Validity
+            Not Before: Apr 27 10:31:18 2012 GMT
+            Not After : Apr 25 10:31:18 2022 GMT
+        Subject: C=FR, ST=Alsace, O=www.freelan.org, OU=freelan, CN=alice/emailAddress=contact@freelan.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:dd:6d:bd:f8:80:fa:d7:de:1b:1f:a7:a3:2e:b2:
+                    02:e2:16:f6:52:0a:3c:bf:a6:42:f8:ca:dc:93:67:
+                    4d:60:c3:4f:8d:c3:8a:00:1b:f1:c4:4b:41:6a:69:
+                    d2:69:e5:3f:21:8e:c5:0b:f8:22:37:ad:b6:2c:4b:
+                    55:ff:7a:03:72:bb:9a:d3:ec:96:b9:56:9f:cb:19:
+                    99:c9:32:94:6f:8f:c6:52:06:9f:45:03:df:fd:e8:
+                    97:f6:ea:d6:ba:bb:48:2b:b5:e0:34:61:4d:52:36:
+                    0f:ab:87:52:25:03:cf:87:00:87:13:f2:ca:03:29:
+                    16:9d:90:57:46:b5:f4:0e:ae:17:c8:0a:4d:92:ed:
+                    08:a6:32:23:11:71:fe:f2:2c:44:d7:6c:07:f3:0b:
+                    7b:0c:4b:dd:3b:b4:f7:37:70:9f:51:b6:88:4e:5d:
+                    6a:05:7f:8d:9b:66:7a:ab:80:20:fe:ee:6b:97:c3:
+                    49:7d:78:3b:d5:99:97:03:75:ce:8f:bc:c5:be:9c:
+                    9a:a5:12:19:70:f9:a4:bd:96:27:ed:23:02:a7:c7:
+                    57:c9:71:cf:76:94:a2:21:62:f6:b8:1d:ca:88:ee:
+                    09:ad:46:2f:b7:61:b3:2c:15:13:86:9f:a5:35:26:
+                    5a:67:f4:37:c8:e6:80:01:49:0e:c7:ed:61:d3:cd:
+                    bc:e4:f8:be:3f:c9:4e:f8:7d:97:89:ce:12:bc:ca:
+                    b5:c6:d2:e0:d9:b3:68:3c:2e:4a:9d:b4:5f:b8:53:
+                    ee:50:3d:bf:dd:d4:a2:8a:b6:a0:27:ab:98:0c:b3:
+                    b2:58:90:e2:bc:a1:ad:ff:bd:8e:55:31:0f:00:bf:
+                    68:e9:3d:a9:19:9a:f0:6d:0b:a2:14:6a:c6:4c:c6:
+                    4e:bd:63:12:a5:0b:4d:97:eb:42:09:79:53:e2:65:
+                    aa:24:34:70:b8:c1:ab:23:80:e7:9c:6c:ed:dc:82:
+                    aa:37:04:b8:43:2a:3d:2a:a8:cc:20:fc:27:5d:90:
+                    26:58:f9:b7:14:e2:9e:e2:c1:70:73:97:e9:6b:02:
+                    8e:d3:52:59:7b:00:ec:61:30:f1:56:3f:9c:c1:7c:
+                    05:c5:b1:36:c8:18:85:cf:61:40:1f:07:e8:a7:06:
+                    87:df:9a:77:0b:a9:64:72:03:f6:93:fc:e0:02:59:
+                    c1:96:ec:c0:09:42:3e:30:a2:7f:1b:48:2f:fe:e0:
+                    21:8f:53:87:25:0d:cb:ea:49:f5:4a:9b:d0:e3:5f:
+                    ee:78:18:e5:ba:71:31:a9:04:98:0f:b1:ad:67:52:
+                    a0:f2:e3:9c:ab:6a:fe:58:84:84:dd:07:3d:32:94:
+                    05:16:45:15:96:59:a0:58:6c:18:0e:e3:77:66:c7:
+                    b3:f7:99
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            Netscape Comment: 
+                OpenSSL Generated Certificate
+            X509v3 Subject Key Identifier: 
+                59:5F:C9:13:BA:1B:CC:B9:A8:41:4A:8A:49:79:6A:36:F6:7D:3E:D7
+            X509v3 Authority Key Identifier: 
+                keyid:23:6C:2D:3D:3E:29:5D:78:B8:6C:3E:AA:E2:BB:2E:1E:6C:87:F2:53
+
+    Signature Algorithm: sha1WithRSAEncryption
+        13:e7:02:45:3e:a7:ab:bd:b8:da:e7:ef:74:88:ac:62:d5:dd:
+        10:56:d5:46:07:ec:fa:6a:80:0c:b9:62:be:aa:08:b4:be:0b:
+        eb:9a:ef:68:b7:69:6f:4d:20:92:9d:18:63:7a:23:f4:48:87:
+        6a:14:c3:91:98:1b:4e:08:59:3f:91:80:e9:f4:cf:fd:d5:bf:
+        af:4b:e4:bd:78:09:71:ac:d0:81:e5:53:9f:3e:ac:44:3e:9f:
+        f0:bf:5a:c1:70:4e:06:04:ef:dc:e8:77:05:a2:7d:c5:fa:80:
+        58:0a:c5:10:6d:90:ca:49:26:71:84:39:b7:9a:3e:e9:6f:ae:
+        c5:35:b6:5b:24:8c:c9:ef:41:c3:b1:17:b6:3b:4e:28:89:3c:
+        7e:87:a8:3a:a5:6d:dc:39:03:20:20:0b:c5:80:a3:79:13:1e:
+        f6:ec:ae:36:df:40:74:34:87:46:93:3b:a3:e0:a4:8c:2f:43:
+        4c:b2:54:80:71:76:78:d4:ea:12:28:d8:f2:e3:80:55:11:9b:
+        f4:65:dc:53:0e:b4:4c:e0:4c:09:b4:dc:a0:80:5c:e6:b5:3b:
+        95:d3:69:e4:52:3d:5b:61:86:02:e5:fd:0b:00:3a:fa:b3:45:
+        cc:c9:a3:64:f2:dc:25:59:89:58:0d:9e:6e:28:3a:55:45:50:
+        5f:88:67:2a:d2:e2:48:cc:8b:de:9a:1b:93:ae:87:e1:f2:90:
+        50:40:d9:0f:44:31:53:46:ad:62:4e:8d:48:86:19:77:fc:59:
+        75:91:79:35:59:1d:e3:4e:33:5b:e2:31:d7:ee:52:28:5f:0a:
+        70:a7:be:bb:1c:03:ca:1a:18:d0:f5:c1:5b:9c:73:04:b6:4a:
+        e8:46:52:58:76:d4:6a:e6:67:1c:0e:dc:13:d0:61:72:a0:92:
+        cb:05:97:47:1c:c1:c9:cf:41:7d:1f:b1:4d:93:6b:53:41:03:
+        21:2b:93:15:63:08:3e:2c:86:9e:7b:9f:3a:09:05:6a:7d:bb:
+        1c:a7:b7:af:96:08:cb:5b:df:07:fb:9c:f2:95:11:c0:82:81:
+        f6:1b:bf:5a:1e:58:cd:28:ca:7d:04:eb:aa:e9:29:c4:82:51:
+        2c:89:61:95:b6:ed:a5:86:7c:7c:48:1d:ec:54:96:47:79:ea:
+        fc:7f:f5:10:43:0a:9b:00:ef:8a:77:2e:f4:36:66:d2:6a:a6:
+        95:b6:9f:23:3b:12:e2:89:d5:a4:c1:2c:91:4e:cb:94:e8:3f:
+        22:0e:21:f9:b8:4a:81:5c:4c:63:ae:3d:05:b2:5c:5c:54:a7:
+        55:8f:98:25:55:c4:a6:90:bc:19:29:b1:14:d4:e2:b0:95:e4:
+        ff:89:71:61:be:8a:16:85
+-----BEGIN CERTIFICATE-----
+MIIGJzCCBA+gAwIBAgIBATANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTAzMTE4WhcNMjIwNDI1MTAz
+MTE4WjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWFsaWNl
+MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+9w0BAQEFAAOCAg8AMIICCgKCAgEA3W29+ID6194bH6ejLrIC4hb2Ugo8v6ZC+Mrc
+k2dNYMNPjcOKABvxxEtBamnSaeU/IY7FC/giN622LEtV/3oDcrua0+yWuVafyxmZ
+yTKUb4/GUgafRQPf/eiX9urWurtIK7XgNGFNUjYPq4dSJQPPhwCHE/LKAykWnZBX
+RrX0Dq4XyApNku0IpjIjEXH+8ixE12wH8wt7DEvdO7T3N3CfUbaITl1qBX+Nm2Z6
+q4Ag/u5rl8NJfXg71ZmXA3XOj7zFvpyapRIZcPmkvZYn7SMCp8dXyXHPdpSiIWL2
+uB3KiO4JrUYvt2GzLBUThp+lNSZaZ/Q3yOaAAUkOx+1h08285Pi+P8lO+H2Xic4S
+vMq1xtLg2bNoPC5KnbRfuFPuUD2/3dSiiragJ6uYDLOyWJDivKGt/72OVTEPAL9o
+6T2pGZrwbQuiFGrGTMZOvWMSpQtNl+tCCXlT4mWqJDRwuMGrI4DnnGzt3IKqNwS4
+Qyo9KqjMIPwnXZAmWPm3FOKe4sFwc5fpawKO01JZewDsYTDxVj+cwXwFxbE2yBiF
+z2FAHwfopwaH35p3C6lkcgP2k/zgAlnBluzACUI+MKJ/G0gv/uAhj1OHJQ3L6kn1
+SpvQ41/ueBjlunExqQSYD7GtZ1Kg8uOcq2r+WISE3Qc9MpQFFkUVllmgWGwYDuN3
+Zsez95kCAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFFlfyRO6G8y5qEFKikl5
+ajb2fT7XMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+DQEBBQUAA4ICAQAT5wJFPqervbja5+90iKxi1d0QVtVGB+z6aoAMuWK+qgi0vgvr
+mu9ot2lvTSCSnRhjeiP0SIdqFMORmBtOCFk/kYDp9M/91b+vS+S9eAlxrNCB5VOf
+PqxEPp/wv1rBcE4GBO/c6HcFon3F+oBYCsUQbZDKSSZxhDm3mj7pb67FNbZbJIzJ
+70HDsRe2O04oiTx+h6g6pW3cOQMgIAvFgKN5Ex727K4230B0NIdGkzuj4KSML0NM
+slSAcXZ41OoSKNjy44BVEZv0ZdxTDrRM4EwJtNyggFzmtTuV02nkUj1bYYYC5f0L
+ADr6s0XMyaNk8twlWYlYDZ5uKDpVRVBfiGcq0uJIzIvemhuTrofh8pBQQNkPRDFT
+Rq1iTo1Ihhl3/Fl1kXk1WR3jTjNb4jHX7lIoXwpwp767HAPKGhjQ9cFbnHMEtkro
+RlJYdtRq5mccDtwT0GFyoJLLBZdHHMHJz0F9H7FNk2tTQQMhK5MVYwg+LIaee586
+CQVqfbscp7evlgjLW98H+5zylRHAgoH2G79aHljNKMp9BOuq6SnEglEsiWGVtu2l
+hnx8SB3sVJZHeer8f/UQQwqbAO+Kdy70NmbSaqaVtp8jOxLiidWkwSyRTsuU6D8i
+DiH5uEqBXExjrj0FslxcVKdVj5glVcSmkLwZKbEU1OKwleT/iXFhvooWhQ==
+-----END CERTIFICATE-----

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/bob.crt
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/bob.crt
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2 (0x2)
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=FR, ST=Alsace, L=Strasbourg, O=www.freelan.org, OU=freelan, CN=Freelan Sample Certificate Authority/emailAddress=contact@freelan.org
+        Validity
+            Not Before: Apr 27 10:54:40 2012 GMT
+            Not After : Apr 25 10:54:40 2022 GMT
+        Subject: C=FR, ST=Alsace, O=www.freelan.org, OU=freelan, CN=bob/emailAddress=contact@freelan.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:c2:3f:43:14:4a:d4:dd:43:5a:b9:43:5e:2d:bb:
+                    89:a1:17:18:f7:ae:47:4b:7a:f4:d4:dc:a3:e1:b7:
+                    85:3a:10:20:eb:bc:51:18:d8:8b:25:c6:04:95:4f:
+                    80:e9:05:5c:00:f4:7c:23:7b:d1:ad:81:58:f1:9d:
+                    43:c3:37:ee:7f:61:03:b5:ff:29:bb:10:1a:fb:a8:
+                    77:97:9b:de:4c:7d:3f:ca:ff:53:8c:37:30:b6:88:
+                    f2:0e:be:7c:dc:92:76:c9:5f:22:96:19:0b:91:ea:
+                    9c:18:96:9f:43:d1:9d:22:9e:d9:c3:12:9f:80:05:
+                    85:1f:70:bb:87:5d:63:c1:5a:51:3d:7e:69:3d:76:
+                    6d:b0:56:ea:db:3f:ae:f0:cd:0c:19:48:b1:f2:d5:
+                    2e:e7:fa:12:dd:15:bc:8c:dc:09:c2:26:9c:dc:22:
+                    52:8e:c8:1c:c1:cd:01:bd:1a:24:c5:be:4f:18:08:
+                    f3:de:59:1c:8f:63:a6:63:1d:4f:5a:92:68:7a:49:
+                    94:26:54:d1:83:be:16:e4:5e:8f:73:2f:81:3a:3a:
+                    30:80:fd:57:a9:7f:1b:7b:e5:0f:6c:01:68:f7:1f:
+                    45:49:fe:06:3c:08:57:64:27:a5:0b:55:18:b7:30:
+                    be:08:45:70:8b:cd:43:ea:fc:80:1e:03:5c:c3:52:
+                    8d:a9:55:53:55:f4:61:2e:8b:50:64:6a:30:a7:6f:
+                    bd:b8:80:12:ee:66:98:d8:78:5f:a0:f5:65:6a:6d:
+                    f5:09:cc:62:4d:55:56:80:21:75:48:73:4d:b9:e3:
+                    f9:1d:96:c9:2c:5d:79:4d:3c:c5:7a:9e:84:ff:9d:
+                    c7:94:87:0a:3e:69:81:d2:7f:c0:5f:67:9c:06:8c:
+                    33:5c:a3:9f:52:e7:04:c7:d3:81:ef:b2:77:1e:d0:
+                    57:1f:1f:90:a5:69:c0:0d:43:c5:f6:a6:7e:f7:ea:
+                    45:7c:60:b6:68:1f:64:59:dc:60:33:c2:13:8c:b7:
+                    06:c2:2a:cd:cc:2b:02:de:a2:e9:70:0c:db:79:fe:
+                    ce:eb:5e:c0:06:eb:76:43:09:e0:2a:c7:ee:1e:6a:
+                    af:60:49:73:3c:a8:53:8c:e1:39:2c:e7:9e:fe:fd:
+                    44:20:f0:85:9a:1f:eb:c7:40:c8:5b:90:43:e6:a1:
+                    6a:00:50:4b:73:73:72:c5:39:77:13:1e:3c:95:be:
+                    a9:37:6a:d1:4e:34:3d:34:ec:87:f8:1e:6c:e7:dc:
+                    8b:7f:8e:d1:3c:78:c2:e2:09:93:d7:c0:68:ae:70:
+                    81:b9:f0:d0:f7:26:a4:e2:c0:12:1d:2f:01:63:eb:
+                    53:05:cb:aa:db:66:b0:fb:16:9b:e7:e7:be:c3:66:
+                    da:5c:c9
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            Netscape Comment: 
+                OpenSSL Generated Certificate
+            X509v3 Subject Key Identifier: 
+                9C:D2:71:50:35:F7:10:43:DD:E8:CE:75:29:A3:53:5D:11:A7:A8:3B
+            X509v3 Authority Key Identifier: 
+                keyid:23:6C:2D:3D:3E:29:5D:78:B8:6C:3E:AA:E2:BB:2E:1E:6C:87:F2:53
+
+    Signature Algorithm: sha1WithRSAEncryption
+        c3:b0:a4:82:f5:64:e5:4e:a0:e5:74:5e:c4:3d:d0:9c:f7:4e:
+        f7:8d:af:8b:2e:80:59:63:b5:6e:2f:10:5b:66:d6:29:2a:ca:
+        e2:01:20:68:e1:2b:ff:d6:e1:e1:f2:a6:e0:cc:f5:8f:9f:5c:
+        72:b8:fa:81:76:7d:5c:ee:60:29:e5:d7:de:8f:4a:9c:55:3e:
+        e5:27:1c:76:bc:35:e7:16:80:6f:32:77:fd:57:ae:51:87:fb:
+        be:c2:a1:cc:76:9a:61:01:c9:ff:86:00:ff:d1:96:cd:ff:2c:
+        0f:48:9e:ae:83:d8:df:d4:78:1d:4c:37:87:f5:58:5d:26:c6:
+        ca:16:cd:fa:16:1d:6f:42:ae:57:4a:99:45:52:80:5c:1c:76:
+        42:a8:f8:f3:15:9c:1b:3e:36:01:e0:09:5e:d8:19:b1:ed:a0:
+        ef:3b:c7:09:a7:aa:5f:b6:2d:c1:20:84:9b:2c:87:1a:2b:35:
+        de:9e:9c:0c:d9:0c:5e:cf:51:38:d6:d6:80:ae:91:15:b5:c6:
+        22:df:7e:17:9f:c3:eb:bf:fd:d5:3b:4b:ea:66:00:72:a0:b5:
+        b7:65:a8:5a:d9:a8:f1:67:c1:41:d8:79:dd:cc:2f:78:7a:9e:
+        5e:0a:9d:77:0e:59:52:49:d2:10:94:1c:eb:f4:3c:04:0e:3c:
+        1c:1a:75:a6:e8:23:d5:f0:73:14:90:b1:71:5a:32:57:8d:34:
+        d7:6a:61:dc:73:1a:da:1d:1f:56:a7:2e:ef:0d:a4:f5:fb:94:
+        0b:f4:cf:1d:d2:10:0f:07:cd:ba:9d:78:87:e8:04:63:6a:e5:
+        7a:6b:20:bd:bd:29:c2:39:5b:fc:86:84:77:0b:e3:f8:2c:37:
+        ac:af:1b:ed:4f:b9:d6:08:a3:ac:2f:31:07:4a:f8:8e:cf:11:
+        dd:92:1c:c9:aa:c7:a5:b7:62:a4:77:6e:58:20:78:17:cb:5e:
+        ef:6d:41:eb:b6:c2:1f:7f:a1:de:fa:bb:71:92:20:de:b1:5e:
+        34:84:6c:ed:6c:e1:43:86:13:f0:3f:d7:2d:c5:ba:c0:de:37:
+        8d:48:bc:df:c7:4f:b3:a6:a5:e5:c2:db:f1:ef:db:0c:25:69:
+        e6:58:8d:ba:72:bd:5e:3f:cf:81:36:b6:ab:ee:a8:67:8f:ee:
+        bb:fe:6f:c9:1f:8a:1f:ef:e9:c9:7a:52:40:ad:a0:3f:23:45:
+        7a:63:95:98:3d:12:b8:e2:f3:0b:88:10:38:04:68:b0:f1:a7:
+        8b:d0:61:d7:0f:2f:cf:17:51:21:eb:76:69:2d:19:e8:01:c5:
+        33:fd:61:cd:46:64:87:89:43:e9:31:d0:be:88:a0:a2:82:0c:
+        7f:9f:66:41:3a:9a:5a:6a
+-----BEGIN CERTIFICATE-----
+MIIGJTCCBA2gAwIBAgIBAjANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTA1NDQwWhcNMjIwNDI1MTA1
+NDQwWjB8MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDDAKBgNVBAMMA2JvYjEi
+MCAGCSqGSIb3DQEJARYTY29udGFjdEBmcmVlbGFuLm9yZzCCAiIwDQYJKoZIhvcN
+AQEBBQADggIPADCCAgoCggIBAMI/QxRK1N1DWrlDXi27iaEXGPeuR0t69NTco+G3
+hToQIOu8URjYiyXGBJVPgOkFXAD0fCN70a2BWPGdQ8M37n9hA7X/KbsQGvuod5eb
+3kx9P8r/U4w3MLaI8g6+fNySdslfIpYZC5HqnBiWn0PRnSKe2cMSn4AFhR9wu4dd
+Y8FaUT1+aT12bbBW6ts/rvDNDBlIsfLVLuf6Et0VvIzcCcImnNwiUo7IHMHNAb0a
+JMW+TxgI895ZHI9jpmMdT1qSaHpJlCZU0YO+FuRej3MvgTo6MID9V6l/G3vlD2wB
+aPcfRUn+BjwIV2QnpQtVGLcwvghFcIvNQ+r8gB4DXMNSjalVU1X0YS6LUGRqMKdv
+vbiAEu5mmNh4X6D1ZWpt9QnMYk1VVoAhdUhzTbnj+R2WySxdeU08xXqehP+dx5SH
+Cj5pgdJ/wF9nnAaMM1yjn1LnBMfTge+ydx7QVx8fkKVpwA1DxfamfvfqRXxgtmgf
+ZFncYDPCE4y3BsIqzcwrAt6i6XAM23n+zutewAbrdkMJ4CrH7h5qr2BJczyoU4zh
+OSznnv79RCDwhZof68dAyFuQQ+ahagBQS3NzcsU5dxMePJW+qTdq0U40PTTsh/ge
+bOfci3+O0Tx4wuIJk9fAaK5wgbnw0PcmpOLAEh0vAWPrUwXLqttmsPsWm+fnvsNm
+2lzJAgMBAAGjezB5MAkGA1UdEwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wg
+R2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBSc0nFQNfcQQ93oznUpo1Nd
+EaeoOzAfBgNVHSMEGDAWgBQjbC09PildeLhsPqriuy4ebIfyUzANBgkqhkiG9w0B
+AQUFAAOCAgEAw7CkgvVk5U6g5XRexD3QnPdO942viy6AWWO1bi8QW2bWKSrK4gEg
+aOEr/9bh4fKm4Mz1j59ccrj6gXZ9XO5gKeXX3o9KnFU+5Sccdrw15xaAbzJ3/Veu
+UYf7vsKhzHaaYQHJ/4YA/9GWzf8sD0ieroPY39R4HUw3h/VYXSbGyhbN+hYdb0Ku
+V0qZRVKAXBx2Qqj48xWcGz42AeAJXtgZse2g7zvHCaeqX7YtwSCEmyyHGis13p6c
+DNkMXs9RONbWgK6RFbXGIt9+F5/D67/91TtL6mYAcqC1t2WoWtmo8WfBQdh53cwv
+eHqeXgqddw5ZUknSEJQc6/Q8BA48HBp1pugj1fBzFJCxcVoyV40012ph3HMa2h0f
+Vqcu7w2k9fuUC/TPHdIQDwfNup14h+gEY2rlemsgvb0pwjlb/IaEdwvj+Cw3rK8b
+7U+51gijrC8xB0r4js8R3ZIcyarHpbdipHduWCB4F8te721B67bCH3+h3vq7cZIg
+3rFeNIRs7WzhQ4YT8D/XLcW6wN43jUi838dPs6al5cLb8e/bDCVp5liNunK9Xj/P
+gTa2q+6oZ4/uu/5vyR+KH+/pyXpSQK2gPyNFemOVmD0SuOLzC4gQOARosPGni9Bh
+1w8vzxdRIet2aS0Z6AHFM/1hzUZkh4lD6THQvoigooIMf59mQTqaWmo=
+-----END CERTIFICATE-----

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/carol.crt
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/certificates/carol.crt
@@ -1,0 +1,125 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 3 (0x3)
+        Signature Algorithm: sha1WithRSAEncryption
+        Issuer: C=FR, ST=Alsace, L=Strasbourg, O=www.freelan.org, OU=freelan, CN=Freelan Sample Certificate Authority/emailAddress=contact@freelan.org
+        Validity
+            Not Before: Apr 27 10:54:53 2012 GMT
+            Not After : Apr 25 10:54:53 2022 GMT
+        Subject: C=FR, ST=Alsace, O=www.freelan.org, OU=freelan, CN=carol/emailAddress=contact@freelan.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+                    00:d7:c0:a7:c6:e9:48:c4:53:40:b3:76:d9:2f:37:
+                    28:3d:a3:c4:42:d0:76:cd:08:9b:50:e3:1c:51:e5:
+                    14:72:fa:2b:a0:b1:06:23:f3:c1:ad:92:7c:79:fe:
+                    15:54:d1:e5:67:62:da:ed:81:aa:7e:e2:b1:50:a9:
+                    fb:d8:29:09:da:84:4d:3c:f4:6e:13:ab:0b:d5:ee:
+                    80:63:32:7d:57:af:83:3c:1c:27:ed:ec:67:d6:fd:
+                    1c:13:2d:40:bf:d1:da:bf:7a:b6:67:7e:b0:75:3b:
+                    6d:61:9d:cc:6c:1a:97:f1:56:de:9f:80:d3:16:60:
+                    bb:8a:6f:46:9b:be:34:75:c3:4c:d2:f1:c8:f3:3e:
+                    98:28:30:e4:cb:2d:25:61:62:48:be:2e:dc:ed:90:
+                    93:ae:74:b7:fa:49:43:65:20:ac:8e:fe:52:6c:00:
+                    8e:51:3e:b6:9a:c6:4f:44:1c:7b:84:17:bd:5c:f6:
+                    36:e9:4c:91:89:6f:4e:ad:ac:10:41:c5:c5:65:8a:
+                    20:c8:f7:27:a3:ea:ac:5b:74:09:99:27:88:60:c7:
+                    44:69:18:0c:32:1a:77:f2:47:53:46:e3:12:c5:69:
+                    95:45:15:9a:14:60:76:20:a7:b5:8c:51:bf:5a:57:
+                    19:5a:c7:a8:bc:0b:c4:30:ca:0b:e6:d0:f8:c4:a8:
+                    84:d9:24:a2:92:f6:84:f2:13:ea:a4:93:97:fe:ed:
+                    77:d8:2f:75:7a:2c:39:88:3c:44:56:0a:ef:12:57:
+                    d5:9e:8f:35:8e:7f:84:e7:1a:d1:19:8d:23:db:b5:
+                    ce:c5:7f:e1:88:6d:04:d6:01:de:f0:72:3e:51:95:
+                    1d:4f:30:b6:32:0a:0f:84:b5:00:34:e4:bf:80:71:
+                    10:62:14:c1:32:5a:a9:a6:de:c2:58:e8:52:eb:66:
+                    5a:b8:5e:c2:06:7c:a6:6a:33:f2:1e:8a:41:07:53:
+                    bb:6b:41:92:59:85:79:04:a9:df:56:4c:e0:62:1e:
+                    98:87:95:07:b1:10:49:34:9c:90:4c:0b:83:25:27:
+                    9f:01:27:fb:d0:c4:6e:50:cc:f5:02:47:2c:45:9a:
+                    31:e5:ce:7d:86:8f:db:fd:83:ea:a6:00:49:71:14:
+                    44:a1:8e:9d:ba:a4:a4:cf:9d:15:20:2d:67:76:42:
+                    81:63:a2:76:4e:4b:22:b5:de:3d:d8:f8:e0:43:7f:
+                    a3:10:f0:73:fb:6e:e1:6a:37:99:dc:87:a3:05:4c:
+                    29:f5:63:14:9b:eb:a3:3a:9b:2b:b4:51:f5:05:03:
+                    de:41:e5:cb:1a:8e:76:eb:47:93:53:90:71:c5:8f:
+                    86:5f:9e:0b:4d:33:9c:3c:88:8a:90:9f:90:a6:35:
+                    90:81:f1
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: 
+                CA:FALSE
+            Netscape Comment: 
+                OpenSSL Generated Certificate
+            X509v3 Subject Key Identifier: 
+                B5:5D:0D:4F:55:F6:75:1A:23:B3:F5:8C:BC:6B:5A:B6:96:6C:AE:E0
+            X509v3 Authority Key Identifier: 
+                keyid:23:6C:2D:3D:3E:29:5D:78:B8:6C:3E:AA:E2:BB:2E:1E:6C:87:F2:53
+
+    Signature Algorithm: sha1WithRSAEncryption
+        bf:3f:e7:16:a2:ba:b1:cf:d6:79:f3:84:ed:a5:10:3e:60:42:
+        0e:d5:1a:c6:e9:b1:39:86:5a:2e:dd:ae:b6:b7:16:33:33:17:
+        3e:83:f7:a1:f7:b4:1b:09:74:8f:9b:0d:8e:4c:c7:a1:d6:66:
+        6c:02:3a:b5:f2:72:aa:c9:e4:b3:c6:9d:6e:c0:48:dc:39:21:
+        30:18:a0:6f:cb:09:be:de:0f:63:83:04:32:73:a7:bc:42:34:
+        b7:a1:dc:21:21:08:86:65:bc:2e:c5:78:ae:fb:fe:ab:fb:8b:
+        85:bf:61:e0:e2:aa:52:5f:1e:0d:19:22:13:94:7a:b4:bd:5c:
+        30:8d:43:22:b4:e9:13:62:7e:3e:f5:e2:7a:2a:3b:da:1f:57:
+        4a:5d:b8:6c:4c:f5:6e:34:b9:bd:b4:1f:dc:88:d0:28:20:a2:
+        0c:31:e8:7f:3a:23:b8:60:48:c8:4e:e1:02:62:ae:00:fb:d0:
+        a5:76:cb:ea:f3:d7:75:0d:9e:56:48:c1:2e:44:c7:0c:9f:03:
+        b3:ac:96:c5:a2:a0:06:9e:2b:c3:eb:b5:04:15:33:79:4a:9e:
+        28:94:1d:28:50:98:e3:eb:b5:74:69:7f:69:bc:61:72:d1:8a:
+        cc:fb:89:be:51:34:81:11:7b:fa:8a:cf:e7:bf:81:91:34:1a:
+        11:63:92:41:eb:62:7d:7a:2a:5a:2b:a3:85:36:5b:39:08:40:
+        6b:0d:bc:b7:ed:36:42:60:45:ee:0c:27:f1:41:38:9e:db:99:
+        8f:0f:ff:1b:ea:02:98:9f:19:21:33:ca:a2:47:89:cb:1d:a9:
+        4c:94:b6:3d:b2:e2:bf:1d:f7:12:8d:01:ff:77:d6:72:65:70:
+        ca:80:8e:a2:2d:78:0c:b2:9d:84:3a:50:f9:e8:8e:85:03:58:
+        eb:0a:d3:5b:d3:55:d0:bd:7d:de:c8:5b:80:ea:0e:53:d6:35:
+        86:60:10:ed:bd:06:f4:59:15:64:75:4c:bd:2f:fb:8a:fa:c1:
+        d0:c2:d9:68:09:2b:9a:91:c4:00:b1:65:7d:6d:a8:c2:42:d1:
+        d7:f1:71:ae:db:96:33:e7:a9:29:27:f3:89:8d:c8:ac:87:14:
+        fa:a5:cf:ec:b6:1b:a6:03:93:d7:ef:7f:49:b0:d5:22:fe:9e:
+        5a:1b:e1:ff:e9:e3:71:fa:e9:09:3f:b4:1a:33:ae:3a:60:27:
+        d2:e6:2f:12:f4:32:54:be:29:be:fc:14:a5:2a:2d:99:88:e0:
+        9d:d0:c6:07:e1:76:fb:96:60:0e:4c:d9:93:bd:26:29:2a:8f:
+        49:d9:f6:7d:7a:bc:34:31:84:81:4f:28:e1:e8:5e:cf:45:b1:
+        c1:8a:2b:e0:52:72:5f:19
+-----BEGIN CERTIFICATE-----
+MIIGJzCCBA+gAwIBAgIBAzANBgkqhkiG9w0BAQUFADCBsjELMAkGA1UEBhMCRlIx
+DzANBgNVBAgMBkFsc2FjZTETMBEGA1UEBwwKU3RyYXNib3VyZzEYMBYGA1UECgwP
+d3d3LmZyZWVsYW4ub3JnMRAwDgYDVQQLDAdmcmVlbGFuMS0wKwYDVQQDDCRGcmVl
+bGFuIFNhbXBsZSBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkxIjAgBgkqhkiG9w0BCQEW
+E2NvbnRhY3RAZnJlZWxhbi5vcmcwHhcNMTIwNDI3MTA1NDUzWhcNMjIwNDI1MTA1
+NDUzWjB+MQswCQYDVQQGEwJGUjEPMA0GA1UECAwGQWxzYWNlMRgwFgYDVQQKDA93
+d3cuZnJlZWxhbi5vcmcxEDAOBgNVBAsMB2ZyZWVsYW4xDjAMBgNVBAMMBWNhcm9s
+MSIwIAYJKoZIhvcNAQkBFhNjb250YWN0QGZyZWVsYW4ub3JnMIICIjANBgkqhkiG
+9w0BAQEFAAOCAg8AMIICCgKCAgEA18CnxulIxFNAs3bZLzcoPaPEQtB2zQibUOMc
+UeUUcvoroLEGI/PBrZJ8ef4VVNHlZ2La7YGqfuKxUKn72CkJ2oRNPPRuE6sL1e6A
+YzJ9V6+DPBwn7exn1v0cEy1Av9Hav3q2Z36wdTttYZ3MbBqX8Vben4DTFmC7im9G
+m740dcNM0vHI8z6YKDDkyy0lYWJIvi7c7ZCTrnS3+klDZSCsjv5SbACOUT62msZP
+RBx7hBe9XPY26UyRiW9OrawQQcXFZYogyPcno+qsW3QJmSeIYMdEaRgMMhp38kdT
+RuMSxWmVRRWaFGB2IKe1jFG/WlcZWseovAvEMMoL5tD4xKiE2SSikvaE8hPqpJOX
+/u132C91eiw5iDxEVgrvElfVno81jn+E5xrRGY0j27XOxX/hiG0E1gHe8HI+UZUd
+TzC2MgoPhLUANOS/gHEQYhTBMlqppt7CWOhS62ZauF7CBnymajPyHopBB1O7a0GS
+WYV5BKnfVkzgYh6Yh5UHsRBJNJyQTAuDJSefASf70MRuUMz1AkcsRZox5c59ho/b
+/YPqpgBJcRREoY6duqSkz50VIC1ndkKBY6J2Tksitd492PjgQ3+jEPBz+27hajeZ
+3IejBUwp9WMUm+ujOpsrtFH1BQPeQeXLGo5260eTU5BxxY+GX54LTTOcPIiKkJ+Q
+pjWQgfECAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhCAQ0EHxYdT3BlblNT
+TCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFLVdDU9V9nUaI7P1jLxr
+WraWbK7gMB8GA1UdIwQYMBaAFCNsLT0+KV14uGw+quK7Lh5sh/JTMA0GCSqGSIb3
+DQEBBQUAA4ICAQC/P+cWorqxz9Z584TtpRA+YEIO1RrG6bE5hlou3a62txYzMxc+
+g/eh97QbCXSPmw2OTMeh1mZsAjq18nKqyeSzxp1uwEjcOSEwGKBvywm+3g9jgwQy
+c6e8QjS3odwhIQiGZbwuxXiu+/6r+4uFv2Hg4qpSXx4NGSITlHq0vVwwjUMitOkT
+Yn4+9eJ6KjvaH1dKXbhsTPVuNLm9tB/ciNAoIKIMMeh/OiO4YEjITuECYq4A+9Cl
+dsvq89d1DZ5WSMEuRMcMnwOzrJbFoqAGnivD67UEFTN5Sp4olB0oUJjj67V0aX9p
+vGFy0YrM+4m+UTSBEXv6is/nv4GRNBoRY5JB62J9eipaK6OFNls5CEBrDby37TZC
+YEXuDCfxQTie25mPD/8b6gKYnxkhM8qiR4nLHalMlLY9suK/HfcSjQH/d9ZyZXDK
+gI6iLXgMsp2EOlD56I6FA1jrCtNb01XQvX3eyFuA6g5T1jWGYBDtvQb0WRVkdUy9
+L/uK+sHQwtloCSuakcQAsWV9bajCQtHX8XGu25Yz56kpJ/OJjcishxT6pc/sthum
+A5PX739JsNUi/p5aG+H/6eNx+ukJP7QaM646YCfS5i8S9DJUvim+/BSlKi2ZiOCd
+0MYH4Xb7lmAOTNmTvSYpKo9J2fZ9erw0MYSBTyjh6F7PRbHBiivgUnJfGQ==
+-----END CERTIFICATE-----

--- a/import-export-cli/integration/testdata/api_params_full.yaml
+++ b/import-export-cli/integration/testdata/api_params_full.yaml
@@ -1,0 +1,30 @@
+environments:
+    - name: production
+      configs:
+        endpoints:
+            production:
+                url: https://prod.wso2.com
+            sandbox:
+                url: https://sand.wso2.com
+        security:
+            enabled: true
+            type: basic
+            username: admin
+            password: admin
+        certs:
+            - hostName: https://prod.wso2.com
+              alias: alice
+              path: alice.crt
+        mutualSslCerts:
+            - tierName: Gold
+              alias: bob
+              path: bob.crt
+            - tierName: Silver
+              alias: carol
+              path: carol.crt
+        deploymentEnvironments:
+            - displayOnDevportal: true
+              deploymentEnvironment: Production and Sandbox
+        policies:
+            - Gold
+            - Silver 

--- a/import-export-cli/integration/testdata/api_product_params_full.yaml
+++ b/import-export-cli/integration/testdata/api_product_params_full.yaml
@@ -1,0 +1,35 @@
+environments:
+    - name: production
+      configs:
+          dependentAPIs:
+              ${DEPENDENTAPI_2}:
+                  endpoints:
+                      production:
+                          url: https://prod.wso2.com
+                      sandbox:
+                          url: https://sand.wso2.com
+                  security:
+                      enabled: true
+                      type: basic
+                      username: admin
+                      password: admin
+                  certs:
+                      - hostName: https://prod.wso2.com
+                        alias: alice
+                        path: alice.crt
+                  policies:
+                      - Gold
+                      - Silver
+          deploymentEnvironments:
+              - displayOnDevportal: true
+                deploymentEnvironment: Production and Sandbox
+          mutualSslCerts:
+              - tierName: Gold
+                alias: bob
+                path: bob.crt
+              - tierName: Silver
+                alias: carol
+                path: carol.crt
+          policies:
+              - Gold
+              - Silver

--- a/import-export-cli/integration/testutils/apiParams.go
+++ b/import-export-cli/integration/testutils/apiParams.go
@@ -18,7 +18,7 @@
 
 package testutils
 
-type APIParams struct {
+type Params struct {
 	Environments []Environment `yaml:"environments"`
 }
 
@@ -34,6 +34,7 @@ type Configs struct {
 	Certs                  []Cert                   `yaml:"certs,omitempty"`
 	MsslCerts              []MsslCert               `yaml:"mutualSslCerts,omitempty"`
 	Policies               []string                 `yaml:"policies,omitempty"`
+	DependentAPIs          map[string]interface{}   `yaml:"dependentAPIs,omitempty"`
 }
 
 type DeploymentEnvironments struct {

--- a/import-export-cli/integration/testutils/apiParams.go
+++ b/import-export-cli/integration/testutils/apiParams.go
@@ -28,10 +28,17 @@ type Environment struct {
 }
 
 type Configs struct {
-	Endpoints           Endpoints `yaml:"endpoints"`
-	Security            Security  `yaml:"security,omitempty"`
-	GatewayEnvironments []string  `yaml:"gatewayEnvironments,omitempty"`
-	Certs               []Cert    `yaml:"certs,omitempty"`
+	Endpoints              Endpoints                `yaml:"endpoints"`
+	Security               Security                 `yaml:"security,omitempty"`
+	DeploymentEnvironments []DeploymentEnvironments `yaml:"deploymentEnvironments,omitempty"`
+	Certs                  []Cert                   `yaml:"certs,omitempty"`
+	MsslCerts              []MsslCert               `yaml:"mutualSslCerts,omitempty"`
+	Policies               []string                 `yaml:"policies,omitempty"`
+}
+
+type DeploymentEnvironments struct {
+	DisplayOnDevportal    bool   `yaml:"displayOnDevportal,omitempty"`
+	DeploymentEnvironment string `yaml:"deploymentEnvironment,omitempty"`
 }
 
 type Endpoints struct {
@@ -59,6 +66,12 @@ type Security struct {
 
 type Cert struct {
 	HostName string `yaml:"hostName"`
+	Alias    string `yaml:"alias"`
+	Path     string `yaml:"path"`
+}
+
+type MsslCert struct {
+	TierName string `yaml:"tierName"`
 	Alias    string `yaml:"alias"`
 	Path     string `yaml:"path"`
 }

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -163,7 +163,7 @@ func importAPIProduct(t *testing.T, args *ApiProductImportExportTestArgs) (strin
 
 	fileName := base.GetAPIArchiveFilePath(t, args.SrcAPIM.GetEnvName(), args.ApiProduct.Name, utils.DefaultApiProductVersion)
 
-	params := []string{"import", "api-product", "-f", fileName, "-e", args.DestAPIM.EnvName, "-k", "--verbose"}
+	params := []string{"import", "api-product", "-f", fileName, "-e", args.DestAPIM.EnvName, "-k", "--verbose", "--preserve-provider=false"}
 
 	if args.ImportApisFlag {
 		params = append(params, "--import-apis")

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -142,6 +142,10 @@ func GetEnvAPIExportPath(envName string) string {
 	return filepath.Join(utils.DefaultExportDirPath, utils.ExportedApisDirName, envName)
 }
 
+func GetEnvAPIProductExportPath(envName string) string {
+	return filepath.Join(utils.DefaultExportDirPath, utils.ExportedApiProductsDirName, envName)
+}
+
 func exportAPI(t *testing.T, name string, version string, provider string, env string) (string, error) {
 	var output string
 	var err error
@@ -379,7 +383,7 @@ func GetImportedAPI(t *testing.T, args *ApiImportExportTestArgs) *apim.API {
 	return importedAPI
 }
 
-func ReadAPIParams(t *testing.T, apiParamsPath string) *APIParams {
+func ReadParams(t *testing.T, apiParamsPath string) *Params {
 	reader, err := os.Open(apiParamsPath)
 
 	if err != nil {
@@ -387,7 +391,7 @@ func ReadAPIParams(t *testing.T, apiParamsPath string) *APIParams {
 	}
 	defer reader.Close()
 
-	apiParams := APIParams{}
+	apiParams := Params{}
 	yaml.NewDecoder(reader).Decode(&apiParams)
 
 	return &apiParams

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -166,11 +166,11 @@ func ValidateAPIImportExportWithDeploymentDir(t *testing.T, args *ApiImportExpor
 	importedAPI := GetImportedAPI(t, args)
 
 	apiParams := ReadParams(t, args.ParamsFile+string(os.PathSeparator)+utils.ParamFile)
-	ValidateParamsWithoutCerts(t, apiParams, importedAPI, nil, importedAPI.Policies,
+	validateParamsWithoutCerts(t, apiParams, importedAPI, nil, importedAPI.Policies,
 		importedAPI.GatewayEnvironments)
 
 	args.SrcAPIM = args.DestAPIM // The API should be exported from prod env
-	ValidateExportedAPICerts(t, apiParams, importedAPI, args)
+	validateExportedAPICerts(t, apiParams, importedAPI, args)
 }
 
 func ValidateAPIProductImportExportWithDeploymentDir(t *testing.T, args *ApiProductImportExportTestArgs,
@@ -188,10 +188,10 @@ func ValidateAPIProductImportExportWithDeploymentDir(t *testing.T, args *ApiProd
 	importedAPIProduct := ValidateAPIProductImport(t, args, true)
 
 	apiProductParams := ReadParams(t, args.ParamsFile+string(os.PathSeparator)+utils.ParamFile)
-	ValidateParamsWithoutCerts(t, apiProductParams, nil, importedAPIProduct, importedAPIProduct.Policies, importedAPIProduct.GatewayEnvironments)
+	validateParamsWithoutCerts(t, apiProductParams, nil, importedAPIProduct, importedAPIProduct.Policies, importedAPIProduct.GatewayEnvironments)
 
 	args.SrcAPIM = args.DestAPIM // The API Product should be exported from prod env
-	ValidateExportedAPIProductCerts(t, apiProductParams, importedAPIProduct, args)
+	validateExportedAPIProductCerts(t, apiProductParams, importedAPIProduct, args)
 }
 
 func ValidateDependentAPIWithParams(t *testing.T, dependentAPI *apim.API, client *apim.Client, username, password string) {
@@ -200,7 +200,7 @@ func ValidateDependentAPIWithParams(t *testing.T, dependentAPI *apim.API, client
 	srcPathForParamsFile, _ := filepath.Abs(APIFullParamsFile)
 	apiParams := ReadParams(t, srcPathForParamsFile)
 
-	ValidateParamsWithoutCerts(t, apiParams, importedDependentAPI, nil, importedDependentAPI.Policies,
+	validateParamsWithoutCerts(t, apiParams, importedDependentAPI, nil, importedDependentAPI.Policies,
 		importedDependentAPI.GatewayEnvironments)
 }
 
@@ -236,7 +236,7 @@ func ValidateEndpointSecurityDefinition(t *testing.T, api *apim.API, apiParams *
 	ValidateAPIsEqual(t, &apiCopy, &importedAPICopy)
 }
 
-func ValidateParamsWithoutCerts(t *testing.T, params *Params, api *apim.API, apiProduct *apim.APIProduct,
+func validateParamsWithoutCerts(t *testing.T, params *Params, api *apim.API, apiProduct *apim.APIProduct,
 	policies, gatewayEnvironments []string) {
 	t.Helper()
 
@@ -272,7 +272,7 @@ func validateDeploymentEnvironments(t *testing.T, apiParams *Params, gatewayEnvi
 	assert.ElementsMatch(t, deploymentEnvironments, gatewayEnvironments, "Mismatched deployment environments")
 }
 
-func ValidateExportedAPICerts(t *testing.T, apiParams *Params, api *apim.API, args *ApiImportExportTestArgs) {
+func validateExportedAPICerts(t *testing.T, apiParams *Params, api *apim.API, args *ApiImportExportTestArgs) {
 	output, _ := exportAPI(t, args.Api.Name, args.Api.Version, args.ApiProvider.Username, args.SrcAPIM.GetEnvName())
 
 	//Unzip exported API and check whether the imported certificates are there
@@ -292,7 +292,7 @@ func ValidateExportedAPICerts(t *testing.T, apiParams *Params, api *apim.API, ar
 	})
 }
 
-func ValidateExportedAPIProductCerts(t *testing.T, apiProductParams *Params, apiProduct *apim.APIProduct, args *ApiProductImportExportTestArgs) {
+func validateExportedAPIProductCerts(t *testing.T, apiProductParams *Params, apiProduct *apim.APIProduct, args *ApiProductImportExportTestArgs) {
 	output, _ := exportAPIProduct(t, args.ApiProduct.Name, utils.DefaultApiProductVersion, args.SrcAPIM.GetEnvName())
 
 	//Unzip exported API Product and check whether the imported certificates are there

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -21,6 +21,7 @@ package testutils
 import (
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -226,7 +227,7 @@ func ValidateExportedAPICerts(t *testing.T, apiParams *Params, api *apim.API, ar
 	relativePath := strings.ReplaceAll(exportedPath, ".zip", "")
 	base.Unzip(relativePath, exportedPath)
 
-	pathOfExportedApi := relativePath + "/" + api.Name + "-" + api.Version
+	pathOfExportedApi := relativePath + string(os.PathSeparator) + api.Name + "-" + api.Version
 
 	validateEndpointCerts(t, apiParams, pathOfExportedApi)
 	validateMutualSSLCerts(t, apiParams, pathOfExportedApi)
@@ -246,7 +247,7 @@ func ValidateExportedAPIProductCerts(t *testing.T, apiProductParams *Params, api
 	relativePath := strings.ReplaceAll(exportedPath, ".zip", "")
 	base.Unzip(relativePath, exportedPath)
 
-	pathOfExportedApiProduct := relativePath + "/" + apiProduct.Name + "-" + utils.DefaultApiProductVersion
+	pathOfExportedApiProduct := relativePath + string(os.PathSeparator) + apiProduct.Name + "-" + utils.DefaultApiProductVersion
 
 	validateMutualSSLCerts(t, apiProductParams, pathOfExportedApiProduct)
 
@@ -258,7 +259,7 @@ func ValidateExportedAPIProductCerts(t *testing.T, apiProductParams *Params, api
 }
 
 func validateEndpointCerts(t *testing.T, apiParams *Params, path string) {
-	pathOfExportedEndpointCerts := path + "/" + utils.InitProjectEndpointCertificates
+	pathOfExportedEndpointCerts := path + string(os.PathSeparator) + utils.InitProjectEndpointCertificates
 	isEndpointCertsDirExists, _ := utils.IsDirExists(pathOfExportedEndpointCerts)
 
 	if isEndpointCertsDirExists {
@@ -280,7 +281,7 @@ func validateEndpointCerts(t *testing.T, apiParams *Params, path string) {
 }
 
 func validateMutualSSLCerts(t *testing.T, apiParams *Params, path string) {
-	pathOfExportedMsslCerts := path + "/" + utils.InitProjectClientCertificates
+	pathOfExportedMsslCerts := path + string(os.PathSeparator) + utils.InitProjectClientCertificates
 	isClientCertsDirExists, _ := utils.IsDirExists(pathOfExportedMsslCerts)
 
 	if isClientCertsDirExists {

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -66,3 +66,9 @@ const APISecurityDigestParamsFile = "testdata/api_params_security_digest.yaml"
 
 // APISecurityBasicParamsFile : Security Basic api_params.yaml
 const APISecurityBasicParamsFile = "testdata/api_params_security_basic.yaml"
+
+// APIFullParamsFile : Full api_params.yaml
+const APIFullParamsFile = "testdata/api_params_full.yaml"
+
+// CertificatesDirectoryPath : Directory path for the dunnmy certificates
+const CertificatesDirectoryPath = "testdata/TestArtifactDirectory/certificates"

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -70,5 +70,8 @@ const APISecurityBasicParamsFile = "testdata/api_params_security_basic.yaml"
 // APIFullParamsFile : Full api_params.yaml
 const APIFullParamsFile = "testdata/api_params_full.yaml"
 
+// APIProductFullParamsFile : Full api_product_params.yaml
+const APIProductFullParamsFile = "testdata/api_product_params_full.yaml"
+
 // CertificatesDirectoryPath : Directory path for the dunnmy certificates
 const CertificatesDirectoryPath = "testdata/TestArtifactDirectory/certificates"

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -95,3 +95,8 @@ type ApiChangeLifeCycleStatusTestArgs struct {
 	Provider      string
 	ExpectedState string
 }
+
+type GenDeploymentDirTestArgs struct {
+	Source      string
+	Destination string
+}

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -45,6 +45,7 @@ type ApiProductImportExportTestArgs struct {
 	ImportApisFlag       bool
 	UpdateApisFlag       bool
 	UpdateApiProductFlag bool
+	ParamsFile           string
 }
 
 type AppImportExportTestArgs struct {

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -71,6 +71,23 @@ const ExportedAppsDirName = "apps"
 const ExportedMigrationArtifactsDirName = "migration"
 const CertificatesDirName = "certs"
 
+const (
+	InitProjectDefinitions          = "Definitions"
+	InitProjectImage                = "Image"
+	InitProjectDocs                 = "Docs"
+	InitProjectSequences            = "Sequences"
+	InitProjectSequencesFault       = "Sequences/fault-sequence"
+	InitProjectSequencesIn          = "Sequences/in-sequence"
+	InitProjectSequencesOut         = "Sequences/out-sequence"
+	InitProjectClientCertificates   = "Client-certificates"
+	InitProjectEndpointCertificates = "Endpoint-certificates"
+	InitProjectInterceptors         = "Interceptors"
+	InitProjectLibs                 = "libs"
+)
+
+const DeploymentDirPrefix = "DeploymentArtifacts_"
+const DeploymentCertificatesDirectory = "certificates"
+
 var DefaultExportDirPath = filepath.Join(ConfigDirPath, DefaultExportDirName)
 var DefaultCertDirPath = filepath.Join(ConfigDirPath, CertificatesDirName)
 


### PR DESCRIPTION
## Purpose
Write two wide test cases for APIs and API Products with the params file within deployment directories.

## Goals
Complete the integration tests for APICTL.

## Approach
- Added a prefix to the deployment directory generated by **apictl gen deployment-dir** as **DeploymentArtifacts_**.
- Write two (2) wide test cases as explained below.
  1. Export an API from one environment and generate the deployment directory for that. Import it to another environment with the params and certificates. Validate the imported API with the used params. Again, re-export it to validate the certs.
  2. Export an API Product from one environment and generate the deployment directory for that. Import it to another environment with the params and certificates. Validate the imported API Product with the used params. Again, re-export it to validate the certs. (Further, this test will validate the params of dependent APIs as well)

## User stories
User stories explained in the **Approach** section will be covered.

## Related PRs
Need to merge https://github.com/wso2/carbon-apimgt/pull/10020 to fix an issue. (Otherwise, the 2nd test will fail)

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64