### PR TITLE
Adding an integration test when importing an API with an invalid OAS

### DIFF
--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -245,25 +245,28 @@ func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 
 // Import an API from initialized project with an invalid Open API 3 definition
 func TestImportProjectCreatedFromInvalidOpenAPI3Definition(t *testing.T) {
-	apim := GetDevClient()
-	projectName := base.GenerateRandomName(16)
-	username := superAdminUser
-	password := superAdminPassword
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			apim := GetDevClient()
+			projectName := base.GenerateRandomString()
 
-	args := &testutils.InitTestArgs{
-		CtlUser:   testutils.Credentials{Username: username, Password: password},
-		SrcAPIM:   apim,
-		InitFlag:  projectName,
-		OasFlag:   testutils.TestOpenAPI3DefinitionPath,
-		APIName:   "NoahExpressTimeTableAPI",
-		ForceFlag: false,
+			args := &testutils.InitTestArgs{
+				CtlUser:   testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				SrcAPIM:   apim,
+				InitFlag:  projectName,
+				OasFlag:   testutils.TestInvalidOpenAPI3DefinitionPath,
+				APIName:   base.GenerateRandomString() + "API",
+				ForceFlag: false,
+			}
+
+			// Initialize a project with OAS
+			testutils.ValidateInitializeProjectWithOASFlag(t, args)
+
+			// Assert that project import to publisher portal is unsuccessful
+			testutils.ValidateImportProjectWithInvalidSwaggerFailed(t, args, "",
+				!isTenantUser(user.CtlUser.Username, TENANT1))
+		})
 	}
-
-	// Initialize a project with OAS
-	testutils.ValidateInitializeProjectWithOASFlag(t, args)
-
-	// Assert that project import to publisher portal is unsuccessful
-	testutils.ValidateImportProjectFailed(t, args, "")
 }
 
 // Import API from initialized project from API definition which is already in publisher with --update flag

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -243,6 +243,29 @@ func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	testutils.ValidateImportProject(t, args, "", true)
 }
 
+// Import an API from initialized project with an invalid Open API 3 definition
+func TestImportProjectCreatedFromInvalidOpenAPI3Definition(t *testing.T) {
+	apim := GetDevClient()
+	projectName := base.GenerateRandomName(16)
+	username := superAdminUser
+	password := superAdminPassword
+
+	args := &testutils.InitTestArgs{
+		CtlUser:   testutils.Credentials{Username: username, Password: password},
+		SrcAPIM:   apim,
+		InitFlag:  projectName,
+		OasFlag:   testutils.TestOpenAPI3DefinitionPath,
+		APIName:   "NoahExpressTimeTableAPI",
+		ForceFlag: false,
+	}
+
+	// Initialize a project with OAS
+	testutils.ValidateInitializeProjectWithOASFlag(t, args)
+
+	// Assert that project import to publisher portal is unsuccessful
+	testutils.ValidateImportProjectFailed(t, args, "")
+}
+
 // Import API from initialized project from API definition which is already in publisher with --update flag
 func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	for _, user := range testCaseUsers {

--- a/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
+++ b/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
@@ -1,0 +1,147 @@
+openapi: 3.0.1
+info:
+  title: NoahExpressTimeTableAPI
+  description: | 
+    This is the definition of the API for the public community to get the Noah Express train schedules
+  version: 1.0.0
+servers:
+  - url: http://backend-service:8080/train-operations/v1
+paths:
+  /schedules:
+    get:
+      parameters:
+       - in: query
+         name: from
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: to
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: startTime
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: endTime
+         schema:
+           type: string
+           description: Train starting station
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleItemList'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleItem'
+        required: true
+      responses:
+        '200':
+          description: ok
+  /schedules/{id1}_{id2}:
+    get:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleItem'
+    put:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+    delete:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    ScheduleItem:
+      title: Schedule information 
+      type: object
+      properties:
+        entryId:
+          type: string
+          description: Id of the schedule item.
+        startTime:
+          type: string
+          description: Train starting time.
+        endTime:
+          type: string
+          description: Train destination arrival time.
+        from:
+          type: string
+          description: Train starting station.
+        to:
+          type: string
+          description: Train destination station.
+        trainType:
+          type: string
+          description: Train category.
+    ScheduleItemList:
+        title: List of schedule items information 
+        type: array
+        items:
+          $ref: '#/components/schemas/ScheduleItem'
+            

--- a/import-export-cli/integration/testutils/devFirst_testUtils.go
+++ b/import-export-cli/integration/testutils/devFirst_testUtils.go
@@ -253,6 +253,22 @@ func ValidateImportProjectFailed(t *testing.T, args *InitTestArgs, paramsPath st
 	})
 }
 
+func ValidateImportProjectWithInvalidSwaggerFailed(t *testing.T, args *InitTestArgs, paramsPath string, preserveProvider bool) {
+	t.Helper()
+
+	result, _ := importApiFromProject(t, args.InitFlag, args.APIName, paramsPath, args.SrcAPIM, &args.CtlUser, false, preserveProvider)
+
+	assert.Contains(t, result, "400", "Test failed because API is imported successfully")
+	assert.Contains(t, result, "Error while parsing OpenAPI definition", "Test failed because API is imported successfully")
+
+	base.WaitForIndexing()
+
+	//Remove Created project and logout
+	t.Cleanup(func() {
+		base.RemoveDir(args.InitFlag)
+	})
+}
+
 func ValidateImportUpdateProject(t *testing.T, args *InitTestArgs, preserveProvider bool) *apim.API {
 	t.Helper()
 

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -27,6 +27,7 @@ const EnvVariableNameOfCustomCustomDirectoryAtInit = "APICTL_CONFIG_DIR"
 
 const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
 const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
+const TestInvalidOpenAPI3DefinitionPath = "testdata/invalidOpenAPI3Definition.yaml"
 const TestOpenAPI3DefinitionWithoutEndpointsPath = "testdata/openAPI3DefinitionWithoutEndpoints.yaml"
 const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"
 const TestMigrationDirectorySuffix = "/migration"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/115
Adding a test for the scenario covered in [1].

## Goals
Adding an integration test when importing an API with an invalid OAS

## Approach
Added a table driven test named TestImportProjectCreatedFromInvalidOpenAPI3Definition

## Related PRs
[1] https://github.com/wso2/carbon-apimgt/pull/11281

## Test environment
- Ubuntu 20.04.3 LTS
- go version go1.16.3 linux/amd64
