### PR TITLE
Adding the tests for import update (with/without params) and refactor gen deployment-dir tests to the table driven format

### DIFF
--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -169,8 +169,8 @@ func AddAPIFromOpenAPIDefinition(t *testing.T, client *apim.Client, username str
 }
 
 func AddAPIFromOpenAPIDefinitionToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
-	path := "testdata/petstore.yaml"
 	client1.Login(username, password)
+	path := GetSwaggerPetstoreDefinition(t, username)
 	additionalProperties := client1.GenerateAdditionalProperties(username, RESTAPIEndpoint, APITypeREST, nil)
 	id1 := client1.AddAPIFromOpenAPIDefinition(t, path, additionalProperties, username, password)
 	api1 := client1.GetAPI(id1)

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -160,8 +160,8 @@ func AddAPIToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, u
 }
 
 func AddAPIFromOpenAPIDefinition(t *testing.T, client *apim.Client, username string, password string) *apim.API {
-	path := "testdata/petstore.yaml"
 	client.Login(username, password)
+	path := GetSwaggerPetstoreDefinition(t, username)
 	additionalProperties := client.GenerateAdditionalProperties(username, RESTAPIEndpoint, APITypeREST, nil)
 	id := client.AddAPIFromOpenAPIDefinition(t, path, additionalProperties, username, password)
 	api := client.GetAPI(id)
@@ -365,21 +365,27 @@ func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 		params = append(params, "--params", args.ParamsFile)
 	}
 
+	if args.Update {
+		params = append(params, "--update=true")
+	}
+
 	output, err := base.Execute(t, params...)
 
-	t.Cleanup(func() {
-		if strings.EqualFold("PUBLISHED", args.Api.LifeCycleStatus) {
-			args.CtlUser.Username, args.CtlUser.Password =
-				apim.RetrieveAdminCredentialsInsteadCreator(args.CtlUser.Username, args.CtlUser.Password)
-		}
-		err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
+	if !args.Update {
+		t.Cleanup(func() {
+			if strings.EqualFold("PUBLISHED", args.Api.LifeCycleStatus) {
+				args.CtlUser.Username, args.CtlUser.Password =
+					apim.RetrieveAdminCredentialsInsteadCreator(args.CtlUser.Username, args.CtlUser.Password)
+			}
+			err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
 
-		if err != nil {
-			t.Fatal(err)
-		}
-		base.WaitForIndexing()
-	})
+			if err != nil {
+				t.Fatal(err)
+			}
+			base.WaitForIndexing()
+		})
 
+	}
 	return output, err
 }
 

--- a/import-export-cli/integration/testutils/dynamicData_testUtils.go
+++ b/import-export-cli/integration/testutils/dynamicData_testUtils.go
@@ -42,6 +42,7 @@ const (
 
 func SetEnvVariablesForAPI(t *testing.T, client *apim.Client) {
 
+	t.Log("Setting up the environment variable values")
 	os.Setenv(devEnvProdUrl, "https://localhost:"+strconv.Itoa(9443+client.GetPortOffset())+
 		"/am/sample/pizzashack/v1/api/")
 	os.Setenv(devEnvSandUrl, "https://localhost:"+strconv.Itoa(9443+client.GetPortOffset())+
@@ -51,6 +52,7 @@ func SetEnvVariablesForAPI(t *testing.T, client *apim.Client) {
 	os.Setenv(envKey, "dev_101")
 
 	t.Cleanup(func() {
+		t.Log("Unsetting the environment variable values")
 		os.Unsetenv(devEnvProdUrl)
 		os.Unsetenv(devEnvSandUrl)
 		os.Unsetenv(devEnvProdRetryDelay)

--- a/import-export-cli/integration/testutils/gateway_testUtils.go
+++ b/import-export-cli/integration/testutils/gateway_testUtils.go
@@ -129,7 +129,7 @@ func ValidateAPIUndeployFailure(t *testing.T, args *UndeployTestArgs, provider, 
 
 	assert.NotNil(t, err, "Should not return nil error")
 	assert.Contains(t, base.GetValueOfUniformResponse(result), "Exit status 1",
-		"Test failed because API Product was undeployed successfully")
+		"Test failed because API was undeployed successfully")
 }
 
 func ValidateDeployedGateways(t *testing.T, deployedRevisionsBeforeUndeploy *apim.APIRevisionList,

--- a/import-export-cli/integration/testutils/swaggerPetstore_testUtils.go
+++ b/import-export-cli/integration/testutils/swaggerPetstore_testUtils.go
@@ -1,0 +1,119 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package testutils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	yaml2 "gopkg.in/yaml.v2"
+)
+
+func GetSwaggerPetstoreDefinition(t *testing.T, username string) string {
+	path := "testdata/petstore.yaml"
+	tempSwaggerPetstoreFileNameforUser := "testdata" + string(os.PathSeparator) + base.GenerateRandomString() + "-" + username + ".yaml"
+
+	sampleData, _ := ioutil.ReadFile(path)
+
+	// Extract the content to a structure
+	petstoreDefinitionMap := make(map[interface{}]interface{})
+	err := yaml2.Unmarshal(sampleData, &petstoreDefinitionMap)
+	if err != nil {
+		t.Error(err)
+	}
+	//fmt.Printf("--- m:\n%v\n\n", petstoreDefinitionMap)
+
+	scope1 := base.GenerateRandomString() + username + "Scope1"
+	scope2 := base.GenerateRandomString() + username + "Scope2"
+	petstoreDefinitionMapKeys := keys(petstoreDefinitionMap)
+
+	if contains(petstoreDefinitionMapKeys, "paths") {
+		paths := petstoreDefinitionMap["paths"].(map[interface{}]interface{})
+		for _, pathKey := range keys(paths) {
+			resourcePath := paths[pathKey].(map[interface{}]interface{})
+			for _, resourcePathKey := range keys(resourcePath) {
+				resourcePathHtppVerb := resourcePath[resourcePathKey].(map[interface{}]interface{})
+				resourcePathHtppVerbKeys := keys(resourcePathHtppVerb)
+				if contains(resourcePathHtppVerbKeys, "security") {
+					petstoreAuth := map[string]interface{}{
+						"petstore_auth": []interface{}{scope1, scope2},
+					}
+					updatedSecurityField := []interface{}{petstoreAuth}
+					resourcePathHtppVerb["security"] = updatedSecurityField
+				}
+			}
+		}
+	}
+
+	if contains(petstoreDefinitionMapKeys, "securityDefinitions") {
+		securityDefinitions := petstoreDefinitionMap["securityDefinitions"].(map[interface{}]interface{})
+		for _, securityDefinitionKey := range keys(securityDefinitions) {
+			securityDefinitionKeyProperties := securityDefinitions[securityDefinitionKey].(map[interface{}]interface{})
+			securityDefinitionKeyPropertiesKeys := keys(securityDefinitionKeyProperties)
+			if contains(securityDefinitionKeyPropertiesKeys, "scopes") {
+				updatedScopesField := map[string]interface{}{
+					scope1: "Description of " + scope1,
+					scope2: "Description of " + scope2,
+				}
+				securityDefinitionKeyProperties["scopes"] = updatedScopesField
+			}
+		}
+	}
+
+	swaggerData, err := yaml2.Marshal(petstoreDefinitionMap)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = ioutil.WriteFile(tempSwaggerPetstoreFileNameforUser, swaggerData, os.ModePerm)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Cleanup(func() {
+		// Remove extracted archive
+		base.RemoveDir(tempSwaggerPetstoreFileNameforUser)
+	})
+
+	return tempSwaggerPetstoreFileNameforUser
+}
+
+// keys returns a string array of the keys of a map
+func keys(m map[interface{}]interface{}) []interface{} {
+	keys := make([]interface{}, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+// contains checks if a string is present in a slice
+func contains(s []interface{}, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -46,6 +46,7 @@ type ApiImportExportTestArgs struct {
 	Revision         string
 	IsDeployed       bool
 	IsLatest         bool
+	Update           bool
 }
 
 type ApiProductImportExportTestArgs struct {


### PR DESCRIPTION
## Purpose
Adding the tests for import update (with params as well) .

## Goals
Adding the missing tests for update import.

## Approach
Refactored existing two (2) tests to have table driven format and to accomplish the above stated goal which will cover eight (8) user scenarios (admin, devops - both super tenant and tenant) from a single test.
1. Update an existing API by importing it again by providing api_params.yaml with different endpoint configs for prod and dev environments (with --update flag) - **TestEnvironmentSpecificParamsEndpoint**
2. Update an existing API which was imported as different owner (without preserving provider) by importing it - **TestImportProjectCreatedPassWhenAPIIsExisted**

Refactored existing two (2) tests related to **apictl gen deployment-dir** command to have table driven format which will cover eight (8) user scenarios (admin, devops - both super tenant and tenant) from a single test.

## User stories
The user stories covered by the above test cases.

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64