### PR TITLE
[3.2.x] Supporting missing parameters for endpoint configs via params file

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -17,7 +17,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apictl.go -v 3.2.0 -f` to build for all platforms.
+    Execute `./build.sh -t apictl.go -v 3.2.4 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
 

--- a/import-export-cli/integration/README.md
+++ b/import-export-cli/integration/README.md
@@ -49,7 +49,7 @@ rest-api-version: v1
    The version of the apictl that is being integration tested.
 
 ```
-apictl-version: 3.2.0
+apictl-version: 3.2.4
 ```   
 
 
@@ -92,7 +92,7 @@ apictl-version: 3.2.0
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name>
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz
+example: go test -p 1 -timeout 0 -archive apictl-3.2.4-linux-x64.tar.gz
 
 ```
 
@@ -101,7 +101,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -run <Test function name or partial name regex>
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz -run TestVersion
+example: go test -p 1 -timeout 0 -archive apictl-3.2.4-linux-x64.tar.gz -run TestVersion
 ```
 
 - Print verbose output
@@ -109,7 +109,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz -run Tes
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -v
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz -v
+example: go test -p 1 -timeout 0 -archive apictl-3.2.4-linux-x64.tar.gz -v
 ```
 
 - Print http transport request/responses
@@ -117,7 +117,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz -v
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -logtransport
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.0-linux-x64.tar.gz -logtransport
+example: go test -p 1 -timeout 0 -archive apictl-3.2.4-linux-x64.tar.gz -logtransport
 ```
 
 ---

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -14,4 +14,4 @@ indexing-delay: 1000
 
 dcr-version: v0.17
 rest-api-version: v1
-apictl-version: 3.2.3
+apictl-version: 3.2.4

--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -68,8 +68,8 @@ func TestEnvironmentSpecificParamsEndpoint(t *testing.T) {
 	testutils.ValidateAPIsEqual(t, &apiCopy, &importedAPICopy)
 }
 
-// Add an API to one environment, export it and re-import it to another environment by 
-// setting the configs for endpoints using the params file by a super tenant user the Internal/devops role
+// Add an API to one environment, export it and re-import it to another environment by setting 
+// the configs for endpoints using the params file by a super tenant user with the Internal/devops role
 func TestEnvironmentSpecificParamsEndpointConfigsDevopsSuperTenant(t *testing.T) {
 	devopsUsername := devops.UserName
 	devopsPassword := devops.Password
@@ -125,8 +125,8 @@ func TestEnvironmentSpecificParamsEndpointConfigsDevopsSuperTenant(t *testing.T)
 	testutils.ValidateAPIsEqual(t, &apiCopy, &importedAPICopy)
 }
 
-// Add an API to one environment, export it and re-import it to another environment by 
-// setting the configs for endpoints using the params file by a tenant user the Internal/devops role
+// Add an API to one environment, export it and re-import it to another environment by setting 
+// the configs for endpoints using the params file by a tenant user with the Internal/devops role
 func TestEnvironmentSpecificParamsEndpointConfigsDevopsTenant(t *testing.T) {
 	tenantDevopsUsername := devops.UserName + "@" + TENANT1
 	tenantDevopsPassword := devops.Password

--- a/import-export-cli/integration/testdata/api_params_endpoint_configs.yaml
+++ b/import-export-cli/integration/testdata/api_params_endpoint_configs.yaml
@@ -1,0 +1,19 @@
+environments:
+    - name: production
+      endpoints:
+          production:
+              url: 'https://prod.wso2.com'
+              config:
+                  factor: 3
+                  suspendMaxDuration: 25000
+                  suspendDuration: 45000
+                  suspendErrorCode: 
+                      - "101504"
+                      - "101501"
+                  retryTimeOut: 13000
+                  retryDelay: 23000
+                  retryErroCode:
+                      - "101503" 
+                      - "101504"
+                  actionSelect: discard
+                  actionDuration: 75000

--- a/import-export-cli/integration/testdata/api_params_endpoint_retrytimeout.yaml
+++ b/import-export-cli/integration/testdata/api_params_endpoint_retrytimeout.yaml
@@ -1,7 +1,0 @@
-environments:
-    - name: production
-      endpoints:
-          production:
-              url: 'https://prod.wso2.com'
-              config:
-                  retryTimeOut: 60

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -49,6 +49,9 @@ const APIEndpointParamsFile = "testdata/api_params_endpoint.yaml"
 // APIEndpointRetryTimeoutParamsFile : Endpoint URL and Retry Timeout api_params.yaml
 const APIEndpointRetryTimeoutParamsFile = "testdata/api_params_endpoint_retrytimeout.yaml"
 
+// APIEndpointConfigsParamsFile : Endpoint URL and Retry Timeout api_params.yaml
+const APIEndpointConfigsParamsFile = "testdata/api_params_endpoint_configs.yaml"
+
 // APISecurityFalseParamsFile : Security false api_params.yaml
 const APISecurityFalseParamsFile = "testdata/api_params_security_false.yaml"
 

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -17,6 +17,18 @@ type Configuration struct {
 	RetryDelay *int `yaml:"retryDelay,omitempty" json:"retryDelay,omitempty"`
 	// Factor used for config
 	Factor *int `yaml:"factor,omitempty" json:"factor,omitempty"`
+	// RetryErroCode used for config
+	RetryErroCode *[]string `yaml:"retryErroCode,omitempty" json:"retryErroCode,omitempty"`
+	// SuspendErrorCode used for config
+	SuspendErrorCode *[]string `yaml:"suspendErrorCode,omitempty" json:"suspendErrorCode,omitempty"`
+	// SuspendDuration used for config
+	SuspendDuration *int `yaml:"suspendDuration,omitempty" json:"suspendDuration,omitempty"`
+	// SuspendMaxDuration used for config
+	SuspendMaxDuration *int `yaml:"suspendMaxDuration,omitempty" json:"suspendMaxDuration,omitempty"`
+	// ActionSelect used for config (values can be "discard" and "fault")
+	ActionSelect *string `yaml:"actionSelect,omitempty" json:"actionSelect,omitempty"`
+	// ActionDuration used for config
+	ActionDuration *int `yaml:"actionDuration,omitempty" json:"actionDuration,omitempty"`
 }
 
 // Endpoint details


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/787

## Goals
Supporting the parameters **retryErroCode**, **suspendErrorCode**, **suspendDuration**, **suspendMaxDuration**, **actionSelect** and **actionDuration** to be configured through the params file.

## Approach
Added the above stated missing parameters to the struct **Configuration**

## User stories
The use case mentioned in [1] is supported now.

## Documentation
- https://github.com/wso2/product-apim-tooling/issues/788

## Automation tests
 - Integration tests
   - Two (2) integration tests have been added. 
     1.  Add an API to one environment, export it and re-import it to another environment by setting the configs for endpoints using the params file by a **super tenant** user with the Internal/devops role
     2.  Add an API to one environment, export it and re-import it to another environment by setting the configs for endpoints using the params file by a **tenant** user with the Internal/devops role
     
![image](https://user-images.githubusercontent.com/25246848/135835583-2867729b-c398-46d2-ae44-e306f1cea80c.png)

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64

[1] https://github.com/wso2/product-apim-tooling/issues/787