### PR TITLE
[3.2.x] Remove the version from the export API Product examples

### DIFF
--- a/import-export-cli/cmd/exportAPIProduct.go
+++ b/import-export-cli/cmd/exportAPIProduct.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 
@@ -44,7 +45,7 @@ const exportAPIProductCmdShortDesc = "Export API Product"
 const exportAPIProductCmdLongDesc = "Export an API Product in an environment"
 
 const exportAPIProductCmdExamples = utils.ProjectName + ` ` + exportCmdLiteral + ` ` + exportAPIProductCmdLiteral + ` -n LeasingAPIProduct -e dev
-` + utils.ProjectName + ` ` + exportCmdLiteral + ` ` + exportAPIProductCmdLiteral + ` -n CreditAPIProduct -v 1.0.0 -r admin -e production
+` + utils.ProjectName + ` ` + exportCmdLiteral + ` ` + exportAPIProductCmdLiteral + ` -n CreditAPIProduct -r admin -e production
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory`
 
 // ExportAPIProductCmd represents the exportAPIProduct command
@@ -74,7 +75,7 @@ func executeExportAPIProductCmd(credential credentials.Credential, exportDirecto
 	if preCommandErr == nil {
 		adminEndpoint := utils.GetAdminEndpointOfEnv(cmdExportEnvironment, utils.MainConfigFilePath)
 		if exportAPIProductVersion == "" {
-			// If the user has not specified the version, use the version as 1.0.0
+			// Since the user cannot specify the version, use the version as 1.0.0
 			exportAPIProductVersion = utils.DefaultApiProductVersion
 		}
 		resp, err := getExportApiProductResponse(exportAPIProductName, exportAPIProductVersion, exportAPIProductProvider, exportAPIProductFormat, adminEndpoint,

--- a/import-export-cli/docs/apictl_export_api-product.md
+++ b/import-export-cli/docs/apictl_export_api-product.md
@@ -14,7 +14,7 @@ apictl export api-product (--name <name-of-the-api-product> --provider <provider
 
 ```
 apictl export api-product -n LeasingAPIProduct -e dev
-apictl export api-product -n CreditAPIProduct -v 1.0.0 -r admin -e production
+apictl export api-product -n CreditAPIProduct -r admin -e production
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory
 ```
 


### PR DESCRIPTION
## Purpose
Correcting the API Products export examples.

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/657