### PR TITLE
Add Support for Throttling Policy Deletion

### DIFF
--- a/import-export-cli/cmd/deleteThrottlePolicy.go
+++ b/import-export-cli/cmd/deleteThrottlePolicy.go
@@ -57,9 +57,7 @@ var DeleteThrottlingPolicyCmd = &cobra.Command{
 		if err != nil {
 			utils.HandleErrorAndExit("Error getting credentials", err)
 		}
-
 		executeDeleteThrottlingPolicyCmd(cred)
-
 	},
 }
 

--- a/import-export-cli/cmd/deleteThrottlePolicy.go
+++ b/import-export-cli/cmd/deleteThrottlePolicy.go
@@ -1,0 +1,93 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var deleteThrottlingPolicyEnvironment string
+var deleteThrottlingPolicyName string
+var deleteThrottlingPolicyType string
+
+// DeleteThrottlingPolicy command related usage info
+const DeleteThrottlingPolicyCmdLiteral = "rate-limiting"
+const DeleteThrottlingPolicyCmdShortDesc = "Delete Throttling Policy"
+const DeleteThrottlingPolicyCmdLongDesc = "Delete a throttling policy from an environment"
+
+const DeleteThrottlingPolicyCmdExamplesDefault = utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + DeletePolicyCmdLiteral + ` ` + DeleteThrottlingPolicyCmdLiteral + ` -n Gold -e dev --type sub 
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + DeletePolicyCmdLiteral + ` ` + DeleteThrottlingPolicyCmdLiteral + ` -n AppPolicy -e prod --type app
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + DeletePolicyCmdLiteral + ` ` + DeleteThrottlingPolicyCmdLiteral + ` -n TestPolicy -e dev --type advanced 
+` + utils.ProjectName + ` ` + deleteCmdLiteral + ` ` + DeletePolicyCmdLiteral + ` ` + DeleteThrottlingPolicyCmdLiteral + ` -n CustomPolicy -e prod --type custom 
+NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.`
+
+// DeleteThrottlingPolicyCmd represents the delete Throttling policy command
+var DeleteThrottlingPolicyCmd = &cobra.Command{
+	Use: DeleteThrottlingPolicyCmdLiteral + " (--name <name-of-the-throttling-policy> --environment " +
+		"<environment-from-which-the-policy-should-be-deleted>)" +
+		"--type <type-of-the-throttling-policy>",
+	Short:   DeleteThrottlingPolicyCmdShortDesc,
+	Long:    DeleteThrottlingPolicyCmdLongDesc,
+	Example: DeleteThrottlingPolicyCmdExamplesDefault,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + DeleteThrottlingPolicyCmdLiteral + " called")
+
+		cred, err := GetCredentials(deleteThrottlingPolicyEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+
+		executeDeleteThrottlingPolicyCmd(cred)
+
+	},
+}
+
+// executeDeleteThrottlingPolicyCmd executes the delete Throttling policy command
+func executeDeleteThrottlingPolicyCmd(credential credentials.Credential) {
+	accessToken, preCommandErr := credentials.GetOAuthAccessToken(credential, deleteThrottlingPolicyEnvironment)
+	if preCommandErr == nil {
+		_, err := impl.DeleteThrottlingPolicy(accessToken, deleteThrottlingPolicyName, deleteThrottlingPolicyType, deleteThrottlingPolicyEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error while deleting Throttling Policy ", err)
+		}
+		impl.PrintDeleteThrottlingPolicyResponse(deleteThrottlingPolicyName, deleteThrottlingPolicyType, err)
+	} else {
+		// Error deleting Throttling Policy
+		fmt.Println("Error getting OAuth tokens while deleting Throttling Policy:" + preCommandErr.Error())
+	}
+}
+
+// Init using Cobra
+func init() {
+	DeletePolicyCmd.AddCommand(DeleteThrottlingPolicyCmd)
+	DeleteThrottlingPolicyCmd.Flags().StringVarP(&deleteThrottlingPolicyName, "name", "n", "",
+		"Name of the Throttling Policy to be deleted")
+	DeleteThrottlingPolicyCmd.Flags().StringVarP(&deleteThrottlingPolicyEnvironment, "environment", "e",
+		"", "Environment from which the Throttling Policy should be deleted")
+	DeleteThrottlingPolicyCmd.Flags().StringVarP(&deleteThrottlingPolicyType, "type", "t",
+		"", "Type of the Throttling Policies to be exported (sub,app,custom,advanced)")
+	_ = DeleteThrottlingPolicyCmd.MarkFlagRequired("name")
+	_ = DeleteThrottlingPolicyCmd.MarkFlagRequired("environment")
+	_ = DeleteThrottlingPolicyCmd.MarkFlagRequired("type")
+}

--- a/import-export-cli/docs/apictl_delete_policy.md
+++ b/import-export-cli/docs/apictl_delete_policy.md
@@ -33,4 +33,5 @@ apictl delete policy api -n addHeader -e prod
 
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
 * [apictl delete policy api](apictl_delete_policy_api.md)	 - Delete an API Policy
+* [apictl delete policy rate-limiting](apictl_delete_policy_rate-limiting.md)	 - Delete Throttling Policy
 

--- a/import-export-cli/docs/apictl_delete_policy_rate-limiting.md
+++ b/import-export-cli/docs/apictl_delete_policy_rate-limiting.md
@@ -4,26 +4,29 @@ Delete Throttling Policy
 
 ### Synopsis
 
-Export Throttling Policy from an environment
+Delete a throttling policy from an environment
 
 ```
-apictl delete policy rate-limiting (--name <name-of-the-rate-limiting-policy> --type <type-of-the-rate-limiting-policy> --environment <environment-from-which-the-rate-limiting-policy-should-be-deleted>) [flags]
+apictl delete policy rate-limiting (--name <name-of-the-throttling-policy> --environment <environment-from-which-the-policy-should-be-deleted>)--type <type-of-the-throttling-policy> [flags]
 ```
 
 ### Examples
 
 ```
-apictl delete policy rate-limiting -n addHeader --type advanced -e dev
-NOTE: All the 2 flags (--name (-n), --type and --environment (-e)) are mandatory.
+apictl delete policy rate-limiting -n Gold -e dev --type sub 
+apictl delete policy rate-limiting -n AppPolicy -e prod --type app
+apictl delete policy rate-limiting -n TestPolicy -e dev --type advanced 
+apictl delete policy rate-limiting -n CustomPolicy -e prod --type custom 
+NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.
 ```
 
 ### Options
 
 ```
   -e, --environment string   Environment from which the Throttling Policy should be deleted
-  -h, --help                 help for Throttling Policy
+  -h, --help                 help for rate-limiting
   -n, --name string          Name of the Throttling Policy to be deleted
-  --type string              Type of the Throttling Policy to be deleted
+  -t, --type string          Type of the Throttling Policies to be exported (sub,app,custom,advanced)
 ```
 
 ### Options inherited from parent commands
@@ -35,5 +38,5 @@ NOTE: All the 2 flags (--name (-n), --type and --environment (-e)) are mandatory
 
 ### SEE ALSO
 
-* [apictl delete policy](apictl_delete_policy.md) - Delete a Policy
+* [apictl delete policy](apictl_delete_policy.md)	 - Delete a Policy
 

--- a/import-export-cli/impl/deleteThrottlingPolicy.go
+++ b/import-export-cli/impl/deleteThrottlingPolicy.go
@@ -44,8 +44,6 @@ func DeleteThrottlingPolicy(accessToken, policyName, policyType, environment str
 	resource := "throttling/policies/search"
 	searchEndpoint := endpoint + resource
 
-	// queryParamString := `query=name:` + policyName
-
 	switch policyType {
 	case CmdPolicyTypeSubscription:
 		throttlingPolicyType = QueryPolicyTypeSubscription
@@ -85,18 +83,13 @@ func DeleteThrottlingPolicy(accessToken, policyName, policyType, environment str
 		resource += utils.ThrottlingPolicyTypeCus
 	}
 
-	resource = utils.AppendSlashToString(resource)
-
-	resource += policyId
-
+	resource = utils.AppendSlashToString(resource) + policyId
 	url = endpoint + resource
-	fmt.Println(url)
 	utils.Logln(utils.LogPrefixInfo+"DeleteThrottlingPolicy: URL:", url)
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 
 	resp, err := utils.InvokeDELETERequest(url, headers)
-
 	if err != nil {
 		return nil, err
 	}

--- a/import-export-cli/impl/deleteThrottlingPolicy.go
+++ b/import-export-cli/impl/deleteThrottlingPolicy.go
@@ -1,0 +1,126 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// DeleteThrottlingPolicy
+// @param accessToken : Access Token for the resource
+// @param policyName : Name of the Throttling Policy to delete
+// @param policyType : Type of the Throttling Policy to delete
+// @param environment : Environment where Throttling should be deleted
+// @return response Response in the form of *resty.Response
+func DeleteThrottlingPolicy(accessToken, policyName, policyType, environment string) (*resty.Response, error) {
+	endpoint := utils.GetAdminEndpointOfEnv(environment, utils.MainConfigFilePath)
+	endpoint = utils.AppendSlashToString(endpoint)
+
+	resource := "throttling/policies/search"
+	searchEndpoint := endpoint + resource
+
+	queryParam := `?name=` + policyName
+
+	url := searchEndpoint + queryParam
+
+	policyId, err := getThrottlingPolicyId(accessToken, environment, url, policyType, policyName)
+
+	if policyId == "" && err == nil {
+		errMsg := "Requested Policy with name=" + policyName + " and type=" + policyType + " no found."
+		utils.HandleErrorAndExit("Deletion Failed ! ", errors.New(errMsg))
+	}
+
+	if err != nil {
+		utils.HandleErrorAndExit("Error while getting Throttling Policy Id for deletion ", err)
+	}
+
+	resource = "throttling/policies/"
+
+	switch policyType {
+	case CmdPolicyTypeSubscription:
+		resource += utils.ThrottlingPolicyTypeSub
+	case CmdPolicyTypeApplication:
+		resource += utils.ThrottlingPolicyTypeApp
+	case CmdPolicyTypeAdvanced:
+		resource += utils.ThrottlingPolicyTypeAdv
+	case CmdPolicyTypeCustom:
+		resource += utils.ThrottlingPolicyTypeCus
+	}
+
+	resource = utils.AppendSlashToString(resource)
+
+	resource += policyId
+
+	url = endpoint + resource
+	fmt.Println(url)
+	utils.Logln(utils.LogPrefixInfo+"DeleteThrottlingPolicy: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+
+	resp, err := utils.InvokeDELETERequest(url, headers)
+
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusNoContent {
+		return nil, errors.New(strconv.Itoa(resp.StatusCode()) + ":<" + string(resp.Body()) + ">")
+	}
+	return resp, nil
+}
+
+func getThrottlingPolicyId(accessToken, environment, url, policyType, policyName string) (string, error) {
+	utils.Logln(utils.LogPrefixInfo+"DeleteThrottlingPolicy: URL:", url)
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+	resp, err := utils.InvokeGETRequest(url, headers)
+
+	if err != nil {
+		return "", err
+	}
+
+	var policyList utils.ThrottlingPoliciesDetailsList
+	err = json.Unmarshal(resp.Body(), &policyList)
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, obj := range policyList.List {
+		if obj.Type == policyType && obj.PolicyName == policyName {
+			return obj.Uuid, nil
+		}
+	}
+
+	return "", nil
+}
+
+func PrintDeleteThrottlingPolicyResponse(policyName, policyType string, err error) {
+	if err != nil {
+		fmt.Println("Error deleting Throttling Policy:", err)
+	} else {
+		fmt.Println(policyName + " Throttling Policy with type " + policyType + " deleted successfully!")
+	}
+}

--- a/import-export-cli/impl/deleteThrottlingPolicy.go
+++ b/import-export-cli/impl/deleteThrottlingPolicy.go
@@ -57,7 +57,7 @@ func DeleteThrottlingPolicy(accessToken, policyName, policyType, environment str
 		throttlingPolicyType = QueryCmdPolicyTypeCustom
 	}
 
-	queryParamString := `query=type:` + throttlingPolicyType
+	queryParamString := `query=name:` + policyName + ` type:` + throttlingPolicyType
 
 	url := searchEndpoint
 
@@ -123,10 +123,8 @@ func getThrottlingPolicyId(accessToken, environment, url, queryParamString, poli
 		return "", err
 	}
 
-	for _, obj := range policyList.List {
-		if obj.PolicyName == policyName {
-			return obj.Uuid, nil
-		}
+	if policyList.Count > 0 {
+		return policyList.List[0].Uuid, nil
 	}
 
 	return "", nil

--- a/import-export-cli/impl/deleteThrottlingPolicy.go
+++ b/import-export-cli/impl/deleteThrottlingPolicy.go
@@ -49,8 +49,8 @@ func DeleteThrottlingPolicy(accessToken, policyName, policyType, environment str
 	policyId, err := getThrottlingPolicyId(accessToken, environment, url, policyType, policyName)
 
 	if policyId == "" && err == nil {
-		errMsg := "Requested Policy with name=" + policyName + " and type=" + policyType + " no found."
-		utils.HandleErrorAndExit("Deletion Failed ! ", errors.New(errMsg))
+		errMsg := "Requested Policy with name=" + policyName + " and type=" + policyType + " not found."
+		utils.HandleErrorAndExit("Deletion Failed! ", errors.New(errMsg))
 	}
 
 	if err != nil {

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -1031,6 +1031,57 @@ _apictl_delete_policy_help()
     noun_aliases=()
 }
 
+_apictl_delete_policy_rate-limiting()
+{
+    last_command="apictl_delete_policy_rate-limiting"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    two_word_flags+=("-n")
+    local_nonpersistent_flags+=("--name")
+    local_nonpersistent_flags+=("--name=")
+    local_nonpersistent_flags+=("-n")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    two_word_flags+=("-t")
+    local_nonpersistent_flags+=("--type")
+    local_nonpersistent_flags+=("--type=")
+    local_nonpersistent_flags+=("-t")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_flag+=("--name=")
+    must_have_one_flag+=("-n")
+    must_have_one_flag+=("--type=")
+    must_have_one_flag+=("-t")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_delete_policy()
 {
     last_command="apictl_delete_policy"
@@ -1040,6 +1091,7 @@ _apictl_delete_policy()
     commands=()
     commands+=("api")
     commands+=("help")
+    commands+=("rate-limiting")
 
     flags=()
     two_word_flags=()

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -298,3 +298,7 @@ const ZipFileSuffix = ".zip"
 const JsonArrayFormatType = "jsonArray"
 
 const DefaultAPIPolicyVersion = "v1"
+const ThrottlingPolicyTypeSub = "subscription"
+const ThrottlingPolicyTypeApp = "application"
+const ThrottlingPolicyTypeAdv = "advanced"
+const ThrottlingPolicyTypeCus = "custom"


### PR DESCRIPTION
## Purpose
Fixes: [wso2/api-manager#439](https://github.com/wso2/api-manager/issues/439)

## Approach
- Introduced a new APICTL delete command for throttling policy deletion.
- Throttling Policy name and type are mandatory fields to be provided along with the environment.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11286