### PR TITLE
Give priority to meta data file in Deployment repo during vcs deploy

### DIFF
--- a/import-export-cli/git/gitUtils.go
+++ b/import-export-cli/git/gitUtils.go
@@ -417,12 +417,20 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 				hasDeletedProjects = true
 				continue
 			}
+			projectDeploymentParamsDirLocation := generateDeploymentProjectPath(mainConfig, projectParam)
+			dirExists, _ := utils.IsDirExists(projectDeploymentParamsDirLocation)
+			if !dirExists {
+				projectDeploymentParamsDirLocation = ""
+			} else {
+				err := resolveProjectParamsMetaDataDeployConfig(&projectParam.MetaData.DeployConfig,
+					projectDeploymentParamsDirLocation+string(os.PathSeparator)+utils.MetaFileAPI)
+				if err != nil {
+					fmt.Println("Error... ", err)
+					failedProjects[projectParam.Type] = append(failedProjects[projectParam.Type], projectParam)
+				}
+			}
 			importParams := projectParam.MetaData.DeployConfig.Import
 			fmt.Println(strconv.Itoa(i+1) + ": " + projectParam.NickName + ": (" + projectParam.RelativePath + ")")
-			projectDeploymentParamsDirLocation := generateDeploymentProjectPath(mainConfig, projectParam)
-			if dirExists, _ := utils.IsDirExists(projectDeploymentParamsDirLocation); !dirExists {
-				projectDeploymentParamsDirLocation = ""
-			}
 			err := impl.ImportAPIToEnv(accessToken, environment, generateSourceProjectPath(mainConfig, projectParam),
 				projectDeploymentParamsDirLocation, importParams.Update, importParams.PreserveProvider, false, importParams.RotateRevision, false)
 			if err != nil {
@@ -443,12 +451,20 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 				hasDeletedProjects = true
 				continue
 			}
+			projectDeploymentParamsDirLocation := generateDeploymentProjectPath(mainConfig, projectParam)
+			dirExists, _ := utils.IsDirExists(projectDeploymentParamsDirLocation)
+			if !dirExists {
+				projectDeploymentParamsDirLocation = ""
+			} else {
+				err := resolveProjectParamsMetaDataDeployConfig(&projectParam.MetaData.DeployConfig,
+					projectDeploymentParamsDirLocation+string(os.PathSeparator)+utils.MetaFileAPIProduct)
+				if err != nil {
+					fmt.Println("Error... ", err)
+					failedProjects[projectParam.Type] = append(failedProjects[projectParam.Type], projectParam)
+				}
+			}
 			importParams := projectParam.MetaData.DeployConfig.Import
 			fmt.Println(strconv.Itoa(i+1) + ": " + projectParam.NickName + ": (" + projectParam.RelativePath + ")")
-			projectDeploymentParamsDirLocation := generateDeploymentProjectPath(mainConfig, projectParam)
-			if dirExists, _ := utils.IsDirExists(projectDeploymentParamsDirLocation); !dirExists {
-				projectDeploymentParamsDirLocation = ""
-			}
 			err := impl.ImportAPIProductToEnv(accessToken, environment, generateSourceProjectPath(mainConfig, projectParam),
 				projectDeploymentParamsDirLocation, importParams.ImportAPIs, importParams.UpdateAPIs, importParams.UpdateAPIProduct,
 				importParams.PreserveProvider, false, importParams.RotateRevision, false)
@@ -492,6 +508,22 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 	}
 
 	return hasDeletedProjects, deletedProjectsPerType, failedProjects
+}
+
+// This method is responsible for resolving the correct meta data deplof configurations
+// for API and API Product projects by considering both the Source and Deployment repositories
+// sourceDeploymentMetaData is the values of the meta data file from the Source repository
+// deploymentDirPath is deployment repository path to retrieve meta data from
+func resolveProjectParamsMetaDataDeployConfig(sourceDeploymentMetaData *utils.DeployConfig,
+	deploymentDirPath string) error {
+	utils.Logln("Resolving deployment parameters in " + deploymentDirPath)
+	metaData, err := LoadMetaDataFile(deploymentDirPath)
+	if err != nil {
+		return err
+	}
+	*sourceDeploymentMetaData = metaData.DeployConfig
+	return nil
+
 }
 
 // This method is responsible for updating the vcs configuration file at the end of the deployment


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/833

## Goals
Reflect the parameters updated from api_meta.yaml file inside deployment directory when executing VCS commands

## Approach
Wrote a new function to check the deployment parameters inside the Deployment repository. If the Deployment repository does not exist the old behaviour will happen.