### PR TITLE
Fix: RestEndpointType issue

### DIFF
--- a/import-export-cli/cmd/importAPI.go
+++ b/import-export-cli/cmd/importAPI.go
@@ -1012,7 +1012,7 @@ func setupEndpoints(environmentParams *params.Environment) ([]byte, error) {
 	var configData []byte
 	var err error
 
-	// if the endpoint routing policy or the endpoints field is not specified
+	// if the endpoint routing policy and the endpoints field is not specified
 	if environmentParams.EndpointRoutingPolicy == "" && environmentParams.Endpoints == nil {
 		// if endpoint type is Dynamic
 		if environmentParams.EndpointType == utils.DynamicEndpointType {
@@ -1031,8 +1031,8 @@ func setupEndpoints(environmentParams *params.Environment) ([]byte, error) {
 		}
 	}
 
-	// if endpoint type is HTTP/REST
-	if environmentParams.EndpointType == utils.HttpRESTEndpointType || environmentParams.EndpointType == utils.HttpRESTEndpointTypeForJSON {
+	// if endpoint type is HTTP/REST or endpoint is not defined
+	if isEmpty(environmentParams.EndpointType) || environmentParams.EndpointType == utils.HttpRESTEndpointType {
 		environmentParams.EndpointType = utils.HttpRESTEndpointTypeForJSON
 
 		if environmentParams.Endpoints != nil {


### PR DESCRIPTION
## Purpose
Empty rest endpoint type in api params file gives ` unexpected end of JSON input` error when importing APIs

## Goals
Check the emptiness of the rest endpoint type in `api_params.yaml` file.

## Approach
Added a condition to check the emptiness of rest endpoint type.

## Release note
WSO2 API Controller 3.1.5 now supports importing an API with multiple endpoints.

## Related PRs
#917 