### PR TITLE
Fixing the flags in the build script

### DIFF
--- a/import-export-cli/build.sh
+++ b/import-export-cli/build.sh
@@ -31,7 +31,7 @@ function detectPlatformSpecificBuild() {
 }
 
 
-while getopts :t:v:f:c FLAG; do
+while getopts :t:v:fc FLAG; do
   case $FLAG in
     c)
       cgo_enabled=0


### PR DESCRIPTION
## Purpose
-f was not detected unless we specify -c. Hence, fixed that issue.

## Approach
: should only be used with the flags which take arguments [1]. -f and -c do not take arguments. Hence, removed : from those.

[1] https://www.shellscript.sh/tips/getopts/