### PR TITLE
Fixing the test failure of the TestDeleteApiWithActiveSubscriptionsSuperTenantUser

### DIFF
--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -1117,7 +1117,7 @@ func TestDeleteApiProductWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
 	base.WaitForIndexing()
 
 	//Get keys for ApiProduct and keep subscription active
-	testutils.ValidateGetKeysWithoutCleanup(t, args)
+	testutils.ValidateGetKeysWithoutCleanup(t, args, true)
 
 	argsToDelete := &testutils.ApiProductImportExportTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUsername, Password: adminPassword},

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -20,11 +20,11 @@ package integration
 
 import (
 	"fmt"
-	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 	"os"
 	"testing"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 
@@ -806,12 +806,12 @@ func TestDeleteApiWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
 	apiPublisher := publisher.UserName
 	apiPublisherPassword := publisher.Password
 
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
 	dev := GetDevClient()
 
-	var api *apim.API
-
-	// This will be the API that will be deleted by apictl, so no need to do cleaning
-	api = testutils.AddAPIWithoutCleaning(t, dev, adminUser, adminPassword)
+	api := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
 
 	// Create and Deploy Revision of the above API
 	testutils.CreateAndDeployAPIRevision(t, dev, apiPublisher, apiPublisherPassword, api.ID)
@@ -822,16 +822,15 @@ func TestDeleteApiWithActiveSubscriptionsSuperTenantUser(t *testing.T) {
 		Apim:    dev,
 	}
 	//Publish created API
-	testutils.PublishAPI(dev, adminUser, adminPassword, api.ID)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, api.ID)
 
-	testutils.ValidateGetKeysWithoutCleanup(t, args)
+	testutils.ValidateGetKeysWithoutCleanup(t, args, false)
 	//args to delete API
 	argsToDelete := &testutils.ApiImportExportTestArgs{
 		CtlUser: testutils.Credentials{Username: adminUser, Password: adminPassword},
 		Api:     api,
 		SrcAPIM: dev,
 	}
-	base.WaitForIndexing()
 
 	//validate Api with active subscriptions delete failure
 	testutils.ValidateAPIDeleteFailure(t, argsToDelete)

--- a/import-export-cli/integration/getkeys_test.go
+++ b/import-export-cli/integration/getkeys_test.go
@@ -117,7 +117,7 @@ func TestGetKeysConsecutivelyAdminSuperTenantUser(t *testing.T) {
 		Apim:    dev,
 	}
 	//Get keys for the first time without cleaning subscription
-	testutils.ValidateGetKeysWithoutCleanup(t, args)
+	testutils.ValidateGetKeysWithoutCleanup(t, args, true)
 
 	//Get keys for the second time and remove subscription
 	testutils.ValidateGetKeys(t, args)
@@ -392,7 +392,7 @@ func TestGetKeysConsecutivelyForAPIProductAdminSuperTenantUser(t *testing.T) {
 	}
 
 	//Get keys for the first time without cleaning subscription
-	testutils.ValidateGetKeysWithoutCleanup(t, args)
+	testutils.ValidateGetKeysWithoutCleanup(t, args, true)
 
 	//Get keys for the second time and remove subscription
 	testutils.ValidateGetKeys(t, args)

--- a/import-export-cli/integration/testutils/keys_testUtils.go
+++ b/import-export-cli/integration/testutils/keys_testUtils.go
@@ -147,7 +147,7 @@ func ValidateGetKeys(t *testing.T, args *ApiGetKeyTestArgs) {
 	}
 }
 
-func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs) {
+func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs, doInvoke bool) {
 	t.Helper()
 
 	base.SetupEnv(t, args.Apim.GetEnvName(), args.Apim.GetApimURL(), args.Apim.GetTokenURL())
@@ -163,7 +163,9 @@ func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		InvokeAPI(t, GetResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
+		if doInvoke {
+			InvokeAPI(t, GetResourceURL(args.Apim, args.Api), base.GetValueOfUniformResponse(result), 200)
+		}
 	}
 
 	if args.ApiProduct != nil {
@@ -174,6 +176,8 @@ func ValidateGetKeysWithoutCleanup(t *testing.T, args *ApiGetKeyTestArgs) {
 
 		assert.Nil(t, err, "Error while getting key")
 
-		invokeAPIProduct(t, getResourceURLForAPIProduct(args.Apim, args.ApiProduct), base.GetValueOfUniformResponse(result), 200)
+		if doInvoke {
+			invokeAPIProduct(t, getResourceURLForAPIProduct(args.Apim, args.ApiProduct), base.GetValueOfUniformResponse(result), 200)
+		}
 	}
 }


### PR DESCRIPTION
## Purpose
Ignore invoking the API since it is not needed for the use case and restructure the test to use correct user roles.
