### PR TITLE
Fixing the issue on APIs are not getting imported after initializing without providing either an OAS or a definition file

### DIFF
--- a/import-export-cli/impl/init.go
+++ b/import-export-cli/impl/init.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Jeffail/gabs"
 	"github.com/go-openapi/loads"
@@ -166,6 +167,16 @@ func InitAPIProject(initCmdOutputDir, initCmdInitialState, initCmdSwaggerPath, i
 			return err
 		}
 		definitionFile.Data = tmpDef.Data
+	}
+
+	// If the name of the API is still empty, set the project name as the API name
+	if strings.EqualFold(definitionFile.Data.Name, "") {
+		definitionFile.Data.Name = filepath.Base(initCmdOutputDir)
+	}
+
+	// If the context of the API is still empty, set the lowercase project name as the API context
+	if strings.EqualFold(definitionFile.Data.Context, "") {
+		definitionFile.Data.Context = "/" + strings.ToLower(filepath.Base(initCmdOutputDir))
 	}
 
 	apiData, err := yaml2.Marshal(definitionFile)


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/813

## Goals
Fixing the issue on APIs are not getting imported after initializing without providing either an OAS or a definition file

## Approach
- Assign the project name during the apictl init to API name and context if those are not defined anywhere

## Automation tests
 - Integration tests
   - Improved the test **TestInitializeProject** to import the API and converted to the table-driven form

## Test environment
- Ubuntu 20.04.4 LTS
- go version go1.16.3 linux/amd64
