### PR TITLE
Adding the integration test for third party Async API export/import support

### DIFF
--- a/import-export-cli/integration/advertiseOnlyApi_test.go
+++ b/import-export-cli/integration/advertiseOnlyApi_test.go
@@ -219,3 +219,29 @@ func TestInitDeploymentDirImportExportAdvertiseOnlyAPIDevopsTenant(t *testing.T)
 		api.Name, api.Version)
 	testutils.ValidateAPIImportExportWithDeploymentDirForAdvertiseOnlyAPI(t, importExportArgs)
 }
+
+// Export a third party Async API from one environment, import to another environment, and reimport it with update
+func TestExportImportAdvertiseOnlyAsyncApiWithUpdate(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			api := testutils.AddWebStreamingAPIFromAsyncAPIDefinition(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
+				testutils.APITypeAsync)
+
+			args := &testutils.ApiImportExportTestArgs{
+				ApiProvider: testutils.Credentials{Username: user.ApiCreator.Username, Password: user.ApiCreator.Password},
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				DestAPIM:    prod,
+			}
+
+			testutils.ValidateAPIImportExportForAdvertiseOnlyAPI(t, args, testutils.APITypeAsync)
+
+			args.Update = true
+			testutils.ValidateAPIImportExportForAdvertiseOnlyAPI(t, args, testutils.APITypeAsync)
+		})
+	}
+}

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -196,6 +196,15 @@ func (instance *Client) GenerateSampleStreamingAPIData(provider, apiType string)
 	return &api
 }
 
+func GenerateAdvertiseOnlyProperties(api *API, originalDevportalUrl, productionEp, sandboxEp string) {
+	api.AdvertiseInformation.Advertised = true
+	api.AdvertiseInformation.ApiOwner = api.Provider
+	api.AdvertiseInformation.OriginalDevPortalUrl = originalDevportalUrl
+	api.AdvertiseInformation.ApiExternalProductionEndpoint = productionEp
+	api.AdvertiseInformation.ApiExternalSandboxEndpoint = sandboxEp
+	api.AdvertiseInformation.Vendor = "WSO2"
+}
+
 func getContext(provider string) string {
 	context := base.GenerateRandomString()
 	if strings.Contains(provider, "@") {
@@ -247,6 +256,14 @@ func (instance *Client) GenerateAdditionalProperties(provider, endpointUrl, apiT
 					}
 			}
 		}`
+	} else if strings.EqualFold(apiType, "ASYNC") {
+		api := API{}
+		api.Provider = provider
+		GenerateAdvertiseOnlyProperties(&api, "https://localhost:9443/devportal", "amqp://production-ep:9000",
+			"amqp://sandbox-ep:9000")
+		advertiseInfo, _ := json.Marshal(api.AdvertiseInformation)
+		additionalProperties = additionalProperties + `"type":"` + apiType + `",
+		"advertiseInfo": ` + string(advertiseInfo) + `}`
 	} else {
 		additionalProperties = additionalProperties +
 			`"endpointConfig": {   

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/wso2/product-apim-tooling/import-export-cli/integration/adminservices"
 	"gopkg.in/yaml.v2"
 
 	"github.com/stretchr/testify/assert"
@@ -286,22 +285,7 @@ func ValidateAPIImportExportWithDeploymentDirForAdvertiseOnlyAPI(t *testing.T, a
 
 	importedAPI := GetImportedAPI(t, args)
 
-	assert.Equal(t, args.Api.AdvertiseInformation.Advertised, importedAPI.AdvertiseInformation.Advertised)
-	assert.Equal(t, args.Api.Provider, importedAPI.AdvertiseInformation.ApiOwner)
-	assert.Equal(t, args.Api.AdvertiseInformation.ApiExternalProductionEndpoint, importedAPI.AdvertiseInformation.ApiExternalProductionEndpoint)
-	assert.Equal(t, args.Api.AdvertiseInformation.ApiExternalSandboxEndpoint, importedAPI.AdvertiseInformation.ApiExternalSandboxEndpoint)
-
-	if (args.CtlUser.Username == adminservices.AdminUsername) ||
-		(args.CtlUser.Username == adminservices.AdminUsername+"@"+adminservices.Tenant1) {
-		// Only the users who has admin privileges (apim:admin scope) were allowed to set the original devportal URL.
-		assert.Equal(t, args.Api.AdvertiseInformation.OriginalDevPortalUrl,
-			importedAPI.AdvertiseInformation.OriginalDevPortalUrl)
-	} else {
-		assert.Equal(t, "", importedAPI.AdvertiseInformation.OriginalDevPortalUrl)
-	}
-
-	// Certificates should not get exported for advertise only APIs
-	validateNonExportedAPICerts(t, importedAPI, args)
+	ValidateAdvertiseOnlyAPIsEqual(t, importedAPI, args)
 }
 
 func MoveDummyAPIParamsAndCertificatesToDeploymentDir(args *ApiImportExportTestArgs) {

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -138,6 +138,7 @@ const APITypeGraphQL = "GraphQL"
 const APITypeWebScoket = "WS"
 const APITypeWebSub = "WEBSUB"
 const APITypeSSE = "SSE"
+const APITypeAsync = "ASYNC"
 
 // REST API Endpoint URL
 const RESTAPIEndpoint = "https://petstore.swagger.io"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/900
Fixes: https://github.com/wso2/product-apim/issues/12693

## Goals
Adding the integration test for third party Async API export/import support

## Approach
- Wrote a new table driven integration test for all the four (4) users, related to the above concern (TestExportImportAdvertiseOnlyAsyncApiWithUpdate)
- All the tests are passing with the current pack.
  ![image](https://user-images.githubusercontent.com/25246848/158974192-9c1dd38d-a05c-4198-beff-29662abf377c.png)

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11177

## Test environment
- Ubuntu 20.04.4 LTS
- go version go1.16.3 linux/amd64
