### PR TITLE
[3.2.0] Adding the support for Oauth 2.0 endpoint security via params file

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -424,7 +424,6 @@ func handleOAuthSecurityEndpointsParams(envSecurityEndpointParams *params.Securi
 
 // Preprocess OAuth 2.0 security configs in api_params.yaml
 // @param envSecurityPerEndpoint : Environment OAuth 2.0 security endpoint parameters per endpoint type from api_params.yaml
-// @param api : Parameters from api.yaml
 // @return error
 func preprocessOAuthSecurityConfigs(envSecurityPerEndpoint *params.OAuthEndpointSecurity) error {
 	// This is used to denote that the user is supplying a plain text for client secret

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -281,3 +281,131 @@ func TestEnvironmentSpecificParamsEndpointSecurityBasicDevopsTenant(t *testing.T
 
 	testutils.ValidateEndpointSecurityDefinition(t, api, apiParams, importedAPI)
 }
+
+// Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security
+// (with the security type oauth), using the params file by a super tenant user with the Internal/devops role
+func TestEnvironmentSpecificParamsEndpointSecurityOauthDevopsSuperTenant(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+		ParamsFile:  testutils.APISecurityOauthParamsFile,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	importedAPI := testutils.GetImportedAPI(t, args)
+
+	apiParams := testutils.ReadAPIParams(t, args.ParamsFile)
+
+	testutils.ValidateOAuthEndpointSecurityDefinition(t, api, apiParams, importedAPI)
+}
+
+// Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security
+// (with the security type oauth), using the params file by a tenant user with the Internal/devops role
+func TestEnvironmentSpecificParamsEndpointSecurityOauthDevopsTenant(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+		ParamsFile:  testutils.APISecurityOauthParamsFile,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	importedAPI := testutils.GetImportedAPI(t, args)
+
+	apiParams := testutils.ReadAPIParams(t, args.ParamsFile)
+
+	testutils.ValidateOAuthEndpointSecurityDefinition(t, api, apiParams, importedAPI)
+}
+
+// Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security
+// (with the security type oauth) set to false, using the params file by a super tenant user with the Internal/devops role
+func TestEnvironmentSpecificParamsEndpointSecurityOauthFalseDevopsSuperTenant(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+		ParamsFile:  testutils.APISecurityFalseOauthParamsFile,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	importedAPI := testutils.GetImportedAPI(t, args)
+
+	apiParams := testutils.ReadAPIParams(t, args.ParamsFile)
+
+	testutils.ValidateOAuthEndpointSecurityDefinition(t, api, apiParams, importedAPI)
+}
+
+// Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security
+// (with the security type oauth) set to false, using the params file by a tenant user with the Internal/devops role
+func TestEnvironmentSpecificParamsEndpointSecurityOauthFalseDevopsTenant(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+		ParamsFile:  testutils.APISecurityFalseOauthParamsFile,
+	}
+
+	testutils.ValidateAPIExport(t, args)
+
+	importedAPI := testutils.GetImportedAPI(t, args)
+
+	apiParams := testutils.ReadAPIParams(t, args.ParamsFile)
+
+	testutils.ValidateOAuthEndpointSecurityDefinition(t, api, apiParams, importedAPI)
+}

--- a/import-export-cli/integration/testdata/api_params_security_oauth.yaml
+++ b/import-export-cli/integration/testdata/api_params_security_oauth.yaml
@@ -1,0 +1,30 @@
+environments:
+    - name: production
+      endpoints:
+        production:
+              url: 'https://prod.wso2.com'
+        sandbox:
+              url: 'https://sand.wso2.com'
+      security:
+          production:
+              enabled: true
+              type: oauth
+              tokenUrl: https://prod.token.com
+              clientId: Poc7i6mTj0ac3LyTW0szFzdt1gwa
+              clientSecret: edDEOOjlY0kgClxVlntwWVFve64a
+              grantType: client_credentials
+              customParameters: 
+                  param1: val1
+                  param2: val2
+          sandbox:
+              enabled: true
+              username: admin
+              password: password
+              type: oauth
+              tokenUrl: https://sand.token.com
+              clientId: Fcd7i6mTj0ac3LyTW0szFzdt1asd
+              clientSecret: rfDEOOjlY0kgClxVlntwWVFve56f
+              grantType: password
+              customParameters: 
+                  param3: val3
+                  param4: val4

--- a/import-export-cli/integration/testdata/api_params_security_oauth_false.yaml
+++ b/import-export-cli/integration/testdata/api_params_security_oauth_false.yaml
@@ -1,0 +1,18 @@
+environments:
+    - name: production
+      endpoints:
+        production:
+              url: 'https://prod.wso2.com'
+        sandbox:
+              url: 'https://sand.wso2.com'
+      security:
+          production:
+              enabled: false
+              type: oauth
+              tokenUrl: https://prod.token.com
+              clientId: Poc7i6mTj0ac3LyTW0szFzdt1gwa
+              clientSecret: edDEOOjlY0kgClxVlntwWVFve64a
+              grantType: client_credentials
+              customParameters: 
+                  param1: val1
+                  param2: val2

--- a/import-export-cli/integration/testutils/apiParams.go
+++ b/import-export-cli/integration/testutils/apiParams.go
@@ -47,10 +47,26 @@ type Config struct {
 }
 
 type Security struct {
-	Enabled  bool   `yaml:"enabled"`
-	Type     string `yaml:"type"`
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Production OAuthEndpointSecurity `yaml:"production"`
+	Sandbox    OAuthEndpointSecurity `yaml:"sandbox"`
+	Enabled    bool                  `yaml:"enabled"`
+	Type       string                `yaml:"type"`
+	Username   string                `yaml:"username"`
+	Password   string                `yaml:"password"`
+}
+
+// OAuthEndpointSecurity contains details about the OAuth 2.0 endpoint security
+type OAuthEndpointSecurity struct {
+	Password          string            `yaml:"password"`
+	Username          string            `yaml:"username"`
+	TokenUrl          string            `yaml:"tokenUrl"`
+	ClientId          string            `yaml:"clientId"`
+	ClientSecret      string            `yaml:"clientSecret"`
+	CustomParameters  map[string]string `yaml:"customParameters"`
+	Type              string            `yaml:"type"`
+	GrantType         string            `yaml:"grantType"`
+	Enabled           bool              `yaml:"enabled"`
+	IsSecretEncrypted bool              `yaml:"isSecretEncrypted"`
 }
 
 type Cert struct {

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -58,6 +58,12 @@ const APISecurityDigestParamsFile = "testdata/api_params_security_digest.yaml"
 // APISecurityBasicParamsFile : Security Basic api_params.yaml
 const APISecurityBasicParamsFile = "testdata/api_params_security_basic.yaml"
 
+// APISecurityOauthParamsFile : Security Basic api_params.yaml
+const APISecurityOauthParamsFile = "testdata/api_params_security_oauth.yaml"
+
+// APISecurityFalseOauthParamsFile : Security Basic api_params.yaml
+const APISecurityFalseOauthParamsFile = "testdata/api_params_security_oauth_false.yaml"
+
 // UnlimitedPolicy : Unlimited Throttle Policy
 const UnlimitedPolicy = "Unlimited"
 

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -87,6 +87,10 @@ type AWSLambdaEndpointsData struct {
 
 // SecurityData contains the details about endpoint security from api_params.yaml
 type SecurityData struct {
+	// Production endpoint OAuth 2.0 security
+	Production *OAuthEndpointSecurity `yaml:"production" json:"production"`
+	// Sandbox endpoint OAuth 2.0 security
+	Sandbox *OAuthEndpointSecurity `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 	// Decides whether the endpoint security is enabled
 	Enabled string `yaml:"enabled" json:"enabled,omitempty"`
 	// Type of the endpoint security (can be Basic or Digest)
@@ -95,6 +99,31 @@ type SecurityData struct {
 	Username string `yaml:"username" json:"username,omitempty"`
 	// Password for the endpoint
 	Password string `yaml:"password" json:"password,omitempty"`
+}
+
+// OAuthEndpointSecurity contains details about the OAuth 2.0 endpoint security
+type OAuthEndpointSecurity struct {
+	// Password for OAuth 2.0 endpoint security
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+	// Username for OAuth 2.0 endpoint security
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	// TokenUrl for OAuth 2.0 endpoint security
+	TokenUrl string `yaml:"tokenUrl,omitempty" json:"tokenUrl,omitempty"`
+	// ClientId for OAuth 2.0 endpoint security
+	ClientId string `yaml:"clientId,omitempty" json:"clientId,omitempty"`
+	// ClientSecret for OAuth 2.0 endpoint security
+	ClientSecret string `yaml:"clientSecret,omitempty" json:"clientSecret,omitempty"`
+	// CustomParameters for OAuth 2.0 endpoint security
+	CustomParameters map[string]string `yaml:"customParameters,omitempty" json:"customParameters,omitempty"`
+	// Type for OAuth 2.0 endpoint security (can only be oauth)
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+	// GrantType for OAuth 2.0 endpoint security (can be client_credentials or password)
+	GrantType string `yaml:"grantType,omitempty" json:"grantType,omitempty"`
+	// Enabled OAuth 2.0 endpoint security or not
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	// IsSecretEncrypted for OAuth 2.0 endpoint security (This value will be always true when using a
+	//params file to override these parameters)
+	IsSecretEncrypted bool `yaml:"isSecretEncrypted,omitempty" json:"isSecretEncrypted"`
 }
 
 // Cert stores certificate details

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -88,7 +88,7 @@ type AWSLambdaEndpointsData struct {
 // SecurityData contains the details about endpoint security from api_params.yaml
 type SecurityData struct {
 	// Production endpoint OAuth 2.0 security
-	Production *OAuthEndpointSecurity `yaml:"production" json:"production"`
+	Production *OAuthEndpointSecurity `yaml:"production,omitempty" json:"production,omitempty"`
 	// Sandbox endpoint OAuth 2.0 security
 	Sandbox *OAuthEndpointSecurity `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 	// Decides whether the endpoint security is enabled
@@ -123,7 +123,7 @@ type OAuthEndpointSecurity struct {
 	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	// IsSecretEncrypted for OAuth 2.0 endpoint security (This value will be always true when using a
 	//params file to override these parameters)
-	IsSecretEncrypted bool `yaml:"isSecretEncrypted,omitempty" json:"isSecretEncrypted"`
+	IsSecretEncrypted bool `yaml:"isSecretEncrypted" json:"isSecretEncrypted"`
 }
 
 // Cert stores certificate details

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -200,3 +200,9 @@ const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"
 const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
 const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
 const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
+
+// Endpoint security related constants
+const OAuthType = "OAUTH"
+const ClientCredentialsGrantType = "CLIENT_CREDENTIALS"
+const PasswordGrantType = "PASSWORD"
+const EndpointSecurityTypeNone = "NONE"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/784

## Goals
Adding the support for Oauth 2.0 endpoint security via params file

## Approach
Introduced a new config as shown below that can be used from the params file to set/override Oauth 2.0 endpoint security.
```
environments:
   - name: production
     endpoints:
       production:
           url: http://localhost:9000/test
     security:
         production:
             enabled: true
             type: oauth
             tokenUrl: https://prod.token.com
             clientId: Poc7i6mTj0ac3LyTW0szFzdt1gwa
             clientSecret: edDEOOjlY0kgClxVlntwWVFve64a
             grantType: client_credentials
             customParameters: 
                 param1: val1
                 param2: val2
         sandbox:
             enabled: true
             username: admin
             password: password
             type: oauth
             tokenUrl: https://sand.token.com
             clientId: Fcd7i6mTj0ac3LyTW0szFzdt1asd
             clientSecret: rfDEOOjlY0kgClxVlntwWVFve56f
             grantType: password
             customParameters: 
                 param3: val3
                 param4: val4
```

## User stories
Override OAuth 2.0 endpoint security using the params file via apictl

## Documentation
- https://github.com/wso2/product-apim-tooling/issues/786

## Automation tests
 - Integration tests
   - Four (4) integration tests has been added.
     1. Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security (with the security type oauth), using the params file by a **super tenant** user with the Internal/devops role
     2. Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security (with the security type oauth), using the params file by a **tenant** user with the Internal/devops role
     3. Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security (with the security type oauth) set to **false**, using the params file by a **super tenant** user with the Internal/devops role
     4. Add an API to one environment, export it and re-import it to another environment by overriding the endpoint security (with the security type oauth) set to **false**, using the params file by a **tenant** user with the Internal/devops role

![image](https://user-images.githubusercontent.com/25246848/135569236-f9253c8f-4050-435a-97b2-dd0cd6892ce7.png)

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Related PRs
- https://github.com/wso2-support/carbon-apimgt/pull/3854
- https://github.com/wso2-support/carbon-apimgt/pull/3855
- https://github.com/wso2-support/carbon-apimgt/pull/3905
- https://github.com/wso2-support/carbon-apimgt/pull/3906

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64
