### PR TITLE
[3.2.x] Support to override the subscription policies using the api_params.yaml

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -159,6 +159,8 @@ type Environment struct {
 	MutualSslCerts []MutualSslCert `yaml:"mutualSslCerts"`
 	// VCS params for the environment
 	VCS APIVCSParams `yaml:"vcs"`
+	// Policies contains the available subscription policies in an environment that can be enforced to an API
+	Policies []string `yaml:"policies"`
 }
 
 // ApiParams represents environments defined in configuration file


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/564

## Goals
Providing the capability to override the Subscription tiers (of an API) in api.yaml using api_params.yaml file, if the user wants.

## Approach
This procedure modified the template of api_params.yaml as shown in the below example. 
 - A new field was added as **policies** which is an array that conists the subscription tier names for an API in an environment.
```
environments:
  - name: test
    endpoints:
     production:
       url: 'http://dev.doo.com'
       config:
         retryTimeOut: 60
         retryDelay: 70
         factor: 2
     sandbox:
        url: 'http://test.foo.sandbox.com'
    security:
        enabled: true
        type: basic ( or digest )
        username: admin
        password: admin
    policies:
        - Gold
        - Silver
```

## User stories
- If policies parameter is set in api_params.yaml file, override the values in api.yaml file.
- If policies parameter is not set in api_params.yaml file, use the values in api.yaml file. (The old procedure)

## Documentation
Documentation changes should be done. 

## Test environment
- Ubuntu 20.04.1 LTS
- go version go1.14.4 linux/amd64