### PR TITLE
Fix issue when exporting all APIs at once when after adding new APIs

### DIFF
--- a/import-export-cli/impl/exportAPIs.go
+++ b/import-export-cli/impl/exportAPIs.go
@@ -59,10 +59,9 @@ func PrepareResumption(credential credentials.Credential, exportRelatedFilesPath
 	if count == 0 {
 		//last iteration had been completed successfully but operation had halted at that point.
 		//So get the next set of APIs for next iteration
-		apiListOffset += utils.MaxAPIsToExportOnce
 		startingApiIndexFromList = 0
 		count, apis = getAPIList(credential, cmdExportEnvironment, cmdResourceTenantDomain)
-		if len(apis) > 0 {
+		if len(apis)-startingApiIndexFromList > 0 {
 			utils.WriteMigrationApisExportMetadataFile(apis, cmdResourceTenantDomain, cmdUsername,
 				exportRelatedFilesPath, apiListOffset)
 		} else {
@@ -165,8 +164,8 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 					revisionCount, revisions, err := getRevisionsListForAPI(accessToken, cmdExportEnvironment, apis[i],
 						exportAllRevisions)
 					if err != nil {
-						fmt.Println("An error occurred while getting the revisions list for API " + apis[i].Version +
-							"_" + apis[i].Version, err)
+						fmt.Println("An error occurred while getting the revisions list for API "+apis[i].Version+
+							"_"+apis[i].Version, err)
 					} else if revisionCount > 0 {
 						for j := 0; j < len(revisions); j++ {
 							exportApiRevision := utils.GetRevisionNumFromRevisionName(revisions[j].RevisionNumber)

--- a/import-export-cli/impl/exportAPIs.go
+++ b/import-export-cli/impl/exportAPIs.go
@@ -164,8 +164,8 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 					revisionCount, revisions, err := getRevisionsListForAPI(accessToken, cmdExportEnvironment, apis[i],
 						exportAllRevisions)
 					if err != nil {
-						fmt.Println("An error occurred while getting the revisions list for API "+apis[i].Version+
-							"_"+apis[i].Version, err)
+						fmt.Println("An error occurred while getting the revisions list for API " + apis[i].Version+
+							"_" + apis[i].Version, err)
 					} else if revisionCount > 0 {
 						for j := 0; j < len(revisions); j++ {
 							exportApiRevision := utils.GetRevisionNumFromRevisionName(revisions[j].RevisionNumber)

--- a/import-export-cli/impl/exportAPIs.go
+++ b/import-export-cli/impl/exportAPIs.go
@@ -164,7 +164,7 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 					revisionCount, revisions, err := getRevisionsListForAPI(accessToken, cmdExportEnvironment, apis[i],
 						exportAllRevisions)
 					if err != nil {
-						fmt.Println("An error occurred while getting the revisions list for API " + apis[i].Version+
+						fmt.Println("An error occurred while getting the revisions list for API " + apis[i].Version +
 							"_" + apis[i].Version, err)
 					} else if revisionCount > 0 {
 						for j := 0; j < len(revisions); j++ {


### PR DESCRIPTION
## Purpose
Export all the API's of a tenant at once feature (batch export) is not working in the latest APIM  levels. Returns "No APIs to be exported " even when there are API's available in the environment. This will be fixed by this PR.

## Goals
Fixes https://github.com/wso2/product-apim-tooling/issues/850 for the latest release.

### Tests
Add integration test to cover the above scenario.

- **TestExportApisTwiceWithAfterAddingApis**

