### PR TITLE
Fix the issue with generating docs

### DIFF
--- a/import-export-cli/tools/tools.go
+++ b/import-export-cli/tools/tools.go
@@ -1,0 +1,8 @@
+//+build tools
+
+//tools is a dummy package that will be ignored for builds, but included for dependencies
+package tools
+
+import (
+  _ "github.com/spf13/cobra/doc"
+)


### PR DESCRIPTION
## Purpose
Fix the issue with generating docs due to the following.

`tools/gen.go:10:2: cannot find package "." in:
	/home/product-apim-tooling/import-export-cli/vendor/github.com/spf13/cobra/doc
`