### PR TITLE
[4.0.0] Fix adding apictl_bash_completions.sh to apictl distributions

### DIFF
--- a/import-export-cli/build.sh
+++ b/import-export-cli/build.sh
@@ -111,6 +111,10 @@ do
     cp -r "${baseDir}/resources/README.html" $zipdir > /dev/null 2>&1
     cp -r "${baseDir}/LICENSE.txt" $zipdir > /dev/null 2>&1
 
+    if [[ "windows" != "$goos" ]]; then
+      cp -r "${baseDir}/shell-completions/apictl_bash_completions.sh" $zipdir > /dev/null 2>&1
+    fi
+
     # set destination path for binary
     destination="$zipdir/$output"
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/815