### PR TITLE
Fix API definition file update issue in TestAPISequenceUpdate

### DIFF
--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -430,21 +430,6 @@ func IsFileContentIdentical(path1, path2 string) bool {
 	return bytes.Equal(file_1, file_2)
 }
 
-// Append string to a given file
-func AppendStringToFile(str, path string) error {
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = file.WriteString(str)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Copy the src file to dst. Any existing file will be overwritten
 func Copy(src, dst string) error {
 	in, err := os.Open(src)

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -167,7 +167,7 @@ const EndpointSecurityTypeBasic = "BASIC"
 // Constants for sequence update testcase
 const CustomSequenceDirectory = "/Sequences/in-sequence/Custom"
 const CustomSequenceName = "mockSequence"
-const DevFirstSampleCaseApiMetadataPathSuffix = "/Meta-information/api.yaml"
+const DevFirstSampleCaseApiYamlFilePathSuffix = "/api.yaml"
 const DevFirstSampleCaseSequencePath = DevFirstSampleCaseArtifactPath + "/mockSequence.xml"
 const DevFirstSampleCaseDestSequencePathSuffix = CustomSequenceDirectory + "/mockSequence.xml"
 const DevFirstUpdatedSampleCaseSequencePath = DevFirstUpdatedSampleCaseArtifactPath + "/mockSequence.xml"


### PR DESCRIPTION
## Purpose

This PR fixes the API definition file update issue under the TestAPISequenceUpdate testcase. 

Testcase that was originally introduced by [1] was updated in order to accurately update the `api.yaml` file when a custom in-sequence is added using APICTL. Accordingly, the `mediationPolicies` list was modified of the API definition file before importing the API. Also, this value is now asserted at the end of the testcase to verify that the `api.yaml` file is as expected.

## Related PRs

1. https://github.com/wso2/product-apim-tooling/pull/802