### PR TITLE
Checking x-wso2-basepath contains version and remove it to build the context during init

### DIFF
--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -53,7 +53,7 @@ func TestExportApiCompareStruct(t *testing.T) {
 	testutils.ValidateExportedAPIStructure(t, args)
 }
 
-// Export an API from one environment as a super tenant non admin user (who has API Create and API Publish permissions)
+// Export an API from one environment as a super tenant non admin user (who has Internal/publisher role)
 // by specifying the provider name
 func TestExportApiNonAdminSuperTenantUser(t *testing.T) {
 	apiPublisher := publisher.UserName
@@ -125,7 +125,7 @@ func TestExportImportApiDevopsSuperTenantUser(t *testing.T) {
 	testutils.ValidateAPIExportImport(t, args)
 }
 
-// Export an API from one environment as tenant non admin user (who has API Create and API Publish permissions)
+// Export an API from one environment as tenant non admin user (who has Internal/publisher role)
 // by specifying the provider name
 func TestExportApiNonAdminTenantUser(t *testing.T) {
 	tenantApiPublisher := publisher.UserName + "@" + TENANT1

--- a/import-export-cli/integration/deprecatedCommands_test.go
+++ b/import-export-cli/integration/deprecatedCommands_test.go
@@ -36,7 +36,7 @@ func TestListEnvironmentsDeprecated(t *testing.T) {
 	assert.Contains(t, response, apim.GetEnvName(), "TestListEnvironmentsDeprecated Failed")
 }
 
-// Export an API from one environment as a super tenant non admin user (who has API Create and API Publish permissions)
+// Export an API from one environment as a super tenant non admin user (who has Internal/publisher role)
 // by specifying the provider name
 func TestExportApiNonAdminSuperTenantUserDeprecated(t *testing.T) {
 	apiPublisher := publisher.UserName

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -263,7 +263,12 @@ func Swagger2Populate(def *APIDTODefinition, document *loads.Document) error {
 	if basepath, ok := swagger2XWO2BasePath(document); ok {
 		def.Context = path.Clean(basepath)
 		if !strings.Contains(basepath, "{version}") {
-			def.Context = path.Clean(basepath)
+			if strings.Contains(basepath, def.Version) {
+				def.Context = path.Clean(strings.Replace(basepath, def.Version, "",
+					strings.LastIndex(basepath, def.Version)))
+			} else {
+				def.Context = path.Clean(basepath)
+			}
 			def.IsDefaultVersion = true
 		} else {
 			def.Context = path.Clean(strings.ReplaceAll(basepath, "{version}", def.Version))


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/710

## Goals
When the version is already there in the x-wso2-basepath, it should not get appended again. But the apictl does it which is wrong.

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.16.3 linux/amd64