### PR TITLE
Fix: Handle Multiple Endpoints with Configs

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -13,23 +13,41 @@ import (
 // Configuration represents endpoint config
 type Configuration struct {
 	// RetryTimeOut for endpoint
-	RetryTimeOut *int `yaml:"retryTimeOut" json:"retryTimeOut,string"`
+	RetryTimeOut *int `yaml:"retryTimeOut" json:"retryTimeOut,string,omitempty"`
 	// RetryDelay for endpoint
-	RetryDelay *int `yaml:"retryDelay" json:"retryDelay,string"`
+	RetryDelay *int `yaml:"retryDelay" json:"retryDelay,string,omitempty"`
 	// Factor used for config
-	Factor *int `yaml:"factor" json:"factor,string"`
+	Factor *int `yaml:"factor" json:"factor,string,omitempty"`
+	// ActionDuration used for config
+	ActionDuration *int `yaml:"actionDuration" json:"actionDuration,string,omitempty"`
+	// SuspendDuration used for config
+	SuspendDuration *int `yaml:"suspendDuration" json:"suspendDuration,string,omitempty"`
+	// SuspendMaxDuration used for config
+	SuspendMaxDuration *int `yaml:"suspendMaxDuration" json:"suspendMaxDuration,string,omitempty"`
+	// RetryErrorCode used for config
+	RetryErroode []string `yaml:"retryErroCode" json:"retryErroCode,omitempty"`
+	// SuspendEroorCode used for config
+	SuspendErrorCode []string `yaml:"suspendErrorCode" json:"suspendErrorCode,omitempty"`
+	// Optimize used for config
+	Optimize string `yaml:"optimize" json:"optimize,omitempty"`
+	// ActionSelect used for config
+	ActionSelect string `yaml:"actionSelect" json:"actionSelect,omitempty"`
+	// Format used for config
+	Format string `yaml:"format" json:"format,omitempty"`
 }
 
 // Endpoint details
 type Endpoint struct {
+	EndpointType string `json:"endpoint_type,omitempty"`
 	// Url of the endpoint
 	Url *string `yaml:"url" json:"url"`
 	// Config of endpoint
-	Config *Configuration `yaml:"config" json:"config"`
+	Config *Configuration `yaml:"config" json:"config,omitempty"`
 }
 
 // EndpointData contains details about endpoints
 type EndpointData struct {
+	EndpointType string `json:"endpoint_type"`
 	// Production endpoint
 	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
 	// Sandbox endpoint
@@ -64,8 +82,19 @@ type Cert struct {
 type Environment struct {
 	// Name of the environment
 	Name string `yaml:"name"`
+	// Type of the endpoints. Values can be "rest", "soap", "dynamic" or "aws"
+	EndpointType string `yaml:"endpointType"`
+	// EndpointRoutingPolicy contains the routing policy related to the endpoint. Values can be "load_balanced" or "failover".
+	// (Only available for the endpointTypes "rest" or "soap")
+	EndpointRoutingPolicy string `yaml:"endpointRoutingPolicy"`
 	// Endpoints contain details about endpoints in a configuration
 	Endpoints *EndpointData `yaml:"endpoints"`
+	// LoadBalanceEndpoints contain details about endpoints in a configuration for load balancing scenarios
+	LoadBalanceEndpoints *LoadBalanceEndpointsData `yaml:"loadBalanceEndpoints"`
+	// FailoverEndpoints contain details about endpoints in a configuration for failover scenarios
+	FailoverEndpoints *FailoverEndpointsData `yaml:"failoverEndpoints"`
+	// AWSLambdaEndpoints contain details about endpoints in a configuration with AWD Lambda configuration
+	AWSLambdaEndpoints *AWSLambdaEndpointsData `yaml:"awsLambdaEndpoints"`
 	// Security contains the details about endpoint security
 	Security *SecurityData `yaml:"security"`
 	// GatewayEnvironments contains environments that used to deploy API
@@ -84,6 +113,55 @@ type ApiParams struct {
 type APIEndpointConfig struct {
 	// EPConfig is representing endpoint configuration
 	EPConfig string `json:"endpointConfig"`
+}
+
+// LoadBalanceEndpointsData contains details about endpoints mainly to be used in load balancing
+type LoadBalanceEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Production endpoints list for load balancing
+	Production []Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Sandbox endpoints list for load balancing
+	Sandbox []Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Session management method from the load balancing group. Values can be "none", "transport" (by default), "soap", "simpleClientSession" (Client ID)
+	SessionManagement string `yaml:"sessionManagement" json:"sessionManagement,omitempty"`
+	// Session timeout means the number of milliseconds after which the session would time out
+	SessionTimeout int `yaml:"sessionTimeOut" json:"sessionTimeOut,omitempty"`
+	// Class name for algorithm to be used if load balancing should be done
+	AlgorithmClassName string `yaml:"algoClassName" json:"algoClassName,omitempty"`
+	// To disable failover endpoints
+	Failover bool `json:"failOver"`
+	// TODO: Introduce loadbalancedSandbox & loadbalancedProduction
+}
+
+// FailoverEndpointsData contains details about endpoints mainly to be used in failover scenario
+type FailoverEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Primary production endpoint for failover
+	Production *Endpoint `yaml:"production" json:"production_endpoints,omitempty"`
+	// Production failover endpoints list for failover
+	ProductionFailovers []Endpoint `yaml:"productionFailovers" json:"production_failovers,omitempty"`
+	// Primary sandbox endpoint for failover
+	Sandbox *Endpoint `yaml:"sandbox" json:"sandbox_endpoints,omitempty"`
+	// Production failover endpoints list for failover endpoint types
+	SandboxFailovers []Endpoint `yaml:"sandboxFailovers" json:"sandbox_failovers,omitempty"`
+	// To enable failover endpoints
+	Failover bool `json:"failOver,omitempty"`
+}
+
+// AWSLambdaEndpointsData contains details about endpoints to be used with AWS Lambda endpoints
+type AWSLambdaEndpointsData struct {
+	// Type of the endpoints
+	EndpointType string `json:"endpoint_type"`
+	// Access method for endpoint. Values can be "role-supplied" (Using IAM role-supplied temporary AWS credentials) and "stored" (Using stored AWS credentials)
+	AccessMethod string `yaml:"accessMethod" json:"access_method,omitempty"`
+	// Region where endpoint located (Regions list https://docs.aws.amazon.com/general/latest/gr/rande.html)
+	AmznRegion string `yaml:"amznRegion" json:"amznRegion,omitempty"`
+	// Access Key for endpoint
+	AmznAccessKey string `yaml:"amznAccessKey" json:"amznAccessKey,omitempty"`
+	// Access Secret for endpoint
+	AmznSecretKey string `yaml:"amznSecretKey" json:"amznSecretKey,omitempty"`
 }
 
 // loadApiParams loads an configuration from a reader. It returns an error or a valid ApiParams

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -143,3 +143,29 @@ const DefaultApisDisplayLimit = 25
 const DefaultApiProductsDisplayLimit = 25
 const DefaultAppsDisplayLimit = 25
 const DefaultExportFormat = "YAML"
+
+// Multiple endpoints related constants
+const HttpRESTEndpointType = "rest"              // To denote "endpointType: rest" in api_params.yaml
+const HttpRESTEndpointTypeForJSON = "http"       // To denote "endpointType: http" in api_params.yaml and to denote the "endpointType : http" in api.json
+const HttpSOAPEndpointType = "soap"              // To denote "endpointType: soap" in api_params.yaml
+const HttpSOAPEndpointTypeForJSON = "address"    // To denote the "endpointType : address" in api.json
+const AwsLambdaEndpointType = "aws"              // To denote "endpointType: aws" in api_params.yaml
+const AwsLambdaEndpointTypeForJSON = "awslambda" // To denote "endpointType: awslambda" in api.json
+const DynamicEndpointType = "dynamic"            // To denote "endpointType: dynamic" in api_params.yaml
+
+const LoadBalanceEndpointRoutingPolicy = "load_balanced" // To denote "endpointRoutingPolicy: load_balanced" in api_params.yaml
+const LoadBalanceEndpointTypeForJSON = "load_balance"    // To denote the "endpointType : load_balance" in api.json
+const LoadBalanceAlgorithmClass = "org.apache.synapse.endpoints.algorithms.RoundRobin"
+const FailoverRoutingPolicy = "failover" // To denote "endpointRoutingPolicy: failover" in api_params.yaml and to denote the "endpointType : failover" in api.json
+
+const DynamicEndpointConfig = `{"endpoint_type":"default","sandbox_endpoints":{"url":"default"},"failOver":"False","production_endpoints":{"url":"default"}}`
+
+const AwsLambdaRoleSuppliedAccessMethod = "role_supplied"        // To denote "accessMethod: role_supplied" in api_params.yaml
+const AwsLambdaRoleSuppliedAccessMethodForJSON = "role-supplied" // To denote the "accessMethod : role-supplied" in api.json
+const AwsLambdaStoredAccessMethod = "stored"                     // To denote "accessMethod: stored" in api_params.yaml and to denote the "accessMethod : stored" in api.json
+
+const TransportSessionManagementMethod = "transport"
+const TransportSessionManagementMethodForJSON = "http"
+
+const ClientIdSessionManagementMethod = "clientId"
+const ClientIdSessionManagementMethodForJSON = "simpleClientSession"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
Provide the support to import an API with multiple endpoint configurations in `api_params.yaml` file

## Approach
Introduced five (5) new fields.

1. endpointType to specify the type of the endpoint. Values can be "rest", "soap", "dynamic" or "aws".
2. endpointRoutingPolicy to specify the routing policy to be used. Values can be "load_balanced" or "failover".
3. loadBalanceEndpoints should be specified if the endpointRoutingPolicy is "load_balanced". This field contains the following.

  - production: An array which consists the multiple production endpoints
  - sandbox: An array which consists the multiple sandbox endpoints
  - sessionManagement: Values can be "none", "transport", "soap", "simpleClientSession" and if not specified the default value would be "transport"
  - sessionTimeOut: The number of milliseconds after which the session would time out

4. failoverEndpoints should be specified if the endpointRoutingPolicy is "failover". This field contains the following.

  - production: The primary production endpoint (not an array)
  - sandbox: The primary sandbox endpoint (not an array)
  - productionFailovers: An array which consists failover production endpoints
  - sandboxFailovers: An array which consists failover sandbox endpoints

5. awsLambdaEndpoints should be specified if the endpointType is "aws". This field contains the following.

  - accessMethod: The access method of awslambda endpoint. Mandatory to specify. (Values can be "role_supplied" or "stored")
  - amznRegion: Region where the endpoint is located. Can be chosen from https://docs.aws.amazon.com/general/latest/gr/rande.html
  - amznAccessKey: Access Key for endpoint
  - amznSecretKey: Access Secret for endpoint

Other than these configurations, endpoints may have own configurations defined. From the UI, some missing configurations are added. Now the configuration `struct` looks as follows.

```
type Configuration struct {
	RetryTimeOut *int `yaml:"retryTimeOut" json:"retryTimeOut,string,omitempty"`
	RetryDelay *int `yaml:"retryDelay" json:"retryDelay,string,omitempty"`
	Factor *int `yaml:"factor" json:"factor,string,omitempty"`
	ActionDuration *int `yaml:"actionDuration" json:"actionDuration,string,omitempty"`
	SuspendDuration *int `yaml:"suspendDuration" json:"suspendDuration,string,omitempty"`
	SuspendMaxDuration *int `yaml:"suspendMaxDuration" json:"suspendMaxDuration,string,omitempty"`
	RetryErroode []string `yaml:"retryErroCode" json:"retryErroCode,omitempty"`
	SuspendErrorCode []string `yaml:"suspendErrorCode" json:"suspendErrorCode,omitempty"`
	Optimize string `yaml:"optimize" json:"optimize,omitempty"`
	ActionSelect string `yaml:"actionSelect" json:"actionSelect,omitempty"`
	Format string `yaml:"format" json:"format,omitempty"`
}
```

The feature is a replication of a fix done for `apictl 3.2.0`


## Release note
WSO2 API Controller 3.1.0 now supports importing an API with multiple endpoints.

## Documentation
[PR-5955](https://github.com/wso2/docs-apim/pull/5955)


## Related PRs
#336 

## Test environment
go version go1.18.2 darwin/amd64
mac OS Monterey `v12.4`
