### PR TITLE
Adding the provider to the Environment struct of integration tests introduced with Solace feature

### DIFF
--- a/import-export-cli/integration/apim/environmentDTO.go
+++ b/import-export-cli/integration/apim/environmentDTO.go
@@ -26,6 +26,7 @@ type Environment struct {
 	Description string  `json:"description"`
 	IsReadOnly  bool    `json:"isReadOnly"`
 	VHosts      []VHost `json:"vhosts"`
+	Provider    string  `json:"provider"`
 }
 
 type VHost struct {


### PR DESCRIPTION
## Purpose
A new field has been introduced with the Solace integration here [1].

## Goals
Changing the Environments struct in go side to match with the struct in [1].

## Approach
Add the provider field to environmentDTO in go.

[1] https://github.com/wso2/carbon-apimgt/blob/c0e3047210afe0f36d83a49b5f901afeb9591585/components/apimgt/org.wso2.carbon.apimgt.rest.api.admin.v1/src/main/resources/admin-api.yaml#L4039