### PR TITLE
Add integration tests for Managing apictl environments and setup apictl

### DIFF
--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -60,7 +60,7 @@ func TestRunApictlWithCustomDirectoryLocation(t *testing.T) {
 }
 
 // Adding a new Environments with -- token flag and list them and check it
-func TestAddEnvironmentWithToken(t *testing.T) {
+func TestAddEnvironmentWithTokenEndpoint(t *testing.T) {
 	apim := GetDevClient()
 	output, err := testutils.AddEnvironmentWithTokenFlag(t, apim.GetEnvName(), apim.GetApimURL(), apim.GetTokenURL())
 
@@ -70,7 +70,7 @@ func TestAddEnvironmentWithToken(t *testing.T) {
 }
 
 // Adding a new Environments without -- token flag and list them and check it
-func TestAddEnvironmentWithoutToken(t *testing.T) {
+func TestAddEnvironmentWithoutTokenEndpoint(t *testing.T) {
 	apim := GetDevClient()
 	output, err := testutils.AddEnvironmentWithOutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
 
@@ -86,7 +86,55 @@ func TestGetEnvironments(t *testing.T) {
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
 
 	// Validate added environment list
-	testutils.ValidateEnvsList(t, apim.GetEnvName())
+	testutils.ValidateEnvsList(t, apim.GetEnvName(), true)
+}
+
+// Remove an added Environment when an user is logged into the environment
+func TestRemoveEnvironmentWithLoggedInUsers(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			devopsUsername := user.CtlUser.Username
+			devopsPassword := user.CtlUser.Password
+
+			// Add an environment
+			apim := GetDevClient()
+			output, err := testutils.AddEnvironmentWithOutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+
+			// Validate added environment
+			assert.Nil(t, err)
+			testutils.ValidateAddedEnvironments(t, output, apim.GetEnvName(), true)
+
+			// Login to the added environment
+			base.Execute(t, "login", apim.GetEnvName(), "-u", devopsUsername, "-p", devopsPassword)
+
+			// Remove the added environment
+			removeEnvOutput, errr := testutils.RemoveEnvironment(t, apim.GetEnvName())
+			assert.Nil(t, errr)
+
+			//Validate removed environment
+			testutils.ValidateRemoveEnvironments(t, removeEnvOutput, apim.GetEnvName())
+		})
+	}
+}
+
+// Remove an added Environment when an user is logged into the environment
+func TestRemoveEnvironmentWithoutLoggedInUsers(t *testing.T) {
+
+	// Add an environment
+	apim := GetDevClient()
+	output, err := testutils.AddEnvironmentWithOutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+
+	// Validate added environment
+	assert.Nil(t, err)
+	testutils.ValidateAddedEnvironments(t, output, apim.GetEnvName(), true)
+
+	// Remove the added environment
+	removeEnvOutput, errr := testutils.RemoveEnvironment(t, apim.GetEnvName())
+	assert.Nil(t, errr)
+
+	//Validate removed environment
+	testutils.ValidateRemoveEnvironments(t, removeEnvOutput, apim.GetEnvName())
 }
 
 //Change Export directory using apictl and assert the change

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -59,14 +59,34 @@ func TestRunApictlWithCustomDirectoryLocation(t *testing.T) {
 	testutils.ValidateCustomDirectoryChangeAtInit(t, absolutePathOfCustomDir)
 }
 
+// Adding a new Environments with -- token flag and list them and check it
+func TestAddEnvironmentWithToken(t *testing.T) {
+	apim := GetDevClient()
+	output, err := testutils.AddEnvironmentWithTokenFlag(t, apim.GetEnvName(), apim.GetApimURL(), apim.GetTokenURL())
+
+	// Validate added environment
+	assert.Nil(t, err)
+	testutils.ValidateAddedEnvironments(t, output, apim.GetEnvName(), false)
+}
+
+// Adding a new Environments without -- token flag and list them and check it
+func TestAddEnvironmentWithoutToken(t *testing.T) {
+	apim := GetDevClient()
+	output, err := testutils.AddEnvironmentWithOutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
+
+	// Validate added environment
+	assert.Nil(t, err)
+	testutils.ValidateAddedEnvironments(t, output, apim.GetEnvName(), false)
+}
+
 //Get Environments using apictl
 func TestGetEnvironments(t *testing.T) {
 	apim := GetDevClient()
+	//Adding a new environment
 	base.SetupEnvWithoutTokenFlag(t, apim.GetEnvName(), apim.GetApimURL())
-	response, _ := base.Execute(t, "get", "envs")
-	base.GetRowsFromTableResponse(response)
-	base.Log(response)
-	assert.Contains(t, response, apim.GetEnvName(), "TestGetEnvironments Failed")
+
+	// Validate added environment list
+	testutils.ValidateEnvsList(t, apim.GetEnvName())
 }
 
 //Change Export directory using apictl and assert the change

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -31,6 +31,34 @@ import (
 
 const defaultExportPath = utils.DefaultExportDirName
 
+// Run apictl without any environments or .wso2apictl config folder
+func TestRunApictlWithoutAnyEnvironments(t *testing.T) {
+
+	output, err := testutils.InitApictl(t)
+
+	// Validate apictl initialization
+	testutils.ValidateApictlInit(t, err, output)
+}
+
+// Run apictl by setting a custom wso2apictl directory location by specifying the APICTL_CONFIG_DIR environment variable
+func TestRunApictlWithCustomDirectoryLocation(t *testing.T) {
+
+	// Get absolute path of the custom Directory and create temp custom directory
+	absolutePathOfCustomDir, _ := filepath.Abs(testutils.CustomDirectoryAtInit)
+	_ = utils.CreateDirIfNotExist(absolutePathOfCustomDir)
+
+	testutils.SetApictlWithCustomDirectory(t, absolutePathOfCustomDir)
+
+	// Initializing apictl
+	output, err := testutils.InitApictl(t)
+
+	// Validate apictl initialization
+	testutils.ValidateApictlInit(t, err, output)
+
+	// Validate custom directory change at init
+	testutils.ValidateCustomDirectoryChangeAtInit(t, absolutePathOfCustomDir)
+}
+
 //Get Environments using apictl
 func TestGetEnvironments(t *testing.T) {
 	apim := GetDevClient()

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -19,6 +19,7 @@
 package testutils
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -69,6 +70,44 @@ func ValidateCustomDirectoryChangeAtInit(t *testing.T, customDirPath string) {
 		// Remove created custom directory directory
 		base.RemoveDir(customDirPath)
 	})
+}
+
+// AddEnvironmentWithTokenFlag : Add new environment with token endpoint url
+func AddEnvironmentWithTokenFlag(t *testing.T, envName, apimUrl, tokenUrl string) (string, error) {
+	return base.Execute(t, "add", "env", envName, "--apim", apimUrl, "--token", tokenUrl)
+}
+
+// AddEnvironmentWithOutTokenFlag : Add new environment without token endpoint url
+func AddEnvironmentWithOutTokenFlag(t *testing.T, envName, apimUrl string) (string, error) {
+	return base.Execute(t, "add", "env", envName, "--apim", apimUrl)
+}
+
+// ValidateAddedEnvironments : Check whether the added environments are added as expected when listed
+func ValidateAddedEnvironments(t *testing.T, output, envName string, skipCleanup bool) {
+
+	expectedOutput := fmt.Sprintf(`Successfully added environment '%v'`, envName)
+	assert.Equal(t, expectedOutput+"\n", output)
+
+	//List all the environments and check for availability of the added environment
+	ValidateEnvsList(t, envName)
+
+	if skipCleanup == false {
+		t.Cleanup(func() {
+			base.Execute(t, "remove", "env", envName)
+		})
+	}
+}
+
+func ValidateEnvsList(t *testing.T, envName string) {
+	// List environments
+	response, err := base.Execute(t, "get", "envs")
+	assert.Nil(t, err)
+
+	base.GetRowsFromTableResponse(response)
+	base.Log(response)
+
+	//Check added environment in the list
+	assert.Contains(t, response, envName, "TestGetEnvironments Failed")
 }
 
 func InitProjectWithOasFlag(t *testing.T, args *InitTestArgs) (string, error) {

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -35,6 +35,42 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
+// InitApictl : Initializes apictl in the local machine and create directories
+func InitApictl(t *testing.T) (string, error) {
+	return base.Execute(t)
+}
+
+// SetApictlWithCustomDirectory : Set custom directory location using environment variable
+func SetApictlWithCustomDirectory(t *testing.T, customDirPath string) {
+
+	t.Log("Setting up the environment variable value for " + EnvVariableNameOfCustomCustomDirectoryAtInit)
+	os.Setenv(EnvVariableNameOfCustomCustomDirectoryAtInit, customDirPath)
+}
+
+// ValidateApictlInit : Check and verify whether the apictl is initialized properly
+func ValidateApictlInit(t *testing.T, err error, output string) {
+
+	// Asserting the apictl initializing message to check whether apictl is initialized or not.
+	assert.Nil(t, err)
+	assert.Contains(t, output, ApictlInitMessage, "Test failed without initializing apictl")
+}
+
+// ValidateCustomDirectoryChangeAtInit :  Validate custom directory change at init
+func ValidateCustomDirectoryChangeAtInit(t *testing.T, customDirPath string) {
+
+	//Check .wso2apictl and .wso2apictl.local directories on custom directories
+	checkConfigDir, _ := utils.IsDirExists(filepath.Join(customDirPath, utils.ConfigDirName))
+	checkLocalCredentialsDir, _ := utils.IsDirExists(filepath.Join(customDirPath, utils.LocalCredentialsDirectoryName))
+
+	assert.Equal(t, true, checkConfigDir)
+	assert.Equal(t, true, checkLocalCredentialsDir)
+
+	t.Cleanup(func() {
+		// Remove created custom directory directory
+		base.RemoveDir(customDirPath)
+	})
+}
+
 func InitProjectWithOasFlag(t *testing.T, args *InitTestArgs) (string, error) {
 	//Setup Environment and login to it.
 	base.SetupEnvWithoutTokenFlag(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL())

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -82,14 +82,19 @@ func AddEnvironmentWithOutTokenFlag(t *testing.T, envName, apimUrl string) (stri
 	return base.Execute(t, "add", "env", envName, "--apim", apimUrl)
 }
 
+// RemoveEnvironment : Remove an added environment
+func RemoveEnvironment(t *testing.T, envName string) (string, error) {
+	return base.Execute(t, "remove", "env", envName)
+}
+
 // ValidateAddedEnvironments : Check whether the added environments are added as expected when listed
 func ValidateAddedEnvironments(t *testing.T, output, envName string, skipCleanup bool) {
 
 	expectedOutput := fmt.Sprintf(`Successfully added environment '%v'`, envName)
-	assert.Equal(t, expectedOutput+"\n", output)
+	assert.Contains(t, output, expectedOutput)
 
 	//List all the environments and check for availability of the added environment
-	ValidateEnvsList(t, envName)
+	ValidateEnvsList(t, envName, true)
 
 	if skipCleanup == false {
 		t.Cleanup(func() {
@@ -98,7 +103,18 @@ func ValidateAddedEnvironments(t *testing.T, output, envName string, skipCleanup
 	}
 }
 
-func ValidateEnvsList(t *testing.T, envName string) {
+// ValidateRemoveEnvironments : Check whether the added environments is removed
+func ValidateRemoveEnvironments(t *testing.T, output, envName string) {
+
+	expectedOutput := fmt.Sprintf(`Successfully removed environment '%v'`, envName)
+	assert.Contains(t, output, expectedOutput)
+
+	//List all the environments and check for availability of the removed environment
+	ValidateEnvsList(t, envName, false)
+}
+
+// ValidateEnvsList : Check the list and verify the given env is in the list or not
+func ValidateEnvsList(t *testing.T, envName string, checkContains bool) {
 	// List environments
 	response, err := base.Execute(t, "get", "envs")
 	assert.Nil(t, err)
@@ -107,7 +123,11 @@ func ValidateEnvsList(t *testing.T, envName string) {
 	base.Log(response)
 
 	//Check added environment in the list
-	assert.Contains(t, response, envName, "TestGetEnvironments Failed")
+	if checkContains == true {
+		assert.Contains(t, response, envName, "TestGetEnvironments Failed")
+	} else {
+		assert.NotContains(t, response, envName, "TestGetEnvironments Failed")
+	}
 }
 
 func InitProjectWithOasFlag(t *testing.T, args *InitTestArgs) (string, error) {

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -86,6 +86,9 @@ const APISecurityBasicParamsFile = EnvParamsFilesDir + "/api_params_security_bas
 // APIFullParamsFile : Full api_params.yaml
 const APIFullParamsFile = EnvParamsFilesDir + "/api_params_full.yaml"
 
+// APIDynamicDataParamsFile : api_params.yaml with dynamic data
+const APIDynamicDataParamsFile = EnvParamsFilesDir + "/api_params_dynamic_data.yaml"
+
 // APIProductFullParamsFile : Full api_product_params.yaml
 const APIProductFullParamsFile = EnvParamsFilesDir + "/api_product_params_full.yaml"
 
@@ -95,29 +98,8 @@ const CertificatesDirectoryPath = "testdata/TestArtifactDirectory/certificates"
 // UnlimitedPolicy : Unlimited Throttle Policy
 const UnlimitedPolicy = "Unlimited"
 
-// TenPerMinAppThrottlingPolicy: 10 per min application throttling policy
+// TenPerMinAppThrottlingPolicy : 10 per min application throttling policy
 const TenPerMinAppThrottlingPolicy = "10PerMin"
-
-// API types
-const APITypeREST = "HTTP"
-const APITypeSoap = "SOAP"
-const APITypeSoapToRest = "SOAPTOREST"
-const APITypeGraphQL = "GraphQL"
-const APITypeWebScoket = "WS"
-const APITypeWebSub = "WEBSUB"
-const APITypeSSE = "SSE"
-
-// REST API Endpoint URL
-const RESTAPIEndpoint = "petstore.swagger.io"
-
-// SOAP API Endpoint URL
-const SoapEndpointURL = "http://ws.cdyne.com/phoneverify/phoneverify.asmx"
-
-// GraphQL API Endpoint URL
-const GraphQLEndpoint = "http://www.mocky.io/v2/5ea84def2d0000a52d3a3ecd"
-
-// Web Socket API Endpoint URL
-const WebSocketEndpoint = "ws://echo.websocket.org:80"
 
 // APIHttpRestEndpointWithoutLoadBalancingOrFailoverParamsFile : HTTP/REST Endpoint without Loadbalancing and Failover URLs in api_params.yaml
 const APIHttpRestEndpointWithoutLoadBalancingOrFailoverParamsFile = EnvParamsFilesDir + "/api_params_http_rest_endpoint_without_lb_or_failover.yaml"
@@ -145,3 +127,24 @@ const APIAwsEndpointWithStoredCredentialsParamsFile = EnvParamsFilesDir + "/api_
 
 // APIDynamicEndpointParamsFile : Dynamic Endpoint with stored credentials in api_params.yaml
 const APIDynamicEndpointParamsFile = EnvParamsFilesDir + "/api_params_dynamic_endpoint.yaml"
+
+// API types
+const APITypeREST = "HTTP"
+const APITypeSoap = "SOAP"
+const APITypeSoapToRest = "SOAPTOREST"
+const APITypeGraphQL = "GraphQL"
+const APITypeWebScoket = "WS"
+const APITypeWebSub = "WEBSUB"
+const APITypeSSE = "SSE"
+
+// REST API Endpoint URL
+const RESTAPIEndpoint = "petstore.swagger.io"
+
+// SOAP API Endpoint URL
+const SoapEndpointURL = "http://ws.cdyne.com/phoneverify/phoneverify.asmx"
+
+// GraphQL API Endpoint URL
+const GraphQLEndpoint = "http://www.mocky.io/v2/5ea84def2d0000a52d3a3ecd"
+
+// Web Socket API Endpoint URL
+const WebSocketEndpoint = "ws://echo.websocket.org:80"

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -18,7 +18,13 @@
 
 package testutils
 
+//Environment management related test constants
+const ApictlInitMessage = "apictl is a Command Line Tool for Importing and Exporting APIs and Applications between " +
+	"different environments of WSO2 API Manager"
 const CustomTestExportDirectory = "CustomExportDirectory"
+const CustomDirectoryAtInit = "CustomExportDirectoryAtInit"
+const EnvVariableNameOfCustomCustomDirectoryAtInit = "APICTL_CONFIG_DIR"
+
 const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
 const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
 const TestOpenAPI3DefinitionWithoutEndpointsPath = "testdata/openAPI3DefinitionWithoutEndpoints.yaml"
@@ -57,6 +63,9 @@ const TestArtifact3Path = "testdata/TestArtifactDirectory/ArtifactSet3"
 const TestDefaultExtractedFileName = "/SwaggerPetstoreNew-1.0.0"
 const CustomDynamicInSequenceName = "custom-header-in.xml"
 
+//Environment specific testcase constants
+
+// EnvParamsFilesDir : Directory that stored environment specific test resources
 const EnvParamsFilesDir = "testdata/EnvParamsFiles"
 
 // APIEndpointParamsFile : Endpoint URL api_params.yaml
@@ -77,13 +86,10 @@ const APISecurityBasicParamsFile = EnvParamsFilesDir + "/api_params_security_bas
 // APIFullParamsFile : Full api_params.yaml
 const APIFullParamsFile = EnvParamsFilesDir + "/api_params_full.yaml"
 
-// APIDynamicDataParamsFile : api_params.yaml with dynamic data
-const APIDynamicDataParamsFile = EnvParamsFilesDir + "/api_params_dynamic_data.yaml"
-
 // APIProductFullParamsFile : Full api_product_params.yaml
 const APIProductFullParamsFile = EnvParamsFilesDir + "/api_product_params_full.yaml"
 
-// CertificatesDirectoryPath : Directory path for the dunnmy certificates
+// CertificatesDirectoryPath : Directory path for the dummy certificates
 const CertificatesDirectoryPath = "testdata/TestArtifactDirectory/certificates"
 
 // UnlimitedPolicy : Unlimited Throttle Policy


### PR DESCRIPTION
## Purpose
This PR will add integration tests for Managing environments of apictl and setup apictl at the startup.

## Goals
Add Integration tests for

- Init Apictl
- Add environments
- Remove environments

## Approach
These test cases will be added with this PR.
1. Run apictl without any environments or .wso2apictl config folder - **TestRunApictlWithoutAnyEnvironments**
2. Run apictl by setting a custom wso2apictl directory location by specifying the APICTL_CONFIG_DIR environment variable - **TestRunApictlWithCustomDirectoryLocation**
3. Adding a new Environments with -- token flag and list them and verify it - **TestAddEnvironmentWithTokenEndpoint**
4. Adding a new Environments without -- token flag and list them and verify it - **TestAddEnvironmentWithoutTokenEndpoint**
5. Remove an added Environment when a user is logged into the environment (Written in Table driven format for 4 different users) - **TestRemoveEnvironmentWithLoggedInUsers**
6. Remove an added Environment when a user is logged into the environment- **TestRemoveEnvironmentWithoutLoggedInUsers**

## Test environment
Ubuntu 20.04.2 LTS
go version go1.16.3 linux/amd64
 