### PR TITLE
Slice usage for arguments of get api-revisions/api-product-revisions

### DIFF
--- a/import-export-cli/cmd/get.go
+++ b/import-export-cli/cmd/get.go
@@ -23,20 +23,28 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
+const queryParamSeparator = " "
+
 // Get command related usage Info
 const GetCmdLiteral = "get"
 const getCmdShortDesc = "Get APIs/APIProducts/Applications in an environment or Get the environments"
 
 const getCmdLongDesc = `Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
 Display a list containing all the API Products available in the environment specified by flag (--environment, -e)/
-Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)
+Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)/
+Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
+Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)
 OR
 List all the environments`
 
 const getCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetEnvsCmdLiteral + `
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApisCmdLiteral + ` -e dev
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetApiProductsCmdLiteral + ` -e dev
-` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAppsCmdLiteral + ` -e dev`
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAppsCmdLiteral + ` -e dev
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIRevisionsCmdLiteral + ` -n PizzaAPI -v 1.0.0 -e dev
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n PizzaProduct -v 1.0.0 -e dev
+` + utils.ProjectName + " " + GetCmdLiteral + " " + GetKeysCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev`
 
 // ListCmd represents the list command
 var GetCmd = &cobra.Command{

--- a/import-export-cli/cmd/getAPIProductRevisions.go
+++ b/import-export-cli/cmd/getAPIProductRevisions.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 
@@ -30,7 +32,7 @@ var getRevisionsAPIProductName string
 var getRevisionsAPIProductProvider string
 var getAPIProductRevisionsCmdEnvironment string
 var getAPIProductRevisionsCmdFormat string
-var getAPIProductRevisionsCmdQuery string
+var getAPIProductRevisionsCmdQuery []string
 
 // GetAPIProductRevisionsCmd related info
 const GetAPIProductRevisionsCmdLiteral = "api-product-revisions"
@@ -40,6 +42,7 @@ const GetAPIProductRevisionsCmdLongDesc = `Display a list of Revisions available
 
 var getRevisionsCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n PizzaProduct -v 1.0.0 -e dev
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n ShopProduct -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n PizzaProduct -q deployed:true -e dev
 NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are mandatory.`
 
 // getRevisionsCmd represents the revisions command
@@ -66,7 +69,7 @@ func executeGetAPIProductRevisionsCmd(credential credentials.Credential) {
 	}
 
 	_, revisions, err := impl.GetAPIProductRevisionListFromEnv(accessToken, getAPIProductRevisionsCmdEnvironment,
-		getRevisionsAPIProductName, getRevisionsAPIProductProvider, getAPIProductRevisionsCmdQuery)
+		getRevisionsAPIProductName, getRevisionsAPIProductProvider, strings.Join(getAPIProductRevisionsCmdQuery, queryParamSeparator))
 	if err == nil {
 		impl.PrintRevisions(revisions, getAPIProductRevisionsCmdFormat)
 	} else {
@@ -80,8 +83,8 @@ func init() {
 		"Name of the API Product to get the revision")
 	getAPIProductRevisionsCmd.Flags().StringVarP(&getRevisionsAPIProductProvider, "provider", "r", "",
 		"Provider of the API Product")
-	getAPIProductRevisionsCmd.Flags().StringVarP(&getAPIProductRevisionsCmdQuery, "query", "q",
-		"", "Query pattern")
+	getAPIProductRevisionsCmd.Flags().StringSliceVarP(&getAPIProductRevisionsCmdQuery, "query", "q",
+		[]string{}, "Query pattern")
 	getAPIProductRevisionsCmd.Flags().StringVarP(&getAPIProductRevisionsCmdEnvironment, "environment", "e",
 		"", "Environment to be searched")
 	getAPIProductRevisionsCmd.Flags().StringVarP(&getAPIProductRevisionsCmdFormat, "format", "", "", "Pretty-print revisions "+

--- a/import-export-cli/cmd/getAPIRevisions.go
+++ b/import-export-cli/cmd/getAPIRevisions.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
 
@@ -31,7 +33,7 @@ var getAPIRevisionsAPIVersion string
 var getAPIRevisionsAPIProvider string
 var getAPIRevisionsCmdEnvironment string
 var getAPIRevisionsCmdFormat string
-var getAPIRevisionsCmdQuery string
+var getAPIRevisionsCmdQuery []string
 
 // GetRevisionsCmd related info
 const GetAPIRevisionsCmdLiteral = "api-revisions"
@@ -41,6 +43,7 @@ const GetAPIRevisionsCmdLongDesc = `Display a list of Revisions available for th
 
 var getAPIRevisionsCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIRevisionsCmdLiteral + ` -n PizzaAPI -v 1.0.0 -e dev
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIRevisionsCmdLiteral + ` -n TwitterAPI -v 1.0.0 -r admin -e dev
+` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIRevisionsCmdLiteral + ` -n PizzaShackAPI -v 1.0.0 -q deployed:true -e dev
 NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are mandatory.`
 
 // getRevisionsCmd represents the revisions command
@@ -67,7 +70,7 @@ func executeGetAPIRevisionsCmd(credential credentials.Credential) {
 	}
 
 	_, revisions, err := impl.GetRevisionListFromEnv(accessToken, getAPIRevisionsCmdEnvironment, getAPIRevisionsAPIName,
-		getAPIRevisionsAPIVersion, getAPIRevisionsAPIProvider, getAPIRevisionsCmdQuery)
+		getAPIRevisionsAPIVersion, getAPIRevisionsAPIProvider, strings.Join(getAPIRevisionsCmdQuery, queryParamSeparator))
 	if err == nil {
 		impl.PrintRevisions(revisions, getAPIRevisionsCmdFormat)
 	} else {
@@ -83,8 +86,8 @@ func init() {
 		"Version of the API to get the revision")
 	getAPIRevisionsCmd.Flags().StringVarP(&getAPIRevisionsAPIProvider, "provider", "r", "",
 		"Provider of the API")
-	getAPIRevisionsCmd.Flags().StringVarP(&getAPIRevisionsCmdQuery, "query", "q",
-		"", "Query pattern")
+	getAPIRevisionsCmd.Flags().StringSliceVarP(&getAPIRevisionsCmdQuery, "query", "q",
+		[]string{}, "Query pattern")
 	getAPIRevisionsCmd.Flags().StringVarP(&getAPIRevisionsCmdEnvironment, "environment", "e",
 		"", "Environment to be searched")
 	getAPIRevisionsCmd.Flags().StringVarP(&getAPIRevisionsCmdFormat, "format", "", "", "Pretty-print revisions "+

--- a/import-export-cli/cmd/getApis.go
+++ b/import-export-cli/cmd/getApis.go
@@ -34,8 +34,6 @@ var getApisCmdFormat string
 var getApisCmdQuery []string
 var getApisCmdLimit string
 
-const queryParamSeparator = " "
-
 // GetApisCmd related info
 const GetApisCmdLiteral = "apis"
 const getApisCmdShortDesc = "Display a list of APIs in an environment"

--- a/import-export-cli/cmd/undeployApi.go
+++ b/import-export-cli/cmd/undeployApi.go
@@ -86,7 +86,7 @@ func executeUndeployAPICmd(credential credentials.Credential, deployments []util
 		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
 		if resp.StatusCode() == http.StatusCreated {
 			fmt.Println("Revision " + undeployRevisionNum + " of API " + undeployAPIName + "_" + undeployAPIVersion +
-				" successfully undeployed from the gateways environments")
+				" successfully undeployed from the specified gateways environments")
 		} else {
 			fmt.Println("Error while undeploying the  API: ", resp.Status(), "\n", string(resp.Body()))
 		}

--- a/import-export-cli/cmd/undeployApiProduct.go
+++ b/import-export-cli/cmd/undeployApiProduct.go
@@ -47,12 +47,12 @@ const undeployAPIProductCmdExamples = utils.
 	ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPIProductCmdLiteral + ` -n TwitterAPIProduct --rev 2  -e dev
 ` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPIProductCmdLiteral + ` -n StoreProduct --rev 6 -g Label1 -g Label2 -g Label3 -e production
 ` + utils.ProjectName + ` ` + UndeployCmdLiteral + ` ` + UndeployAPIProductCmdLiteral + ` -n FacebookProduct -r admin --rev 2 -g Label1 -e production
-NOTE: All 4 flags (--name (-n), --version (-v), --rev, --environment (-e)) are mandatory.
+NOTE: All 3 flags (--name (-n), --rev, --environment (-e)) are mandatory.
 If the flag (--gateway-env (-g)) is not provided, revision will be undeployed from all deployed gateway environments.`
 
 // UndeployAPIProductCmd represents the deploy API command
 var UndeployAPIProductCmd = &cobra.Command{
-	Use: UndeployAPIProductCmdLiteral + " (--name <name-of-the-api-product> --version <version-of-the-api-product> " +
+	Use: UndeployAPIProductCmdLiteral + " (--name <name-of-the-api-product> " +
 		"--rev<revision-number-of-the-api-product> --gateway-env <gateway-environment> " +
 		"--environment <environment-from-which-the-api-product-should-be-undeployed>)",
 	Short:   undeployAPIProductCmdShortDesc,

--- a/import-export-cli/cmd/undeployApiProduct.go
+++ b/import-export-cli/cmd/undeployApiProduct.go
@@ -87,7 +87,7 @@ func executeUndeployAPIProductCmd(credential credentials.Credential, deployments
 		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
 		if resp.StatusCode() == http.StatusCreated {
 			fmt.Println("Revision " + undeployAPIProductRevisionNum + " of API Product " + undeployAPIProductName +
-				" successfully undeployed from the gateway environments")
+				" successfully undeployed from the specified gateway environments")
 		} else {
 			fmt.Println("Error while undeploying the  APIProduct: ", resp.Status(), "\n", string(resp.Body()))
 		}

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -6,7 +6,10 @@ Get APIs/APIProducts/Applications in an environment or Get the environments
 
 Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
 Display a list containing all the API Products available in the environment specified by flag (--environment, -e)/
-Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)
+Display a list of Applications of a specific user in the environment specified by flag (--environment, -e)/
+Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
+Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)
 OR
 List all the environments
 
@@ -21,6 +24,9 @@ apictl get envs
 apictl get apis -e dev
 apictl get api-products -e dev
 apictl get apps -e dev
+apictl get api-revisions -n PizzaAPI -v 1.0.0 -e dev
+apictl get api-product-revisions -n PizzaProduct -v 1.0.0 -e dev
+apictl get keys -n TwitterAPI -v 1.0.0 -e dev
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_get_api-product-revisions.md
+++ b/import-export-cli/docs/apictl_get_api-product-revisions.md
@@ -15,6 +15,7 @@ apictl get api-product-revisions [flags]
 ```
 apictl get api-product-revisions -n PizzaProduct -v 1.0.0 -e dev
 apictl get api-product-revisions -n ShopProduct -v 1.0.0 -r admin -e dev
+apictl get api-product-revisions -n PizzaProduct -q deployed:true -e dev
 NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are mandatory.
 ```
 
@@ -26,7 +27,7 @@ NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are m
   -h, --help                 help for api-product-revisions
   -n, --name string          Name of the API Product to get the revision
   -r, --provider string      Provider of the API Product
-  -q, --query string         Query pattern
+  -q, --query strings        Query pattern
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_get_api-revisions.md
+++ b/import-export-cli/docs/apictl_get_api-revisions.md
@@ -15,6 +15,7 @@ apictl get api-revisions [flags]
 ```
 apictl get api-revisions -n PizzaAPI -v 1.0.0 -e dev
 apictl get api-revisions -n TwitterAPI -v 1.0.0 -r admin -e dev
+apictl get api-revisions -n PizzaShackAPI -v 1.0.0 -q deployed:true -e dev
 NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are mandatory.
 ```
 
@@ -26,7 +27,7 @@ NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are m
   -h, --help                 help for api-revisions
   -n, --name string          Name of the API to get the revision
   -r, --provider string      Provider of the API
-  -q, --query string         Query pattern
+  -q, --query strings        Query pattern
   -v, --version string       Version of the API to get the revision
 ```
 

--- a/import-export-cli/docs/apictl_undeploy_api-product.md
+++ b/import-export-cli/docs/apictl_undeploy_api-product.md
@@ -7,7 +7,7 @@ Undeploy API Product
 Undeploy an API Product revision from gateway environments
 
 ```
-apictl undeploy api-product (--name <name-of-the-api-product> --version <version-of-the-api-product> --rev<revision-number-of-the-api-product> --gateway-env <gateway-environment> --environment <environment-from-which-the-api-product-should-be-undeployed>) [flags]
+apictl undeploy api-product (--name <name-of-the-api-product> --rev<revision-number-of-the-api-product> --gateway-env <gateway-environment> --environment <environment-from-which-the-api-product-should-be-undeployed>) [flags]
 ```
 
 ### Examples
@@ -16,7 +16,7 @@ apictl undeploy api-product (--name <name-of-the-api-product> --version <version
 apictl undeploy api-product -n TwitterAPIProduct --rev 2  -e dev
 apictl undeploy api-product -n StoreProduct --rev 6 -g Label1 -g Label2 -g Label3 -e production
 apictl undeploy api-product -n FacebookProduct -r admin --rev 2 -g Label1 -e production
-NOTE: All 4 flags (--name (-n), --version (-v), --rev, --environment (-e)) are mandatory.
+NOTE: All 3 flags (--name (-n), --rev, --environment (-e)) are mandatory.
 If the flag (--gateway-env (-g)) is not provided, revision will be undeployed from all deployed gateway environments.
 ```
 

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -487,6 +487,41 @@
 </ul>
 <ul>
     <li>
+        <h4 id="undeploy-api">undeploy api</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --name, -n
+           --version, -v
+           --rev
+           --environment, -e
+       Optional:
+           --gateway-env, -g
+   Examples:
+       apictl undeploy api -n TwitterAPI -v 1.0.0 --rev 2 -e dev
+       apictl undeploy api -n FacebookAPI -v 2.1.0 --rev 6 -g Label1 -g Label2 -g Label3 -e production
+       apictl undeploy api -n FacebookAPI -v 2.1.0 -r alice --rev 2 -g Label1 -e production   
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="undeploy-api-product">undeploy api-product</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --name, -n
+           --rev
+           --environment, -e
+       Optional:
+           --gateway-env, -g
+   Examples:
+       apictl undeploy api-product -n TwitterAPIProduct --rev 2  -e dev
+       apictl undeploy api-product -n StoreProduct --rev 6 -g Label1 -g Label2 -g Label3 -e production
+       apictl undeploy api-product -n FacebookProduct -r admin --rev 2 -g Label1 -e production     
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
         <h4 id="gen-deployment-dir">gen deployment-dir</h4>
         <pre><code class="lang-bash">   Flags:
        Required:


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/705

## Goals
Making consistent to use slices for arguments that have been fixed for apictl mg undeploy with [1].

## Documentation
Documentation should be updated.

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/680
- https://github.com/wso2/product-apim-tooling/pull/699

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.16.3 linux/amd64
 
[1] https://github.com/wso2/product-apim-tooling/pull/680