### PR TITLE
Add support to configure K8s namespace in APICTL secret creation

### DIFF
--- a/import-export-cli/cmd/secret/create.go
+++ b/import-export-cli/cmd/secret/create.go
@@ -33,6 +33,7 @@ import (
 
 var inputPropertiesfile string
 var encryptionAlgorithm string
+var namespace string
 var outputType string
 
 const secretCreateCmdLiteral = "create"
@@ -41,15 +42,17 @@ const secretCreateCmdShortDesc = "Encrypt secrets"
 const secretCreateCmdLongDesc = "Create secrets based on given arguments"
 
 var secretCreateCmdExamples = "To encrypt secret and get output on console\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + "\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + "\n" +
 	"To encrypt secret and get output as a .properties file (stored in the security folder in apictl executable directory)\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o file\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o file\n" +
 	"To encrypt secret and get output as a .yaml file (stored in the security folder in apictl executable directory)\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8\n" +
+	"To encrypt secret and get output as a .yaml file (stored in the security folder in apictl executable directory) with given namespace specified as the namespace of the K8s cluster\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8 -n <namespace>\n" +
 	"To bulk encrypt secrets defined in a properties file\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -f <file_path>\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -f <file_path>\n" +
 	"To bulk encrypt secrets defined in a properties file and get a .yaml file (stored in the security folder in apictl executable directory)\n" +
-	"  " + utils.ProjectName + " " + utils.MiCmdLiteral + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8 -f <file_path>"
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8 -f <file_path>"
 
 var secretCreateCmd = &cobra.Command{
 	Use:     secretCreateCmdLiteral,
@@ -75,12 +78,14 @@ func init() {
 	secretCreateCmd.Flags().StringVarP(&inputPropertiesfile, "from-file", "f", "", "Path to the properties file which contains secrets to be encrypted")
 	secretCreateCmd.Flags().StringVarP(&outputType, "output", "o", "console", "Get the output in yaml (k8) or properties (file) format. By default the output is printed to the console")
 	secretCreateCmd.Flags().StringVarP(&encryptionAlgorithm, "cipher", "c", "RSA/ECB/OAEPWithSHA1AndMGF1Padding", "Encryption algorithm")
+	secretCreateCmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace for the K8s cluster")
 }
 
 func initSecretInformation(keyStoreConfig *utils.KeyStoreConfig) {
 	secretConfig := utils.SecretConfig{
 		OutputType: outputType,
 		Algorithm:  encryptionAlgorithm,
+		Namespace:  namespace,
 	}
 	if isNonEmptyString(inputPropertiesfile) {
 		secretConfig.InputType = "file"

--- a/import-export-cli/utils/encryptionUtils.go
+++ b/import-export-cli/utils/encryptionUtils.go
@@ -61,6 +61,7 @@ type SecretConfig struct {
 	InputFile           string
 	PlainTextAlias      string
 	PlainTextSecretText string
+	Namespace           string
 }
 
 type KeyStoreConfig struct {
@@ -99,7 +100,7 @@ func EncryptSecrets(keyStoreConfig *KeyStoreConfig, secretConfig SecretConfig) e
 		return err
 	}
 	if IsK8(secretConfig.OutputType) {
-		printSecretsToYamlFile(encryptedSecrets)
+		printSecretsToYamlFile(encryptedSecrets, secretConfig.Namespace)
 	} else if IsFile(secretConfig.OutputType) {
 		printSecretsToPropertiesFile(encryptedSecrets)
 	} else {
@@ -208,7 +209,7 @@ func printSecretsToPropertiesFile(secrets map[string]string) {
 	fmt.Println("Secret properties file created in", secretFilePath)
 }
 
-func printSecretsToYamlFile(secrets map[string]string) {
+func printSecretsToYamlFile(secrets map[string]string, namespace string) {
 	secretConfig := k8sSecretConfig{
 		APIVerion:  "v1",
 		Kind:       "Secret",
@@ -216,7 +217,7 @@ func printSecretsToYamlFile(secrets map[string]string) {
 		Type:       "Opaque",
 		MetaData: metaData{
 			Name:      "wso2secret",
-			Namespace: "default",
+			Namespace: namespace,
 		},
 	}
 	secretFilePath := getSecretFilePath(encryptedSecretsYamlFileName)


### PR DESCRIPTION
## Purpose
This PR adds the support to configure the k8s namespace in APICTL secret creation. (Previously, it was hardcoded as "default")

Fixes: https://github.com/wso2/micro-integrator/issues/2134