### PR TITLE
[3.2.0] Add Integration tests for JsonArray format support with list command

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -17,7 +17,7 @@ Command Line tool for importing and exporting APIs/Applications between differen
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apictl.go -v 3.2.5 -f` to build for all platforms.
+    Execute `./build.sh -t apictl.go -v 3.2.6 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
 

--- a/import-export-cli/integration/README.md
+++ b/import-export-cli/integration/README.md
@@ -49,7 +49,7 @@ rest-api-version: v1
    The version of the apictl that is being integration tested.
 
 ```
-apictl-version: 3.2.5
+apictl-version: 3.2.6
 ```   
 
 
@@ -92,7 +92,7 @@ apictl-version: 3.2.5
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name>
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz
+example: go test -p 1 -timeout 0 -archive apictl-3.2.6-linux-x64.tar.gz
 
 ```
 
@@ -101,7 +101,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -run <Test function name or partial name regex>
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz -run TestVersion
+example: go test -p 1 -timeout 0 -archive apictl-3.2.6-linux-x64.tar.gz -run TestVersion
 ```
 
 - Print verbose output
@@ -109,7 +109,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz -run Tes
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -v
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz -v
+example: go test -p 1 -timeout 0 -archive apictl-3.2.6-linux-x64.tar.gz -v
 ```
 
 - Print http transport request/responses
@@ -117,7 +117,7 @@ example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz -v
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -logtransport
 
-example: go test -p 1 -timeout 0 -archive apictl-3.2.5-linux-x64.tar.gz -logtransport
+example: go test -p 1 -timeout 0 -archive apictl-3.2.6-linux-x64.tar.gz -logtransport
 ```
 
 ---

--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -867,6 +867,162 @@ func TestListApiProductsDevopsTenantUser(t *testing.T) {
 	testutils.ValidateAPIProductsList(t, args)
 }
 
+func TestListApiProductsWithJsonArrayFormatAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := testutils.AddAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	for apiProductCount := 0; apiProductCount <= numberOfAPIProducts; apiProductCount++ {
+		// Add the API Product to env1
+		testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIProductsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApiProductsWithJsonArrayFormatDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := testutils.AddAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	for apiProductCount := 0; apiProductCount <= numberOfAPIProducts; apiProductCount++ {
+		// Add the API Product to env1
+		testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIProductsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApiProductsWithJsonArrayFormatAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := testutils.AddAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	for apiProductCount := 0; apiProductCount <= numberOfAPIProducts; apiProductCount++ {
+		// Add the API Product to env1
+		testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIProductsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApiProductsWithJsonArrayFormatDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	apiPublisher := publisher.UserName + "@" + TENANT1
+	apiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+
+	// Add the first dependent API to env1
+	dependentAPI1 := testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI1.ID)
+
+	// Add the second dependent API to env1
+	dependentAPI2 := testutils.AddAPIFromOpenAPIDefinition(t, dev, apiCreator, apiCreatorPassword)
+	testutils.PublishAPI(dev, apiPublisher, apiPublisherPassword, dependentAPI2.ID)
+
+	// Map the real name of the API with the API
+	apisList := map[string]*apim.API{
+		"PizzaShackAPI":   dependentAPI1,
+		"SwaggerPetstore": dependentAPI2,
+	}
+
+	for apiProductCount := 0; apiProductCount <= numberOfAPIProducts; apiProductCount++ {
+		// Add the API Product to env1
+		testutils.AddAPIProductFromJSON(t, dev, apiPublisher, apiPublisherPassword, apisList)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIProductsListWithJsonArrayFormat(t, args)
+}
+
 func TestDeleteApiProductAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -590,6 +590,94 @@ func TestListApisDevopsTenantUser(t *testing.T) {
 	testutils.ValidateAPIsList(t, args)
 }
 
+func TestListApisWithJsonArrayFormatAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApisWithJsonArrayFormatDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	apiCreator := creator.UserName
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApisWithJsonArrayFormatAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsListWithJsonArrayFormat(t, args)
+}
+
+func TestListApisWithJsonArrayFormatDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	apiCreator := creator.UserName + "@" + TENANT1
+	apiCreatorPassword := creator.Password
+
+	dev := apimClients[0]
+
+	for apiCount := 0; apiCount <= numberOfAPIs; apiCount++ {
+		// Add the API to env1
+		testutils.AddAPI(t, dev, apiCreator, apiCreatorPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAPIsListWithJsonArrayFormat(t, args)
+}
+
 func TestDeleteApiAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword

--- a/import-export-cli/integration/app_test.go
+++ b/import-export-cli/integration/app_test.go
@@ -82,6 +82,88 @@ func TestListAppsDevopsTenantUser(t *testing.T) {
 	testutils.ListApps(t, apim.GetEnvName())
 }
 
+func TestListAppsWithJsonArrayFormatAdminSuperTenantUser(t *testing.T) {
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	for appsCount := 0; appsCount <= numberOfApps; appsCount++ {
+		// Add the Application to env1
+		testutils.AddApp(t, dev, adminUsername, adminPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: adminUsername, Password: adminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAppsListWithJsonArrayFormat(t, args)
+}
+
+func TestListAppsWithJsonArrayFormatDevopsSuperTenantUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	adminUsername := superAdminUser
+	adminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	for appsCount := 0; appsCount <= numberOfApps; appsCount++ {
+		// Add the Application to env1
+		testutils.AddApp(t, dev, adminUsername, adminPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAppsListWithJsonArrayFormat(t, args)
+}
+
+func TestListAppsWithJsonArrayFormatAdminTenantUser(t *testing.T) {
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	for appsCount := 0; appsCount <= numberOfApps; appsCount++ {
+		// Add the Application to env1
+		testutils.AddApp(t, dev, tenantAdminUsername, tenantAdminPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantAdminUsername, Password: tenantAdminPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAppsListWithJsonArrayFormat(t, args)
+}
+
+func TestListAppsWithJsonArrayFormatDevopsTenantUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantAdminUsername := superAdminUser + "@" + TENANT1
+	tenantAdminPassword := superAdminPassword
+
+	dev := apimClients[0]
+
+	for appsCount := 0; appsCount <= numberOfApps; appsCount++ {
+		// Add the Application to env1
+		testutils.AddApp(t, dev, tenantAdminUsername, tenantAdminPassword)
+	}
+
+	args := &testutils.ApiImportExportTestArgs{
+		CtlUser: testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		SrcAPIM: dev,
+	}
+
+	testutils.ValidateAppsListWithJsonArrayFormat(t, args)
+}
+
 //List all the applications in an environment (by specifying the owner)
 func TestListAppWithOwner(t *testing.T) {
 	username := superAdminUser

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -14,4 +14,4 @@ indexing-delay: 1000
 
 dcr-version: v0.17
 rest-api-version: v1
-apictl-version: 3.2.5
+apictl-version: 3.2.6

--- a/import-export-cli/integration/testutils/app_testUtils.go
+++ b/import-export-cli/integration/testutils/app_testUtils.go
@@ -86,6 +86,12 @@ func ListApps(t *testing.T, env string) []string {
 	return base.GetRowsFromTableResponse(response)
 }
 
+func listAppsWithJsonArrayFormat(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
+	output, err := base.Execute(t, "list", "apps", "-e", args.SrcAPIM.EnvName, "--format", "jsonArray",
+		"-k", "--verbose")
+	return output, err
+}
+
 func ListAppsWithOwner(t *testing.T, env string, owner string) []string {
 	response, _ := base.Execute(t, "list", "apps", "-e", env, "-k", "--owner", owner)
 
@@ -382,4 +388,23 @@ func updateAdditionalPropertiesOfKeys(t *testing.T, args *AppImportExportTestArg
 	}
 
 	return applicationContent["keyManagerWiseOAuthApp"].(map[string]interface{})
+}
+
+// ValidateAppsListWithJsonArrayFormat : Validate the received list of Applications are in JsonArray format and
+// verify only the required ones are there and others are not in the command line output
+func ValidateAppsListWithJsonArrayFormat(t *testing.T, args *ApiImportExportTestArgs) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	// List APIs of env 1
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	output, _ := listAppsWithJsonArrayFormat(t, args)
+
+	// Validate JsonArray format
+	assert.Contains(t, output, "[\n {\n", "Error while listing APIs in JsonArray format")
 }


### PR DESCRIPTION
## Purpose
Adding integration tests for the improvement related to https://github.com/wso2/product-apim-tooling/pull/858

### New TestCases
**API Products**

_1. TestListApiProductsWithJsonArrayFormatAdminSuperTenantUser
2. TestListApiProductsWithJsonArrayFormatDevopsSuperTenantUser
3. TestListApiProductsWithJsonArrayFormatAdminTenantUser
4. TestListApiProductsWithJsonArrayFormatDevopsTenantUser_

**APIs**

_1. TestListApisWithJsonArrayFormatAdminSuperTenantUser
2. TestListApisWithJsonArrayFormatDevopsSuperTenantUser
3. TestListApisWithJsonArrayFormatAdminTenantUser
4. TestListApisWithJsonArrayFormatDevopsTenantUser_

**Apps**

_1. TestListAppsWithJsonArrayFormatAdminSuperTenantUser
2. TestListAppsWithJsonArrayFormatDevopsSuperTenantUser
3. TestListAppsWithJsonArrayFormatAdminTenantUser
4. TestListAppsWithJsonArrayFormatDevopsTenantUser_