### PR TITLE
[3.2.0] Fixing the app name not URL encoding isse for 3.2.x

### DIFF
--- a/import-export-cli/cmd/exportApp.go
+++ b/import-export-cli/cmd/exportApp.go
@@ -133,11 +133,7 @@ func replaceUserStoreDomainDelimiter(username string) string {
 // @return response Response in the form of *resty.Response
 func getExportAppResponse(name, owner, adminEndpoint, accessToken string) (*resty.Response, error) {
 	adminEndpoint = utils.AppendSlashToString(adminEndpoint)
-	query := "export/applications?appName=" + name + utils.SearchAndTag + "appOwner=" + owner
-
-	if exportAppWithKeys {
-		query += "&withKeys=true"
-	}
+	query := "export/applications"
 
 	url := adminEndpoint + query
 	utils.Logln(utils.LogPrefixInfo+"ExportApp: URL:", url)
@@ -145,7 +141,15 @@ func getExportAppResponse(name, owner, adminEndpoint, accessToken string) (*rest
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
 
-	resp, err := utils.InvokeGETRequest(url, headers)
+	queryParams := map[string]string{
+		"appName":  name,
+		"appOwner": owner,
+	}
+	if exportAppWithKeys {
+		queryParams["withKeys"] = "true"
+	}
+
+	resp, err := utils.InvokeGETRequestWithMultipleQueryParams(queryParams, url, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -433,6 +433,16 @@ func (instance *Client) GenerateSampleAppData() *Application {
 	return &app
 }
 
+// GenerateSampleAppData : Generate sample Application object with space in the application Name
+func (instance *Client) GenerateSampleAppWithNameInSpaceData() *Application {
+	app := Application{}
+	app.Name = generateRandomString() + "Test Application"
+	app.ThrottlingPolicy = "Unlimited"
+	app.Description = "Test Application with space in the name"
+	app.TokenType = "JWT"
+	return &app
+}
+
 // CopyApp : Create a deep copy of an Application object
 func CopyApp(appToCopy *Application) Application {
 	appCopy := Application{}

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -412,3 +412,28 @@ func TestDeleteAppSuperTenantUser(t *testing.T) {
 
 	testutils.ValidateAppDelete(t, args)
 }
+
+// Export an application with space in application name  and import it to another environment while preserving
+// the owner by a user with Internal/devops role to check whether the url encoding is working properly
+func TestExportImportOwnAppWithSpaceInAppName(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	app := testutils.AddAppWithSpaceInAppName(t, dev, adminUsername, adminPassword)
+
+	args := &testutils.AppImportExportTestArgs{
+		AppOwner:    testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Application: app,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAppExportImportWithPreserveOwner(t, args)
+}

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -14,4 +14,4 @@ indexing-delay: 1000
 
 dcr-version: v0.17
 rest-api-version: v1
-apictl-version: 3.2.0
+apictl-version: 3.2.3

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -35,6 +35,13 @@ func AddApp(t *testing.T, client *apim.Client, username string, password string)
 	return client.AddApplication(t, app, username, password, doClean)
 }
 
+func AddAppWithSpaceInAppName(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
+	client.Login(username, password)
+	app := client.GenerateSampleAppWithNameInSpaceData()
+	doClean := true
+	return client.AddApplication(t, app, username, password, doClean)
+}
+
 func AddApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
 	client.Login(username, password)
 	application := client.GenerateSampleAppData()

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -662,6 +662,12 @@ _apictl_delete_api()
     flags+=("--verbose")
 
     must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--version=")
+    must_have_one_flag+=("-v")
     must_have_one_noun=()
     noun_aliases=()
 }


### PR DESCRIPTION
## Purpose
When using the APICTL 3.2.2 tool to export an Application using export-app, if the Application name contains spaces, then we must specify the encoded %20 Unicode in the command parameters as it will not take the unencoded SPACE. This PR will solve this one.

## Goals

- Fixes https://github.com/wso2/product-apim-tooling/issues/759
- Adding test case related to this one

## Approach
After the Fix
![Screenshot from 2021-07-02 16-51-52](https://user-images.githubusercontent.com/42435576/124267430-de1bd080-db55-11eb-9101-77b2e104d3c9.png)


## Automation tests

 - Integration tests
   **TestExportImportOwnAppWithSpaceInAppName** - // Export an application with space in application name  and import it to another environment while preserving the owner by a user with Internal/devops role to check whether the url encoding is working properly

