### PR TITLE
Update APIM pack name in start-apim.sh

### DIFF
--- a/import-export-cli/integration/ci-resources/start-apim.sh
+++ b/import-export-cli/integration/ci-resources/start-apim.sh
@@ -17,7 +17,7 @@ fi
 
 if [ -z "$NAME" ]
 then 
-    APIM_PACK=wso2am-4.0.0
+    APIM_PACK=wso2am-4.0.0-SNAPSHOT
 else
     APIM_PACK=$NAME
 fi


### PR DESCRIPTION
## Purpose
Change the name of the default APIM pack to be taken when running the integration tests.
