### PR TITLE
Slice usage for arguments of get apis/api-products and undeploy apis/api-products

### DIFF
--- a/import-export-cli/cmd/getApiProducts.go
+++ b/import-export-cli/cmd/getApiProducts.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 
@@ -31,7 +32,7 @@ import (
 
 var getApiProductsCmdEnvironment string
 var getApiProductsCmdFormat string
-var getApiProductsCmdQuery string
+var getApiProductsCmdQuery []string
 var getApiProductsCmdLimit string
 
 // GetApiProductsCmd related info
@@ -42,7 +43,7 @@ const getApiProductsCmdLongDesc = `Display a list of API Products in the environ
 
 var getApiProductsCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e dev
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e dev -q provider:devops
-` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e prod -q provider:admin context:/myproduct
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e prod -q provider:admin -q context:/myproduct
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e prod -l 25
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e staging
 NOTE: The flag (--environment (-e)) is mandatory`
@@ -59,12 +60,6 @@ var getApiProductsCmd = &cobra.Command{
 		if err != nil {
 			utils.HandleErrorAndExit("Error getting credentials", err)
 		}
-		//Since other flags does not use args[], query flag will own this
-		if len(args) != 0 && getApiProductsCmdQuery != "" {
-			for _, argument := range args {
-				getApiProductsCmdQuery += " " + argument
-			}
-		}
 		executeGetApiProductsCmd(cred)
 	},
 }
@@ -77,7 +72,8 @@ func executeGetApiProductsCmd(credential credentials.Credential) {
 	}
 
 	// Unified Search endpoint from the config file to search API Products
-	_, apiProducts, err := impl.GetAPIProductListFromEnv(accessToken, getApiProductsCmdEnvironment, getApiProductsCmdQuery,
+	_, apiProducts, err := impl.GetAPIProductListFromEnv(accessToken, getApiProductsCmdEnvironment,
+		strings.Join(getApiProductsCmdQuery, queryParamSeparator),
 		getApiProductsCmdLimit)
 	if err == nil {
 		impl.PrintAPIProducts(apiProducts, getApiProductsCmdFormat)
@@ -91,8 +87,8 @@ func init() {
 
 	getApiProductsCmd.Flags().StringVarP(&getApiProductsCmdEnvironment, "environment", "e",
 		"", "Environment to be searched")
-	getApiProductsCmd.Flags().StringVarP(&getApiProductsCmdQuery, "query", "q",
-		"", "Query pattern")
+	getApiProductsCmd.Flags().StringSliceVarP(&getApiProductsCmdQuery, "query", "q",
+		[]string{}, "Query pattern")
 	getApiProductsCmd.Flags().StringVarP(&getApiProductsCmdLimit, "limit", "l",
 		strconv.Itoa(utils.DefaultApiProductsDisplayLimit), "Maximum number of API Products to return")
 	getApiProductsCmd.Flags().StringVarP(&getApiProductsCmdFormat, "format", "", "", "Pretty-print API Products "+

--- a/import-export-cli/cmd/undeploy.go
+++ b/import-export-cli/cmd/undeploy.go
@@ -29,9 +29,9 @@ const undeployCmdShortDesc = "Undeploy an API/API Product revision from a gatewa
 
 const undeployCmdLongDesc = `Undeploy an API/API Product revision available in the environment specified by flag (--environment, -e) from the gateway specified by flag (--gateway, -g)`
 
-const undeployCmdExamples = utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 Label2 -e dev
+const undeployCmdExamples = utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 -g Label2 -e dev
 ` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n PizzaAPI -v 1.0.0 --rev 2 --all-gateways -e dev
-` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPICmdLiteral + ` -n LeasingAPIProduct -e dev`
+` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPIProductCmdLiteral + ` -n LeasingAPIProduct --rev 3 -g Label1 -e dev`
 
 // UndeployCmd represents the undeploy command
 var UndeployCmd = &cobra.Command{

--- a/import-export-cli/docs/apictl_get_api-products.md
+++ b/import-export-cli/docs/apictl_get_api-products.md
@@ -15,7 +15,7 @@ apictl get api-products [flags]
 ```
 apictl get api-products -e dev
 apictl get api-products -e dev -q provider:devops
-apictl get api-products -e prod -q provider:admin context:/myproduct
+apictl get api-products -e prod -q provider:admin -q context:/myproduct
 apictl get api-products -e prod -l 25
 apictl get api-products -e staging
 NOTE: The flag (--environment (-e)) is mandatory
@@ -28,7 +28,7 @@ NOTE: The flag (--environment (-e)) is mandatory
       --format string        Pretty-print API Products using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for api-products
   -l, --limit string         Maximum number of API Products to return (default "25")
-  -q, --query string         Query pattern
+  -q, --query strings        Query pattern
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_get_apis.md
+++ b/import-export-cli/docs/apictl_get_apis.md
@@ -15,7 +15,7 @@ apictl get apis [flags]
 ```
 apictl get apis -e dev
 apictl get apis -e dev -q version:1.0.0
-apictl get apis -e prod -q provider:admin
+apictl get apis -e prod -q provider:admin -q version:1.0.0
 apictl get apis -e prod -l 100
 apictl get apis -e staging
 NOTE: The flag (--environment (-e)) is mandatory
@@ -28,7 +28,7 @@ NOTE: The flag (--environment (-e)) is mandatory
       --format string        Pretty-print apis using Go Templates. Use "{{ jsonPretty . }}" to list all fields
   -h, --help                 help for apis
   -l, --limit string         Maximum number of apis to return (default "25")
-  -q, --query string         Query pattern
+  -q, --query strings        Query pattern
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_undeploy.md
+++ b/import-export-cli/docs/apictl_undeploy.md
@@ -13,9 +13,9 @@ apictl undeploy [flags]
 ### Examples
 
 ```
-apictl undeploy api -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 Label2 -e dev
+apictl undeploy api -n TwitterAPI -v 1.0.0 -r admin --rev 1 -g Label1 -g Label2 -e dev
 apictl undeploy api -n PizzaAPI -v 1.0.0 --rev 2 --all-gateways -e dev
-apictl undeploy api -n LeasingAPIProduct -e dev
+apictl undeploy api-product -n LeasingAPIProduct --rev 3 -g Label1 -e dev
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_undeploy_api-product.md
+++ b/import-export-cli/docs/apictl_undeploy_api-product.md
@@ -13,9 +13,9 @@ apictl undeploy api-product (--name <name-of-the-api-product> --version <version
 ### Examples
 
 ```
-apictl undeploy api-product -n TwitterAPIProduct -v 1.0.0 --rev 2  -e dev
-apictl undeploy api-product -n StoreProduct -v 2.1.0 --rev 6 -g Label1 Label2 Label3 -e production
-apictl undeploy api-product -n FacebookProduct -v 2.1.0 -r admin --rev 2 -g Label1 -e production
+apictl undeploy api-product -n TwitterAPIProduct --rev 2  -e dev
+apictl undeploy api-product -n StoreProduct --rev 6 -g Label1 -g Label2 -g Label3 -e production
+apictl undeploy api-product -n FacebookProduct -r admin --rev 2 -g Label1 -e production
 NOTE: All 4 flags (--name (-n), --version (-v), --rev, --environment (-e)) are mandatory.
 If the flag (--gateway-env (-g)) is not provided, revision will be undeployed from all deployed gateway environments.
 ```
@@ -23,12 +23,12 @@ If the flag (--gateway-env (-g)) is not provided, revision will be undeployed fr
 ### Options
 
 ```
-  -e, --environment string   Environment of which the API Product should be undeployed
-  -g, --gateway-env string   Gateway environment which the revision has to be undeployed
-  -h, --help                 help for api-product
-  -n, --name string          Name of the API Product to be exported
-  -r, --provider string      Provider of the API
-      --rev string           Revision number of the API Product to undeploy
+  -e, --environment string    Environment of which the API Product should be undeployed
+  -g, --gateway-env strings   Gateway environment which the revision has to be undeployed
+  -h, --help                  help for api-product
+  -n, --name string           Name of the API Product to be exported
+  -r, --provider string       Provider of the API
+      --rev string            Revision number of the API Product to undeploy
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_undeploy_api.md
+++ b/import-export-cli/docs/apictl_undeploy_api.md
@@ -13,8 +13,8 @@ apictl undeploy api (--name <name-of-the-api> --version <version-of-the-api> --p
 ### Examples
 
 ```
-apictl undeploy api -n TwitterAPI -v 1.0.0 -rev 2 -e dev
-apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 Label2 Label3 -e production
+apictl undeploy api -n TwitterAPI -v 1.0.0 --rev 2 -e dev
+apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 -g Label2 -g Label3 -e production
 apictl undeploy api -n FacebookAPI -v 2.1.0 -r alice --rev 2 -g Label1 -e production
 NOTE: All the 4 flags (--name (-n), --version (-v), --rev, --environment (-e)) are mandatory. 
 If the flag (--gateway-env (-g)) is not provided, revision will be undeployed from all deployed gateway environments.
@@ -23,13 +23,13 @@ If the flag (--gateway-env (-g)) is not provided, revision will be undeployed fr
 ### Options
 
 ```
-  -e, --environment string   Environment of which the API should be undeployed
-  -g, --gateway-env string   Gateway environment which the revision has to be undeployed
-  -h, --help                 help for api
-  -n, --name string          Name of the API to be exported
-  -r, --provider string      Provider of the API
-      --rev string           Revision number of the API to undeploy
-  -v, --version string       Version of the API to be exported
+  -e, --environment string    Environment of which the API should be undeployed
+  -g, --gateway-env strings   Gateway environment which the revision has to be undeployed
+  -h, --help                  help for api
+  -n, --name string           Name of the API to be exported
+  -r, --provider string       Provider of the API
+      --rev string            Revision number of the API to undeploy
+  -v, --version string        Version of the API to be exported
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -233,7 +233,7 @@
       Examples:
           apictl get apis -e dev
           apictl get apis -e dev -q version:1.0.0
-          apictl get apis -e prod -q provider:admin
+          apictl get apis -e prod -q provider:admin -q version:1.0.0
           apictl get apis -e prod -l 100
           apictl get apis -e staging
 </code></pre>
@@ -250,7 +250,7 @@
       Examples:
           apictl get api-products -e dev
           apictl get api-products -e dev -q provider:devops
-          apictl get api-products -e prod -q provider:admin context:/myproduct
+          apictl get api-products -e prod -q provider:admin -q context:/myproduct
           apictl get api-products -e prod -l 25
           apictl get api-products -e staging
 </code></pre>
@@ -903,4 +903,3 @@
 </code></pre>
     </li>
 </ul>
-


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/682

## Goals
Making consistent to use slices for arguments that have been fixed for apictl mg undeploy with [1].

## Approach
- The **apictl undeploy api** command will take the gateway environments as shown below from now onwards.
```
apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 -g Label2 -g Label3 -e production
```
-  The **apictl undeploy api-product** command will take the gateway environments as shown below from now onwards.
```
apictl undeploy api-product -n StoreProduct --rev 6 -g Label1 -g Label2 -g Label3 -e production
```
-  The **apictl get apis** command will take the query params as shown below from now onwards.
```
apictl get apis -e prod -q provider:admin -q version:1.0.0
```
-  The **apictl get api-products** command will take the query params as shown below from now onwards.
```
apictl get api-products -e prod -q provider:admin -q context:/myproduct
```
- Updated the examples of the above commands.

## Documentation
Documentation should be updated.

## Related PRs
https://github.com/wso2/product-apim-tooling/pull/680

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.16.3 linux/amd64
 
[1] https://github.com/wso2/product-apim-tooling/pull/680