### PR TITLE
Fix appending version to the context and modify integration tests related to "retryTimeOut"

### DIFF
--- a/import-export-cli/integration/apim/apiDTO.go
+++ b/import-export-cli/integration/apim/apiDTO.go
@@ -48,7 +48,6 @@ type API struct {
 	VisibleTenants                  []string             `json:"visibleTenants"`
 	EndpointSecurity                APIEndpointSecurity  `json:"endpointSecurity,omitempty"`
 	GatewayEnvironments             []string             `json:"gatewayEnvironments"`
-	Labels                          []string             `json:"labels"`
 	MediationPolicies               []MediationPolicy    `json:"mediationPolicies,omitempty"`
 	SubscriptionAvailability        string               `json:"subscriptionAvailability"`
 	SubscriptionAvailableTenants    []string             `json:"subscriptionAvailableTenants"`

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -230,10 +230,6 @@ func CopyAPI(apiToCopy *API) API {
 	apiCopy.GatewayEnvironments = make([]string, len(apiToCopy.GatewayEnvironments))
 	copy(apiCopy.GatewayEnvironments, apiToCopy.GatewayEnvironments)
 
-	// Copy Labels slice
-	apiCopy.Labels = make([]string, len(apiToCopy.Labels))
-	copy(apiCopy.Labels, apiToCopy.Labels)
-
 	// Copy MediationPolicies slice
 	apiCopy.MediationPolicies = make([]MediationPolicy, len(apiToCopy.MediationPolicies))
 	copy(apiCopy.MediationPolicies, apiToCopy.MediationPolicies)
@@ -332,9 +328,6 @@ func SortAPIMembers(api *API) {
 
 	// Sort GatewayEnvironments slice
 	sort.Strings(api.GatewayEnvironments)
-
-	// Sort Labels slice
-	sort.Strings(api.Labels)
 
 	// Sort MediationPolicies slice
 	sort.Sort(ByID(api.MediationPolicies))

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -21,7 +21,6 @@ package integration
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,9 +105,7 @@ func TestEnvironmentSpecificParamsEndpointRetryTimeout(t *testing.T) {
 
 	for k, v := range paramConfig {
 		key := fmt.Sprintf("%v", k)
-		value, _ := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
-
-		assert.Equal(t, value, apiEndpointConfig[key])
+		assert.Equal(t, v, apiEndpointConfig[key])
 	}
 
 	assert.Equal(t, len(paramConfig), len(apiEndpointConfig))

--- a/import-export-cli/integration/testdata/api_params_endpoint_retrytimeout.yaml
+++ b/import-export-cli/integration/testdata/api_params_endpoint_retrytimeout.yaml
@@ -5,4 +5,4 @@ environments:
               production:
                   url: 'https://prod.wso2.com'
                   config:
-                      retryTimeOut: 60
+                      retryTimeOut: '60'

--- a/import-export-cli/integration/testdata/sample-api.yaml
+++ b/import-export-cli/integration/testdata/sample-api.yaml
@@ -46,7 +46,6 @@ data: # Contains the meta data of the API
   gatewayEnvironments: # Gateway environments that the API is available as a list
    - Production and Sandbox
   deploymentEnvironments: [] # Selected deployment environments and clusters of the API as a list
-  labels: [] # Labels of micro-gateway environments attached to the API
   mediationPolicies: # Mediation policies attached to the API that should be executed in the runtime {IN|OUT|FAULT}
    -
     id: 3b8cc0a7-6d98-4678-9111-2aba50fa505c

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -64,7 +64,6 @@ type APIDTODefinition struct {
 	EndpointSecurity             interface{}       `json:"endpointSecurity,omitempty" yaml:"endpointSecurity,omitempty"`
 	GatewayEnvironments          []string          `json:"gatewayEnvironments,omitempty" yaml:"gatewayEnvironments,omitempty"`
 	DeploymentEnvironments       []interface{}     `json:"deploymentEnvironments,omitempty" yaml:"deploymentEnvironments,omitempty"`
-	Labels                       []string          `json:"labels,omitempty" yaml:"labels,omitempty"`
 	MediationPolicies            []interface{}     `json:"mediationPolicies,omitempty" yaml:"mediationPolicies,omitempty"`
 	SubscriptionAvailability     string            `json:"subscriptionAvailability,omitempty" yaml:"subscriptionAvailability,omitempty"`
 	SubscriptionAvailableTenants []string          `json:"subscriptionAvailableTenants,omitempty" yaml:"subscriptionAvailableTenants,omitempty"`

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -217,7 +217,7 @@ func Swagger2Populate(def *APIDTODefinition, document *loads.Document) error {
 		def.Context = path.Clean(basepath)
 		if !strings.Contains(basepath, "{version}") {
 			def.Context = path.Clean(basepath)
-			//def.IsDefaultVersion = true
+			def.IsDefaultVersion = true
 		} else {
 			def.Context = path.Clean(strings.ReplaceAll(basepath, "{version}", def.Version))
 		}

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -204,20 +204,20 @@ func Swagger2Populate(def *APIDTODefinition, document *loads.Document) error {
 	def.Version = document.Spec().Info.Version
 	def.Provider = "admin"
 	def.Description = document.Spec().Info.Description
-	def.Context = fmt.Sprintf("/%s/%s", def.Name, def.Version)
+	def.Context = fmt.Sprintf("/%s", def.Name)
 	def.Tags = swagger2Tags(document)
 
 	// fill basepath from swagger
 	if document.BasePath() != "" {
-		def.Context = path.Clean(fmt.Sprintf("/%s/%s", document.BasePath(), def.Version))
+		def.Context = path.Clean(fmt.Sprintf("/%s", document.BasePath()))
 	}
 
 	// override basepath if wso2 extension provided
 	if basepath, ok := swagger2XWO2BasePath(document); ok {
 		def.Context = path.Clean(basepath)
 		if !strings.Contains(basepath, "{version}") {
-			def.Context = path.Clean(basepath + "/" + def.Version)
-			def.IsDefaultVersion = true
+			def.Context = path.Clean(basepath)
+			//def.IsDefaultVersion = true
 		} else {
 			def.Context = path.Clean(strings.ReplaceAll(basepath, "{version}", def.Version))
 		}


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/664
Modify the integration tests for the use case in https://github.com/wso2/product-apim-tooling/issues/665

## Goals
Fix appending version to the context and modify integration tests related to retryTimeOut

## Approach
- Fixed appending version to the context 
- Modified integration tests related to **retryTimeOut**
- Removed Microgatway labels field from the API DTO

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64
