### PR TITLE
Fixing API Product get keys integration test failures due to the introduction of lifecycle state

### DIFF
--- a/import-export-cli/integration/getkeys_test.go
+++ b/import-export-cli/integration/getkeys_test.go
@@ -303,6 +303,9 @@ func TestGetKeysForAPIProductAdminSuperTenantUser(t *testing.T) {
 	// Create and Deploy API Product Revision
 	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
 
+	// Change life cycle state of API Product from CREATED to PUBLISHED
+	testutils.PublishAPIProduct(dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
+
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},
 		ApiProduct: apiProduct,
@@ -344,6 +347,9 @@ func TestGetKeysForAPIProductAdminTenantUser(t *testing.T) {
 	// Create and Deploy API Product Revision
 	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
 
+	// Change life cycle state of API Product from CREATED to PUBLISHED
+	testutils.PublishAPIProduct(dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
+
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},
 		ApiProduct: apiProduct,
@@ -384,6 +390,9 @@ func TestGetKeysConsecutivelyForAPIProductAdminSuperTenantUser(t *testing.T) {
 
 	// Create and Deploy API Product Revision
 	testutils.CreateAndDeployAPIProductRevision(t, dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
+
+	// Change life cycle state of API Product from CREATED to PUBLISHED
+	testutils.PublishAPIProduct(dev, apiPublisher, apiPublisherPassword, apiProduct.ID)
 
 	args := &testutils.ApiGetKeyTestArgs{
 		CtlUser:    testutils.Credentials{Username: adminUser, Password: adminPassword},


### PR DESCRIPTION
## Purpose
With the introduction of lifecycle states for API Product, the API Product should be in Published state prior to the generation of keys.

## Goals
Fixing API Product get keys integration test failures due to the introduction of lifecycle state

## Approach
Published the API Products before executing get keys in integration tests