### PR TITLE
Fix non-required deployment_environments.yaml found issue

### DIFF
--- a/import-export-cli/integration/apiRevision_test.go
+++ b/import-export-cli/integration/apiRevision_test.go
@@ -45,6 +45,7 @@ func TestExportApiNonDeloyedRevision(t *testing.T) {
 				Api:         apiRevision,
 				SrcAPIM:     dev,
 				Revision:    strconv.Itoa(revNumber),
+				IsDeployed:  true,
 			}
 
 			testutils.ValidateExportedAPIRevisionStructure(t, args)
@@ -95,6 +96,7 @@ func TestExportApiWorkingCopy(t *testing.T) {
 				CtlUser:     user.CtlUser,
 				Api:         api,
 				SrcAPIM:     dev,
+				IsDeployed:  true,
 			}
 
 			testutils.ValidateExportedAPIStructure(t, args)


### PR DESCRIPTION
## Purpose
Partially Fixes https://github.com/wso2/product-apim-tooling/issues/806.

This PR fixes the following test failures:
- TestExportApiWorkingCopy
- TestExportApiNonDeloyedRevision

## Approach
Add the missing `IsDeployed` arg and set it to true, since these test cases have deployments.