### PR TITLE
Fixing the params templates for APIs and API Products during apictl gen deployment-dir

### DIFF
--- a/import-export-cli/box/resources/sample/api_params.yaml
+++ b/import-export-cli/box/resources/sample/api_params.yaml
@@ -3,7 +3,9 @@ environments:
       configs:
           endpoints:
               production:
+                  url:
               sandbox:
+                  url:
           security:
               enabled:
               type:

--- a/import-export-cli/box/resources/sample/api_product_params.yaml
+++ b/import-export-cli/box/resources/sample/api_product_params.yaml
@@ -5,7 +5,9 @@ environments:
               <api_1_name>-<api_1_version>:
                   endpoints:
                       production:
+                          url:
                       sandbox:
+                          url:
                   security:
                       enabled:
                       type:
@@ -31,7 +33,9 @@ environments:
               <api_2_name>-<api_2_version>:
                   endpoints:
                       production:
+                          url:
                       sandbox:
+                          url:
                   security:
                       enabled:
                       type:


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim-tooling/issues/829

## Goals
The endpoints fields didn't contain the url attribute in the params files of APIs and API Products which were generated during apictl ge deployment-dir. Hence, added it.