### PR TITLE
Fixing the app name not URL encoding isse

### DIFF
--- a/import-export-cli/impl/exportApp.go
+++ b/import-export-cli/impl/exportApp.go
@@ -42,15 +42,8 @@ func ExportAppFromEnv(accessToken, name, owner, format, exportEnvironment string
 // @return response Response in the form of *resty.Response
 func ExportApp(name, owner, format, devportalApplicationsEndpoint, accessToken string, exportAppWithKeys bool) (*resty.Response, error) {
 	devportalApplicationsEndpoint = utils.AppendSlashToString(devportalApplicationsEndpoint)
-	query := "export?appName=" + name + utils.SearchAndTag + "appOwner=" + owner
 
-	if exportAppWithKeys {
-		query += "&withKeys=true"
-	}
-
-	if format != "" {
-		query += "&format=" + format
-	}
+	query := "export"
 
 	url := devportalApplicationsEndpoint + query
 	utils.Logln(utils.LogPrefixInfo+"ExportApp: URL:", url)
@@ -58,7 +51,18 @@ func ExportApp(name, owner, format, devportalApplicationsEndpoint, accessToken s
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
 
-	resp, err := utils.InvokeGETRequest(url, headers)
+	queryParams := map[string]string{
+		"appName":  name,
+		"appOwner": owner,
+	}
+	if exportAppWithKeys {
+		queryParams["withKeys"] = "true"
+	}
+	if format != "" {
+		queryParams["format"] = format
+	}
+
+	resp, err := utils.InvokeGETRequestWithMultipleQueryParams(queryParams, url, headers)
 	if err != nil {
 		return nil, err
 	}

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -430,6 +430,17 @@ func (instance *Client) GenerateSampleAppData() *Application {
 	return &app
 }
 
+// GenerateSampleAppData : Generate sample Application object with space in the application Name
+func (instance *Client) GenerateSampleAppWithNameInSpaceData() *Application {
+	app := Application{}
+	app.Name = base.GenerateRandomString() + "Test Application"
+	app.ThrottlingPolicy = "Unlimited"
+	app.Description = "Test Application with space in the name"
+	app.TokenType = "JWT"
+	return &app
+}
+
+
 // CopyApp : Create a deep copy of an Application object
 func CopyApp(appToCopy *Application) Application {
 	appCopy := Application{}

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -440,7 +440,6 @@ func (instance *Client) GenerateSampleAppWithNameInSpaceData() *Application {
 	return &app
 }
 
-
 // CopyApp : Create a deep copy of an Application object
 func CopyApp(appToCopy *Application) Application {
 	appCopy := Application{}

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -481,7 +481,6 @@ func TestDeleteApp(t *testing.T) {
 	}
 }
 
-
 // Export an application with space in application name  and import it to another  to check whether the url
 // encoding is working properly
 func TestExportImportOwnAppWithSpaceInAppName(t *testing.T) {

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -480,3 +480,28 @@ func TestDeleteApp(t *testing.T) {
 		})
 	}
 }
+
+
+// Export an application with space in application name  and import it to another  to check whether the url
+// encoding is working properly
+func TestExportImportOwnAppWithSpaceInAppName(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			app := testutils.AddAppWithSpaceInAppName(t, dev, user.CtlUser.Username, user.CtlUser.Password)
+
+			args := &testutils.AppImportExportTestArgs{
+				AppOwner:      testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				CtlUser:       testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Application:   app,
+				SrcAPIM:       dev,
+				DestAPIM:      prod,
+				PreserveOwner: true,
+			}
+
+			testutils.ValidateAppExportImport(t, args, true)
+		})
+	}
+}

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -489,10 +489,10 @@ func TestExportImportOwnAppWithSpaceInAppName(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			app := testutils.AddAppWithSpaceInAppName(t, dev, user.CtlUser.Username, user.CtlUser.Password)
+			app := testutils.AddAppWithSpaceInAppName(t, dev, user.ApiSubscriber.Username, user.ApiSubscriber.Password)
 
 			args := &testutils.AppImportExportTestArgs{
-				AppOwner:      testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				AppOwner:      testutils.Credentials{Username: user.ApiSubscriber.Username, Password: user.ApiSubscriber.Password},
 				CtlUser:       testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Application:   app,
 				SrcAPIM:       dev,

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -41,6 +41,13 @@ func AddApp(t *testing.T, client *apim.Client, username string, password string)
 	return client.AddApplication(t, app, username, password, doClean)
 }
 
+func AddAppWithSpaceInAppName(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
+	client.Login(username, password)
+	app := client.GenerateSampleAppWithNameInSpaceData()
+	doClean := true
+	return client.AddApplication(t, app, username, password, doClean)
+}
+
 func AddApplicationWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.Application {
 	client.Login(username, password)
 	application := client.GenerateSampleAppData()


### PR DESCRIPTION
## Purpose
When using the APICTL  tool to export an Application using export-app, if the Application name contains spaces, then we must specify the encoded %20 Unicode in the command parameters as it will not take the unencoded SPACE. This PR will solve this one.

## Goals

- Fixes https://github.com/wso2/product-apim-tooling/issues/759 for master 
- Adding test case related to this one

## Approach
After the Fix
![Screenshot from 2021-07-02 16-51-52](https://user-images.githubusercontent.com/42435576/124267430-de1bd080-db55-11eb-9101-77b2e104d3c9.png)


## Automation tests

 - Integration tests
   **TestExportImportOwnAppWithSpaceInAppName** - // Export an application with space in application name  and import it to another environment to check whether the url encoding is working properly

