### PR TITLE
Adding table driven integration tests for Undeploy (API/API Product) command

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -991,14 +991,24 @@ func (instance *Client) CreateAPIProductRevision(apiProductID string) *APIRevisi
 }
 
 // DeployAPIProductRevision : Deploy API Product revision
-func (instance *Client) DeployAPIProductRevision(t *testing.T, apiProductID string, revision *APIRevision) {
+func (instance *Client) DeployAPIProductRevision(t *testing.T, apiProductID, deploymentName, vhost, revisionID string) {
 	deployURL := instance.publisherRestURL + "/api-products/" + apiProductID + "/deploy-revision"
 
 	deploymentInfoArray := []APIRevisionDeployment{}
 	deploymentInfo := APIRevisionDeployment{}
-	deploymentInfo.RevisionUUID = revision.ID
-	deploymentInfo.Name = "Default"
-	deploymentInfo.VHost = "localhost"
+	deploymentInfo.RevisionUUID = revisionID
+
+	if deploymentName == "" {
+		deploymentInfo.Name = "Default"
+	} else {
+		deploymentInfo.Name = deploymentName
+	}
+	if vhost == "" {
+		deploymentInfo.VHost = "localhost"
+	} else {
+		deploymentInfo.VHost = vhost
+	}
+
 	deploymentInfo.DisplayOnDevportal = true
 	deploymentInfoArray = append(deploymentInfoArray, deploymentInfo)
 
@@ -1011,7 +1021,7 @@ func (instance *Client) DeployAPIProductRevision(t *testing.T, apiProductID stri
 	request := base.CreatePost(deployURL, bytes.NewBuffer(data))
 
 	values := url.Values{}
-	values.Add("revisionId", revision.ID)
+	values.Add("revisionId", revisionID)
 
 	request.URL.RawQuery = values.Encode()
 

--- a/import-export-cli/integration/apim/environmentDTO.go
+++ b/import-export-cli/integration/apim/environmentDTO.go
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apim
+
+// Environment : Environment DTO
+type Environment struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	DisplayName string  `json:"displayName"`
+	Description string  `json:"description"`
+	IsReadOnly  bool    `json:"isReadOnly"`
+	VHosts      []VHost `json:"vhosts"`
+}
+
+type VHost struct {
+	Host        string `json:"host"`
+	HttpContext string `json:"httpContext"`
+	HttpPort    int    `json:"httpPort"`
+	HttpsPort   int    `json:"httpsPort"`
+	WsPort      int    `json:"wsPort"`
+	WssPort     int    `json:"wssPort"`
+}

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -19,6 +19,7 @@
 package base
 
 import (
+	"encoding/base32"
 	"flag"
 	"fmt"
 	"io"
@@ -444,4 +445,15 @@ func GenerateRandomName(n int) string {
 		s[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(s)
+}
+
+func GenerateRandomString() string {
+	b := make([]byte, 10)
+	_, err := rand.Read(b)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b)
 }

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -39,7 +39,7 @@ func AddAPIProductFromJSONWithoutCleaning(t *testing.T, client *apim.Client, use
 	doClean := false
 	id := client.AddAPIProductFromJSON(t, path, username, password, apisList, doClean)
 	revision := client.CreateAPIProductRevision(id)
-	client.DeployAPIProductRevision(t, id, revision)
+	client.DeployAPIProductRevision(t, id, "", "", revision.ID)
 	apiProduct := client.GetAPIProduct(id)
 	return apiProduct
 }
@@ -56,10 +56,11 @@ func AddAPIProductFromJSON(t *testing.T, client *apim.Client, username string, p
 	return apiProduct
 }
 
-func CreateAndDeployAPIProductRevision(t *testing.T, client *apim.Client, username, password, apiProductID string) {
+func CreateAndDeployAPIProductRevision(t *testing.T, client *apim.Client, username, password, apiProductID string) string {
 	client.Login(username, password)
 	revision := client.CreateAPIProductRevision(apiProductID)
-	client.DeployAPIProductRevision(t, apiProductID, revision)
+	client.DeployAPIProductRevision(t, apiProductID, "", "", revision.ID)
+	return revision.ID
 }
 
 func getAPIProduct(t *testing.T, client *apim.Client, name string, username string, password string) *apim.APIProduct {

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -97,7 +97,7 @@ func AddWebStreamingAPIFromAsyncAPIDefinition(t *testing.T, client *apim.Client,
 func CreateAndDeployAPIRevision(t *testing.T, client *apim.Client, username, password, apiID string) string {
 	client.Login(username, password)
 	revision := client.CreateAPIRevision(apiID)
-	client.DeployAPIRevision(t, apiID, revision)
+	client.DeployAPIRevision(t, apiID, "", "", revision.ID)
 	return revision.ID
 }
 

--- a/import-export-cli/integration/testutils/gateway_testUtils.go
+++ b/import-export-cli/integration/testutils/gateway_testUtils.go
@@ -1,0 +1,155 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package testutils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+)
+
+func AddGatewayEnv(t *testing.T, client *apim.Client, username, password string) *apim.Environment {
+	client.Login(username, password)
+	env := GenerateSampleGatewayData()
+	addedEnv := client.AddGatewayEnv(t, env, username, password)
+	return addedEnv
+}
+
+func GenerateSampleGatewayData() apim.Environment {
+	env := apim.Environment{}
+	env.Name = base.GenerateRandomString() + "-Gateway"
+	env.DisplayName = env.Name + "-Display Name"
+	env.Description = "Gateway environment for testing purposes"
+	vhost := apim.VHost{
+		Host: env.Name + ".com",
+	}
+	env.VHosts = []apim.VHost{}
+	env.VHosts = append(env.VHosts, vhost)
+
+	return env
+}
+
+func undeployAPI(t *testing.T, args *ApiUndeployTestArgs, provider string) (string, error) {
+	params := []string{"undeploy", "api", "-n", args.Api.Name, "-v", args.Api.Version,
+		"--rev", args.RevisionNo, "-e", args.SrcAPIM.GetEnvName(), "-k", "--verbose"}
+
+	if provider != "" {
+		params = append(params, "-r", provider)
+	}
+
+	if len(args.GatewayEnvs) > 0 {
+		for _, gatewayEnv := range args.GatewayEnvs {
+			params = append(params, "-g", "\""+gatewayEnv+"\"")
+		}
+	}
+
+	output, err := base.Execute(t, params...)
+
+	return output, err
+}
+
+func ValidateAPIUndeploy(t *testing.T, args *ApiUndeployTestArgs, provider, revisionId string) {
+	t.Helper()
+
+	deployedAPIRevisionsBeforeUndeploy := args.SrcAPIM.GetAPIRevisions(args.Api.ID, "deployed:true")
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// Export api from env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	// Execute undeploy API command
+	result, err := undeployAPI(t, args, provider)
+
+	assert.Nil(t, err, "Should return nil error")
+	assert.Contains(t, result, "Revision "+args.RevisionNo+" of API "+args.Api.Name+"_"+
+		args.Api.Version+" successfully undeployed")
+
+	deployedAPIRevisionsAfterUndeploy := args.SrcAPIM.GetAPIRevisions(args.Api.ID, "deployed:true")
+
+	if len(args.GatewayEnvs) > 0 {
+		// Validate the deployed gateways before and after executing the undeploy command
+		ValidateDeployedGateways(t, deployedAPIRevisionsBeforeUndeploy, deployedAPIRevisionsAfterUndeploy, args, revisionId)
+	} else {
+		// This scenario is that the API revision is undeployed from all the gateways
+		assert.Equal(t, len(deployedAPIRevisionsAfterUndeploy.List), 0)
+	}
+
+}
+
+func ValidateAPIUndeployFailure(t *testing.T, args *ApiUndeployTestArgs, provider, revisionId string) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// Export api from env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	// Execute undeploy API command
+	result, err := undeployAPI(t, args, provider)
+
+	assert.NotNil(t, err, "Should not return nil error")
+	assert.Contains(t, base.GetValueOfUniformResponse(result), "Exit status 1")
+}
+
+func ValidateDeployedGateways(t *testing.T, deployedRevisionsBeforeUndeploy *apim.APIRevisionList,
+	deployedRevisionsAfterUndeploy *apim.APIRevisionList, args *ApiUndeployTestArgs, revisionId string) {
+
+	// Validate whether the deployed gateways contain the gateway envs before undeploying
+	assert.True(t, containsGatewaysInDeployment(deployedRevisionsBeforeUndeploy, args.GatewayEnvs, revisionId))
+
+	// Validate whether the deployed gateways do not contain the gateway envs after undeploying
+	assert.False(t, containsGatewaysInDeployment(deployedRevisionsAfterUndeploy, args.GatewayEnvs, revisionId))
+}
+
+func containsGatewaysInDeployment(deployedRevisions *apim.APIRevisionList, gatewayEnvs []string,
+	revisionId string) bool {
+	for _, deployedRevision := range deployedRevisions.List {
+		if strings.EqualFold(deployedRevision.ID, revisionId) {
+			containsGatewaysInDeployment := []bool{}
+
+			// Check whether the passed gateway labels to the command are there in the deployed list
+			// If so mark it as true, else false
+			for _, gatewayEnv := range gatewayEnvs {
+				containsGateway := false
+				for _, deployment := range deployedRevision.DeploymentInfo {
+					if strings.EqualFold(deployment.Name, gatewayEnv) {
+						containsGateway = true
+						break
+					}
+				}
+				containsGatewaysInDeployment = append(containsGatewaysInDeployment, containsGateway)
+			}
+
+			// If any of the gateways are not inside the deployed list, false should be returned
+			for _, containsGatewayInDeployment := range containsGatewaysInDeployment {
+				if !containsGatewayInDeployment {
+					return false
+				}
+			}
+			return true
+		}
+	}
+	return false
+}

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -81,9 +81,10 @@ type ApiGetKeyTestArgs struct {
 	Apim       *apim.Client
 }
 
-type ApiUndeployTestArgs struct {
+type UndeployTestArgs struct {
 	CtlUser     Credentials
 	Api         *apim.API
+	ApiProduct  *apim.APIProduct
 	SrcAPIM     *apim.Client
 	RevisionNo  string
 	GatewayEnvs []string

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -81,6 +81,14 @@ type ApiGetKeyTestArgs struct {
 	Apim       *apim.Client
 }
 
+type ApiUndeployTestArgs struct {
+	CtlUser     Credentials
+	Api         *apim.API
+	SrcAPIM     *apim.Client
+	RevisionNo  string
+	GatewayEnvs []string
+}
+
 type loginTestArgs struct {
 	ctlUser Credentials
 	srcAPIM *apim.Client

--- a/import-export-cli/integration/undeploy_test.go
+++ b/import-export-cli/integration/undeploy_test.go
@@ -1,0 +1,162 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
+)
+
+const revisionNumber = "1"
+
+// Undeploy an API revision from one gateway
+func TestUndeployAPIRevisionSingleGateway(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			// Add the API to env
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			// Add a new gateway env by the respective admin user
+			gatewayEnv := testutils.AddGatewayEnv(t, dev, user.Admin.Username, user.Admin.Password)
+
+			// Create and Deploy Revision of the above API to the default gateway
+			revisionId := testutils.CreateAndDeployAPIRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+
+			// Deploy the same revision in another gateway
+			dev.DeployAPIRevision(t, api.ID, gatewayEnv.Name, gatewayEnv.VHosts[0].Host, revisionId)
+			base.WaitForIndexing()
+
+			args := &testutils.ApiUndeployTestArgs{
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				RevisionNo:  revisionNumber,
+				GatewayEnvs: []string{gatewayEnv.Name},
+			}
+
+			// Validate the undeploy command
+			testutils.ValidateAPIUndeploy(t, args, "", revisionId)
+		})
+	}
+}
+
+// Undeploy an API revision from multiple gateways but not all
+func TestUndeployAPIRevisionMulitpleGateways(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			// Add the API to env
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			// Add two new gateway envs by the respective admin user
+			gatewayEnv1 := testutils.AddGatewayEnv(t, dev, user.Admin.Username, user.Admin.Password)
+			gatewayEnv2 := testutils.AddGatewayEnv(t, dev, user.Admin.Username, user.Admin.Password)
+
+			// Create and Deploy Revision of the above API to the default gateway
+			revisionId := testutils.CreateAndDeployAPIRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+
+			// Deploy the same revision in other gateways
+			dev.DeployAPIRevision(t, api.ID, gatewayEnv1.Name, gatewayEnv1.VHosts[0].Host, revisionId)
+			base.WaitForIndexing()
+			dev.DeployAPIRevision(t, api.ID, gatewayEnv2.Name, gatewayEnv2.VHosts[0].Host, revisionId)
+			base.WaitForIndexing()
+
+			args := &testutils.ApiUndeployTestArgs{
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				RevisionNo:  revisionNumber,
+				GatewayEnvs: []string{gatewayEnv1.Name, gatewayEnv2.Name},
+			}
+
+			// Validate the undeploy command
+			testutils.ValidateAPIUndeploy(t, args, "", revisionId)
+		})
+	}
+}
+
+// Undeploy an API revision from all the gateways
+func TestUndeployAPIRevisionAllGateways(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			// Add the API to env
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			// Add two new gateway envs by the respective admin user
+			gatewayEnv1 := testutils.AddGatewayEnv(t, dev, user.Admin.Username, user.Admin.Password)
+			gatewayEnv2 := testutils.AddGatewayEnv(t, dev, user.Admin.Username, user.Admin.Password)
+
+			// Create and Deploy Revision of the above API to the default gateway
+			revisionId := testutils.CreateAndDeployAPIRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+
+			// Deploy the same revision in other gateways
+			dev.DeployAPIRevision(t, api.ID, gatewayEnv1.Name, gatewayEnv1.VHosts[0].Host, revisionId)
+			base.WaitForIndexing()
+			dev.DeployAPIRevision(t, api.ID, gatewayEnv2.Name, gatewayEnv2.VHosts[0].Host, revisionId)
+			base.WaitForIndexing()
+
+			args := &testutils.ApiUndeployTestArgs{
+				CtlUser:    testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:        api,
+				SrcAPIM:    dev,
+				RevisionNo: revisionNumber,
+			}
+
+			// Validate the undeploy command
+			testutils.ValidateAPIUndeploy(t, args, "", revisionId)
+		})
+	}
+}
+
+// Undeploy an API revision from a gateway that does not exist
+func TestUndeployAPIRevisionFailure(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			// Add the API to env
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			// Create and Deploy Revision of the above API to the default gateway
+			revisionId := testutils.CreateAndDeployAPIRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+
+			args := &testutils.ApiUndeployTestArgs{
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				RevisionNo:  revisionNumber,
+				GatewayEnvs: []string{base.GenerateRandomString()},
+			}
+
+			// Validate the undeploy command failure
+			testutils.ValidateAPIUndeployFailure(t, args, "", revisionId)
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
Adding the tests for undeploy API and API Product commands.

## Goals
Adding table-driven integration tests for undeploy command which will cover four (4) scenarios from one test.

## Approach
Wrote two (8) tests for undeploy API and API Product commands which will cover eight (4) user scenarios (admin, devops - both super tenant and tenant) from a single test.
1. Undeploy an API revision from one gateway
2. Undeploy an API revision from multiple specified gateways but not all
3. Undeploy an API revision from all the gateways
4. Undeploy an API revision from a gateway that does not exist
5. Undeploy an API Product revision from one gateway
6. Undeploy an API Product revision from multiple specified gateways but not all
7. Undeploy an API Product revision from all the gateways
8. Undeploy an API Product revision from a gateway that does not exist

## User stories
The user stories covered by the above test cases.

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64