### PR TITLE
[1.1.x] Add doc generation tools for 1.1.x branch

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -1,5 +1,5 @@
 # CLI for Importing and Exporting APIs and Applications
-## For WSO2 API Manager 2.2.0
+## For WSO2 API Manager 2.5.0
 
 Command Line tool for importing and exporting APIs/Applications between different API Environemnts
 
@@ -16,7 +16,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apimcli.go -v 1.0.0 -f` to build for all platforms.
+    Execute `./build.sh -t apimcli.go -v 1.1.0 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
       
@@ -29,6 +29,11 @@ Command Line tool for importing and exporting APIs/Applications between differen
     
     Execute `apimcli --help` for further instructions.
 
+- ### Generating docs
+  After changing commands run following to generate documents and shell completions
+  `go run tools/gen.go`
+  Commit changes to version control
+  
 - ### Adding Environments
     Add environments by either manually editing `$HOME/.wso2apimcli/main_config.yaml` or using the command
     `apimcli add-env`.

--- a/import-export-cli/tools/gen.go
+++ b/import-export-cli/tools/gen.go
@@ -1,0 +1,38 @@
+//+build ignore
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra/doc"
+	"github.com/wso2/product-apim-tooling/import-export-cli/cmd"
+)
+
+func main() {
+	log.Println("Generating docs...")
+	cmd.RootCmd.DisableAutoGenTag = true
+	err := doc.GenMarkdownTree(cmd.RootCmd, "docs")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.MkdirAll("shell-completions", os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Generating bash completions...")
+	err = cmd.RootCmd.GenBashCompletionFile(filepath.FromSlash("./shell-completions/apimcli_bash_completions.sh"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("Generating zsh completions...")
+	err = cmd.RootCmd.GenZshCompletionFile(filepath.FromSlash("./shell-completions/apimcli_zsh_completions.sh"))
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Purpose
Add doc generation tools for 1.1.x branch. 
 

- After changing commands run the following to generate documents and shell completions

  `go run tools/gen.go`
This will be supported via this PR


