### PR TITLE
Add support for rotateRevision param via api_meta.yaml

### DIFF
--- a/import-export-cli/cmd/vcsDeploy.go
+++ b/import-export-cli/cmd/vcsDeploy.go
@@ -57,7 +57,7 @@ var DeployCmd = &cobra.Command{
 		}
 		mainConfig := utils.GetMainConfigFromFile(utils.MainConfigFilePath)
 		if mainConfig.Config.VCSSourceRepoPath == "" {
-			fmt.Println("VSC source repo path cannot be empty. Set it using apictl set command.")
+			fmt.Println("VCS source repo path cannot be empty. Set it using apictl set command.")
 			os.Exit(1)
 		}
 		credential, err := GetCredentials(flagVCSDeployEnvName)

--- a/import-export-cli/git/gitUtils.go
+++ b/import-export-cli/git/gitUtils.go
@@ -424,7 +424,7 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 				projectDeploymentParamsDirLocation = ""
 			}
 			err := impl.ImportAPIToEnv(accessToken, environment, generateSourceProjectPath(mainConfig, projectParam),
-				projectDeploymentParamsDirLocation, importParams.Update, importParams.PreserveProvider, false, false, false)
+				projectDeploymentParamsDirLocation, importParams.Update, importParams.PreserveProvider, false, importParams.RotateRevision, false)
 			if err != nil {
 				fmt.Println("Error... ", err)
 				failedProjects[projectParam.Type] = append(failedProjects[projectParam.Type], projectParam)
@@ -451,7 +451,7 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 			}
 			err := impl.ImportAPIProductToEnv(accessToken, environment, generateSourceProjectPath(mainConfig, projectParam),
 				projectDeploymentParamsDirLocation, importParams.ImportAPIs, importParams.UpdateAPIs, importParams.UpdateAPIProduct,
-				importParams.PreserveProvider, false, false, false)
+				importParams.PreserveProvider, false, importParams.RotateRevision, false)
 			if err != nil {
 				fmt.Println("\terror... ", err)
 				failedProjects[projectParam.Type] = append(failedProjects[projectParam.Type], projectParam)

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -107,6 +107,7 @@ func WriteToZip(exportAPIName, exportAPIVersion, exportAPIRevisionNumber, zipLoc
 			Import: utils.ImportConfig{
 				Update:           true,
 				PreserveProvider: true,
+				RotateRevision:   false,
 			},
 		},
 	}

--- a/import-export-cli/impl/exportAPIProduct.go
+++ b/import-export-cli/impl/exportAPIProduct.go
@@ -98,6 +98,7 @@ func WriteAPIProductToZip(exportAPIProductName, exportAPIProductVersion, zipLoca
 				ImportAPIs:       true,
 				UpdateAPIProduct: true,
 				UpdateAPIs:       false,
+				RotateRevision:   false,
 			},
 		},
 	}

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -87,6 +87,7 @@ type ApiProductVCSParams struct {
 type APIImportParams struct {
 	Update           bool `yaml:"update"`
 	PreserveProvider bool `yaml:"preserveProvider"`
+	RotateRevision   bool `yaml:"rotateRevision"`
 }
 
 type APIProductImportParams struct {
@@ -94,6 +95,7 @@ type APIProductImportParams struct {
 	UpdateAPIs       bool `yaml:"updateApis"`
 	UpdateAPIProduct bool `yaml:"updateApiProduct"`
 	PreserveProvider bool `yaml:"preserveProvider"`
+	RotateRevision   bool `yaml:"rotateRevision"`
 }
 
 type ApplicationImportParams struct {

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -368,6 +368,7 @@ type DeployConfig struct {
 type ImportConfig struct {
 	Update            bool `json:"update,omitempty" yaml:"update,omitempty"`
 	PreserveProvider  bool `json:"preserveProvider,omitempty" yaml:"preserveProvider,omitempty"`
+	RotateRevision    bool `json:"rotateRevision,omitempty" yaml:"rotateRevision,omitempty"`
 	ImportAPIs        bool `json:"importApis,omitempty" yaml:"importApis,omitempty"`
 	UpdateAPIProduct  bool `json:"updateApiProduct,omitempty" yaml:"updateApiProduct,omitempty"`
 	UpdateAPIs        bool `json:"updateApis,omitempty" yaml:"updateApis,omitempty"`


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-apim-tooling/issues/798

With the changes,
- If we have provided **rotateRevision** param in the **api_meta.yaml** file in the API/APIProduct project folder in the **source** directory, it picks the value from there directly.
- If we haven't provided **rotateRevision** param in the **api_meta.yaml** file in the API/APIProduct project folder in the **source** directory, then it picks the value specified in the **api_meta.yaml** file in the API/APIProduct project folder in the **deployment** directory.
- If the value is there in the **api_meta.yaml** file in the API/APIProduct project folder in the **source** directory, then it ignores what is defined for the **rotateRevision** param in the **api_meta.yaml** file in the API/APIProduct project folder in the **deployment** directory.
- If we haven't provided in the **rotateRevision** param in the **api_meta.yaml** file in the API/APIProduct folders in **both source and deployment** directories, then it takes the value as **false**.
- By **default** when generating the **api_meta.yaml** file inside the API/APIProduct folder when exporting, the value is set to **false**.