### PR TITLE
Adding the integration tests to compare apictl artifacts versions and to check exporting invalid revisions

### DIFF
--- a/import-export-cli/integration/apiProductRevision_test.go
+++ b/import-export-cli/integration/apiProductRevision_test.go
@@ -1,0 +1,64 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
+	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
+)
+
+func TestExportInvalidApiProductRevision(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			// Add the first dependent API to env1
+			dependentAPI1 := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+			testutils.PublishAPI(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, dependentAPI1.ID)
+
+			// Add the second dependent API to env1
+			dependentAPI2 := testutils.AddAPIFromOpenAPIDefinition(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+			testutils.PublishAPI(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, dependentAPI2.ID)
+
+			// Map the real name of the API with the API
+			apisList := map[string]*apim.API{
+				"PizzaShackAPI":   dependentAPI1,
+				"SwaggerPetstore": dependentAPI2,
+			}
+
+			// Add the API Product to env1
+			apiProduct := testutils.AddAPIProductFromJSON(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, apisList)
+
+			testutils.CreateAndDeployAPIProductRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, apiProduct.ID)
+
+			// Export an invalid revision
+			args := &testutils.ApiProductImportExportTestArgs{
+				CtlUser:    user.CtlUser,
+				ApiProduct: apiProduct,
+				SrcAPIM:    dev,
+				Revision:   "100",
+			}
+
+			testutils.ValidateExportedAPIProductRevisionFailure(t, args)
+		})
+	}
+}

--- a/import-export-cli/integration/apiRevision_test.go
+++ b/import-export-cli/integration/apiRevision_test.go
@@ -162,3 +162,27 @@ func TestExportImportApiSameGWEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestExportInvalidApiRevision(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			// Create and Deploy Revision of the above API
+			testutils.CreateAndDeployAPIRevision(t, dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+
+			// Export an invalid revision
+			args := &testutils.ApiImportExportTestArgs{
+				CtlUser:  user.CtlUser,
+				Api:      api,
+				SrcAPIM:  dev,
+				Revision: "100",
+			}
+
+			testutils.ValidateExportedAPIRevisionFailure(t, args)
+		})
+	}
+}

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -18,6 +18,7 @@
 package integration
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/base"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+	"gopkg.in/yaml.v2"
 )
 
 // Initialize a API project by getting the OAS of a AWS API and import it as a super tenant user with
@@ -92,6 +94,23 @@ func TestInitializeProject(t *testing.T) {
 	}
 
 	testutils.ValidateInitializeProject(t, args)
+
+	projectPath, _ := filepath.Abs(projectName)
+	apiYamlPath := projectPath + string(os.PathSeparator) + testutils.APIYamlFilePath
+
+	// Read the api.yaml file in the exported directory
+	fileData, _ := ioutil.ReadFile(apiYamlPath)
+
+	fileContent := make(map[string]interface{})
+	err := yaml.Unmarshal(fileData, &fileContent)
+	if err != nil {
+		t.Error(err)
+	}
+	apiArtifactVersion := fileContent["version"].(string)
+
+	assert.Equal(t, apiArtifactVersion, "v"+yamlConfig.APICTLVersion,
+		"Artifact version: "+apiArtifactVersion+
+			" does not matches with the APICTL version: v"+yamlConfig.APICTLVersion)
 }
 
 // Initialize an API with --definition flag and import it

--- a/import-export-cli/integration/testdata/sample-api.yaml
+++ b/import-export-cli/integration/testdata/sample-api.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 type: api # Type of the exported artifact using APICTL
-version: v4.0.0 # API Manager version
+version: v4.1.0 # API Manager version
 data: # Contains the meta data of the API
   id: 28114236-515c-4f40-82e4-6a016e632008 ## API UUID
   name: PizzaShackAPI # Name of the API without Spaces [required] 

--- a/import-export-cli/integration/testdata/sample-revisioned-api.yaml
+++ b/import-export-cli/integration/testdata/sample-revisioned-api.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 type: api # Type of the exported artifact using APICTL
-version: v4.0.0 # API Manager version
+version: v4.1.0 # API Manager version
 data: # Contains the meta data of the API
   id: 28114236-515c-4f40-82e4-6a016e632008 ## API UUID
   name: PizzaShackAPI # Name of the API without Spaces [required] 

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -644,6 +644,13 @@ func validateAPIStructure(t *testing.T, fileData *[]byte, sampleFile string) {
 	}
 	sampleAPIData := sampleDataContent["data"].(map[interface{}]interface{})
 
+	// Compare the artifact versions
+	exportedAPIArtifactVersion := fileContent["version"].(string)
+	sampleAPIArtifactVersion := sampleDataContent["version"].(string)
+	assert.Equal(t, exportedAPIArtifactVersion, sampleAPIArtifactVersion,
+		"Exported artifact version: "+exportedAPIArtifactVersion+
+			" does not matches with the sample artifact version: "+sampleAPIArtifactVersion)
+
 	// Check whether the fields of the API DTO structure in APICTL has all the fields in API DTO structure from APIM
 	base.Log("\n-----------------------------------------------------------------------------------------")
 	base.Log("Checking whether the fields of APICTL API DTO struct has all the fields from APIM API DTO struct")

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -60,6 +60,8 @@ type ApiProductImportExportTestArgs struct {
 	UpdateApisFlag       bool
 	UpdateApiProductFlag bool
 	ParamsFile           string
+	Revision             string
+	IsLatest             bool
 }
 
 type AppImportExportTestArgs struct {


### PR DESCRIPTION
## Purpose
Adding the integration tests related to
- https://github.com/wso2/product-apim-tooling/issues/810
- https://github.com/wso2/product-apim-tooling/issues/742
- https://github.com/wso2/product-apim/issues/11212

## Goals
Adding/modifying integration tests related to apictl artifacts versions and to check exporting invalid revisions

## Approach
- Added two (2) new table-driven tests.
  1. Export an invalid API revision - TestExportInvalidApiRevision
  2. Export an invalid API Product revision - TestExportInvalidApiProductRevision
- Modify the existing tests to compare apictl artifacts versions from the APIM server and which were generated via apictl init command.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/10876

## Test environment
- Ubuntu 20.04.4 LTS
- go version go1.16.3 linux/amd64
