### PR TITLE
Adding a test for additional properties update of application oauth keys

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -1487,7 +1487,7 @@ func (instance *Client) GenerateKeys(t *testing.T, keyGenRequest utils.KeygenReq
 }
 
 // GetOauthKeys : Get Oauth keys of an application
-func (instance *Client) GetOauthKeys(t *testing.T, application *Application) *ApplicationKey {
+func (instance *Client) GetOauthKeys(t *testing.T, application *Application) *ApplicationKeysList {
 	appsURL := instance.devPortalRestURL + "/applications/" + application.ApplicationID + "/oauth-keys"
 
 	request := base.CreateGet(appsURL)
@@ -1506,9 +1506,9 @@ func (instance *Client) GetOauthKeys(t *testing.T, application *Application) *Ap
 	json.NewDecoder(response.Body).Decode(&applicationKeysList)
 
 	if len(applicationKeysList.List) > 0 {
-		return &applicationKeysList.List[0]
+		return &applicationKeysList
 	} else {
-		return &ApplicationKey{}
+		return &ApplicationKeysList{}
 	}
 
 }

--- a/import-export-cli/integration/apim/applicationKeysDTO.go
+++ b/import-export-cli/integration/apim/applicationKeysDTO.go
@@ -20,14 +20,18 @@ package apim
 
 // ApplicationKey : Application Key Details
 type ApplicationKey struct {
-	ConsumerKey         string           `json:"consumerKey"`
-	ConsumerSecret      string           `json:"consumerSecret"`
-	SupportedGrantTypes []string         `json:"supportedGrantTypes"`
-	CallbackURL         string           `json:"callbackUrl"`
-	KeyState            string           `json:"keyState"`
-	KeyType             string           `json:"keyType"`
-	GroupID             string           `json:"groupId"`
-	Token               ApplicationToken `json:"token"`
+	KeyMappingId         string           `json:"keyMappingId" yaml:"keyMappingId"`
+	KeyManager           string           `json:"keyManager" yaml:"keyManager"`
+	ConsumerKey          string           `json:"consumerKey" yaml:"consumerKey"`
+	ConsumerSecret       string           `json:"consumerSecret" yaml:"consumerSecret"`
+	Mode                 string           `json:"mode" yaml:"mode"`
+	SupportedGrantTypes  []string         `json:"supportedGrantTypes" yaml:"supportedGrantTypes"`
+	CallbackURL          string           `json:"callbackUrl" yaml:"callbackUrl"`
+	KeyState             string           `json:"keyState" yaml:"keyState"`
+	KeyType              string           `json:"keyType" yaml:"keyType"`
+	GroupID              string           `json:"groupId" yaml:"groupId"`
+	Token                ApplicationToken `json:"token" yaml:"token"`
+	AdditionalProperties interface{}      `json:"additionalProperties" yaml:"additionalProperties"`
 }
 
 // ApplicationToken : Application Token Details

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 const numberOfApps = 5 // Number of Applications to be added in a loop
@@ -203,6 +204,40 @@ func TestExportImportAppWithGeneratedKeysBySkippingKeys(t *testing.T) {
 	}
 }
 
+// Export an application (created by a subscriber user) with generated keys and import it to another
+// environment while preserving the owner by a user with Internal/devops role and update the additional properties of the keys
+func TestExportImportAppWithGeneratedKeysUpdateAdditionalProperties(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			app := testutils.AddApp(t, dev, user.ApiSubscriber.Username, user.ApiSubscriber.Password)
+
+			args := &testutils.AppImportExportTestArgs{
+				AppOwner:      testutils.Credentials{Username: user.ApiSubscriber.Username, Password: user.ApiSubscriber.Password},
+				CtlUser:       testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Application:   app,
+				SrcAPIM:       dev,
+				DestAPIM:      prod,
+				PreserveOwner: true,
+				WithKeys:      true,
+			}
+
+			// Generate keys for the application in env 1
+			testutils.GenerateKeys(t, args.SrcAPIM, args.AppOwner.Username, args.AppOwner.Password, app.ApplicationID, utils.ProductionKeyType)
+			testutils.GenerateKeys(t, args.SrcAPIM, args.AppOwner.Username, args.AppOwner.Password, app.ApplicationID, utils.SandboxKeyType)
+
+			testutils.ValidateAppExport(t, args)
+
+			testutils.ValidateAppImport(t, args, true)
+
+			testutils.ValidateAppAdditionalPropertiesOfKeysUpdateImport(t, args, true)
+
+		})
+	}
+}
+
 // Export an application (created by a subscriber user) with subscriptions and import it to another
 // environment while preserving the owner and invoke one API
 func TestExportImportAppWithSubscriptions(t *testing.T) {
@@ -244,7 +279,7 @@ func TestExportImportAppWithSubscriptions(t *testing.T) {
 
 			// Generate keys for the imported application in env 2
 			applicationKey := testutils.GenerateKeys(t, args.DestAPIM, args.AppOwner.Username, args.AppOwner.Password,
-				importedApplication.ApplicationID)
+				importedApplication.ApplicationID, utils.ProductionKeyType)
 			testutils.InvokeAPI(t, testutils.GetResourceURL(args.DestAPIM, api1ofEnv2), applicationKey.Token.AccessToken, 200)
 
 		})

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -115,6 +115,7 @@ const DefaultApiProductType = "APIProduct"
 
 // Application keys related constants
 const ProductionKeyType = "PRODUCTION"
+const SandboxKeyType = "SANDBOX"
 
 var GrantTypesToBeSupported = []string{"refresh_token", "password", "client_credentials"}
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/779

## Goals
Adding an integration test to capture the scenario in the above-mentioned issue.

## Approach
- Wrote a test named **TestExportImportAppWithGeneratedKeysUpdateAdditionalProperties** which will run for four (4) apictl users (Super tenant admin, Tenant admin, A super tenant user with the Internal/devops role and a tenant user with the Internal/devops role).

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/10721

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64
