### PR TITLE
[3.2.x] Mandating tokenUrl when configuring OAuth 2.0 security via the params file

### DIFF
--- a/import-export-cli/impl/importAPI.go
+++ b/import-export-cli/impl/importAPI.go
@@ -444,6 +444,10 @@ func preprocessOAuthSecurityConfigs(envSecurityPerEndpoint *params.OAuthEndpoint
 		return errors.New("You have enabled OAuth 2.0 endpoint security" +
 			" but the Client Secret is not found in the api_params.yaml")
 	}
+	if envSecurityPerEndpoint.TokenUrl == "" {
+		return errors.New("You have enabled OAuth 2.0 endpoint security" +
+			" but Token URL is not found in the api_params.yaml")
+	}
 
 	if strings.EqualFold(strings.ToLower(envSecurityPerEndpoint.GrantType),
 		strings.ToLower(utils.ClientCredentialsGrantType)) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/784

## Goals
Mandating tokenUrl when configuring OAuth 2.0 security via the params file since the UI has the same behaviour.

## Approach
Throw an error if the tokenUrl is empty when the security type is oauth.

## Documentation
- https://github.com/wso2/product-apim-tooling/issues/786

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/790

## Test environment
- Ubuntu 20.04.2 LTS
- go version go1.16.3 linux/amd64