### PR TITLE
Integration test for throttling policy deletion

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -2077,14 +2077,14 @@ func (instance *Client) AddThrottlePolicy(t *testing.T, policy interface{}, user
 	if doClean {
 		t.Cleanup(func() {
 			instance.Login(username, password)
-			instance.DeleteThrottlePolicy(policyId, policyType)
+			instance.DeleteThrottlePolicy(policyId, policyType, doClean)
 		})
 	}
 	return throttlePolicyResponse
 }
 
 // DeleteThrottlePolicy : Deletes Throttling Policy from APIM using UUID
-func (instance *Client) DeleteThrottlePolicy(policyID, policyType string) {
+func (instance *Client) DeleteThrottlePolicy(policyID, policyType string, doClean bool) {
 	policiesURL := instance.adminRestURL + "/throttling/policies/" + policyType + "/" + policyID
 
 	request := base.CreateDelete(policiesURL)
@@ -2095,21 +2095,9 @@ func (instance *Client) DeleteThrottlePolicy(policyID, policyType string) {
 
 	defer response.Body.Close()
 
-	base.ValidateAndLogResponse("apim.DeleteThrottlePolicy()", response, 200)
-}
-
-// DeleteThrottlePolicyWithouValidation : Deletes Throttling Policy from APIM using UUID without validating
-func (instance *Client) DeleteThrottlePolicyWithouValidation(policyID, policyType string) {
-	policiesURL := instance.adminRestURL + "/throttling/policies/" + policyType + "/" + policyID
-
-	request := base.CreateDelete(policiesURL)
-	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
-	base.LogRequest("apim.DeleteThrottlePolicyWithoutValidation()", request)
-
-	response := base.SendHTTPRequest(request)
-
-	defer response.Body.Close()
-
+	if !doClean {
+		base.ValidateAndLogResponse("apim.DeleteThrottlePolicy()", response, 200)
+	}
 }
 
 // GetThrottlePolicy : Get Throttle Policy from APIM using UUID
@@ -2132,9 +2120,9 @@ func (instance *Client) GetThrottlePolicy(policyID, policyType string) map[strin
 }
 
 // DeleteThrottlePolicyByName : Deletes Throttling Policy from APIM using policy name
-func (instance *Client) DeleteThrottlePolicyByName(t *testing.T, policyName, policyType string) {
+func (instance *Client) DeleteThrottlePolicyByName(t *testing.T, policyName, policyType string, doClean bool) {
 	policyID := instance.GetThrottlePolicyID(t, policyName, policyType)
-	instance.DeleteThrottlePolicy(policyID, policyType)
+	instance.DeleteThrottlePolicy(policyID, policyType, doClean)
 }
 
 // GetThrottlePolicyID : Get Throttle Policy UUID using policy name from APIM

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -2073,6 +2073,7 @@ func (instance *Client) AddThrottlePolicy(t *testing.T, policy interface{}, user
 
 	json.NewDecoder(response.Body).Decode(&throttlePolicyResponse)
 	policyId := fmt.Sprintf("%v", throttlePolicyResponse["policyId"])
+
 	if doClean {
 		t.Cleanup(func() {
 			instance.Login(username, password)
@@ -2095,6 +2096,20 @@ func (instance *Client) DeleteThrottlePolicy(policyID, policyType string) {
 	defer response.Body.Close()
 
 	base.ValidateAndLogResponse("apim.DeleteThrottlePolicy()", response, 200)
+}
+
+// DeleteThrottlePolicyWithouValidation : Deletes Throttling Policy from APIM using UUID without validating
+func (instance *Client) DeleteThrottlePolicyWithouValidation(policyID, policyType string) {
+	policiesURL := instance.adminRestURL + "/throttling/policies/" + policyType + "/" + policyID
+
+	request := base.CreateDelete(policiesURL)
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+	base.LogRequest("apim.DeleteThrottlePolicyWithoutValidation()", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
 }
 
 // GetThrottlePolicy : Get Throttle Policy from APIM using UUID

--- a/import-export-cli/integration/testutils/policy_testUtils.go
+++ b/import-export-cli/integration/testutils/policy_testUtils.go
@@ -95,6 +95,25 @@ func ValidateThrottlingPolicyDelete(t *testing.T, args *PolicyImportExportTestAr
 
 }
 
+// Validates whether the throttling policy deletion not exists
+func ValidateThrottlingPolicyDeleteNotExists(t *testing.T, args *PolicyImportExportTestArgs, username, password, policyType string) {
+	t.Helper()
+
+	// Setup apictl envs
+	base.SetupEnv(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL(), args.SrcAPIM.GetTokenURL())
+
+	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	base.WaitForIndexing()
+
+	policyName := base.GenerateRandomString()
+
+	_, err := deleteThrottlingPolicy(t, policyName, policyType, args)
+
+	assert.NotNil(t, err, "Error while deleting the API Policy")
+
+}
+
 func deleteThrottlingPolicy(t *testing.T, name string, policyType string, args *PolicyImportExportTestArgs) (string, error) {
 	output, err := base.Execute(t, "delete", "policy", "rate-limiting", "-e", args.SrcAPIM.EnvName, "-n", name, "-t", policyType, "-k", "--verbose")
 	return output, err

--- a/import-export-cli/integration/testutils/policy_testUtils.go
+++ b/import-export-cli/integration/testutils/policy_testUtils.go
@@ -89,16 +89,9 @@ func ValidateThrottlingPolicyDelete(t *testing.T, args *PolicyImportExportTestAr
 
 	policyName := fmt.Sprintf("%v", args.Policy[policyNameKey])
 
-	policyId := fmt.Sprintf("%v", args.Policy[policyIDKey])
-
 	_, err := deleteThrottlingPolicy(t, policyName, policyType, args)
 
 	assert.Nil(t, err, "Error while deleting the API Policy")
-
-	t.Cleanup(func() {
-		args.SrcAPIM.Login(username, password)
-		args.SrcAPIM.DeleteThrottlePolicyWithouValidation(policyId, policyType)
-	})
 
 }
 
@@ -256,6 +249,11 @@ func createExportedThrottlePolicyFile(t *testing.T, client *apim.Client, policyT
 	policyMap, _ := PolicyStructToMap(policyData)
 	var yamlMap yaml.MapSlice
 	yamlBytes, err := yaml.Marshal(policyMap)
+
+	if err != nil {
+		return "", "", err
+	}
+
 	err = yaml.Unmarshal(yamlBytes, &yamlMap)
 	if err != nil {
 		return "", policyData, err
@@ -319,7 +317,7 @@ func importThrottlePolicy(t *testing.T, username, password, policyName, policyTy
 	if doClean {
 		t.Cleanup(func() {
 			args.DestAPIM.Login(username, password)
-			args.DestAPIM.DeleteThrottlePolicyByName(t, policyName, policyType)
+			args.DestAPIM.DeleteThrottlePolicyByName(t, policyName, policyType, doClean)
 		})
 	}
 

--- a/import-export-cli/integration/testutils/policy_testUtils.go
+++ b/import-export-cli/integration/testutils/policy_testUtils.go
@@ -116,7 +116,11 @@ func ValidateNonExistingThrottlingPolicyDelete(t *testing.T, args *PolicyImportE
 
 	_, err := deleteThrottlingPolicy(t, policyName, policyType, args)
 
+	failureReason := "Requested Policy with name" + policyName + "and type" + policyType + "not found"
+
 	assert.Contains(t, err, "Deletion Failed")
+
+	assert.Contains(t, err, failureReason)
 
 }
 

--- a/import-export-cli/integration/testutils/policy_testUtils.go
+++ b/import-export-cli/integration/testutils/policy_testUtils.go
@@ -77,7 +77,7 @@ func ValidateThrottlePolicyExportImport(t *testing.T, args *PolicyImportExportTe
 }
 
 // Validates whether the throttling policy deletion is complete
-func ValidateThrottlingPolicyDelete(t *testing.T, args *PolicyImportExportTestArgs, username, password, policyType string) {
+func ValidateThrottlingPolicyDelete(t *testing.T, args *PolicyImportExportTestArgs, policyType string) {
 	t.Helper()
 
 	// Setup apictl envs
@@ -96,7 +96,7 @@ func ValidateThrottlingPolicyDelete(t *testing.T, args *PolicyImportExportTestAr
 }
 
 // Validates whether the throttling policy deletion not exists
-func ValidateThrottlingPolicyDeleteNotExists(t *testing.T, args *PolicyImportExportTestArgs, username, password, policyType string) {
+func ValidateThrottlingPolicyDeleteNotExists(t *testing.T, args *PolicyImportExportTestArgs, policyType string) {
 	t.Helper()
 
 	// Setup apictl envs

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -498,7 +498,7 @@ func TestNonExistingThrottlingPolicyDelete(t *testing.T) {
 				Update:   false,
 			}
 
-			testutils.ValidateThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
+			testutils.ValidateNonExistingThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
 		})
 	}
 }

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -40,7 +40,7 @@ func TestExportImportApplicationThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -67,7 +67,7 @@ func TestExportImportSubscriptionThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -94,7 +94,7 @@ func TestExportImportAdvancedThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -124,7 +124,7 @@ func TestExportImportCustomThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -148,7 +148,7 @@ func TestImportUpdateApplicationThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -175,7 +175,7 @@ func TestImportUpdateSubscriptionThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -202,7 +202,7 @@ func TestImportUpdateAdvancedThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -232,7 +232,7 @@ func TestImportUpdateCustomThrottlePolicy(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -256,7 +256,7 @@ func TestSubscriptionThrottlePolicyImportFailureWhenPolicyExisted(t *testing.T) 
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.SubscriptionThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -283,7 +283,7 @@ func TestApplicationThrottlePolicyImportFailureWhenPolicyExisted(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.ApplicationThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -310,7 +310,7 @@ func TestAdvancedThrottlePolicyImportFailureWhenPolicyExisted(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -340,7 +340,7 @@ func TestCustomThrottlePolicyImportFailureWhenPolicyExisted(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.CustomThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -439,7 +439,7 @@ func TestExportImportThrottlePolicyWithoutTypeFlag(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -466,7 +466,7 @@ func TestThrottlingPoliciesDelete(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, false)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,
@@ -474,31 +474,13 @@ func TestThrottlingPoliciesDelete(t *testing.T) {
 				DestAPIM: prod,
 				Update:   false,
 			}
-
-			testutils.ValidateThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
-		})
-	}
-}
-
-// Delete Non Existing Throttling Policy by comparing the status code.
-func TestNonExistingThrottlingPolicyDelete(t *testing.T) {
-
-	for _, user := range testCaseUsers {
-		t.Run(user.Description, func(t *testing.T) {
-
-			dev := GetDevClient()
-			prod := GetProdClient()
-
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
-			args := &testutils.PolicyImportExportTestArgs{
-				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
-				Policy:   throttlePolicy,
-				SrcAPIM:  dev,
-				DestAPIM: prod,
-				Update:   false,
+			adminUsername := superAdminUser
+			adminPassword := superAdminPassword
+			if isTenantUser(args.CtlUser.Username, TENANT1) {
+				adminUsername = adminUsername + "@" + TENANT1
 			}
 
-			testutils.ValidateNonExistingThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
+			testutils.ValidateThrottlingPolicyDelete(t, args, adminUsername, adminPassword, apim.AdvancedThrottlePolicyType)
 		})
 	}
 }

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -458,7 +458,7 @@ func TestExportImportThrottlePolicyWithoutTypeFlag(t *testing.T) {
 }
 
 // Delete Throttling Policy by comparing the status code.
-func TestThrottlingPoliciesDelete(t *testing.T) {
+func TestThrottlingPolicyDelete(t *testing.T) {
 
 	for _, user := range testCaseUsers {
 		t.Run(user.Description, func(t *testing.T) {
@@ -474,19 +474,14 @@ func TestThrottlingPoliciesDelete(t *testing.T) {
 				DestAPIM: prod,
 				Update:   false,
 			}
-			adminUsername := superAdminUser
-			adminPassword := superAdminPassword
-			if isTenantUser(args.CtlUser.Username, TENANT1) {
-				adminUsername = adminUsername + "@" + TENANT1
-			}
 
-			testutils.ValidateThrottlingPolicyDelete(t, args, adminUsername, adminPassword, apim.AdvancedThrottlePolicyType)
+			testutils.ValidateThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
 		})
 	}
 }
 
 // Delete Throttling Policy which is not existing.
-func TestThrottlingPoliciesDeleteNotExists(t *testing.T) {
+func TestThrottlingPolicyDeleteNotExists(t *testing.T) {
 
 	for _, user := range testCaseUsers {
 		t.Run(user.Description, func(t *testing.T) {
@@ -502,13 +497,8 @@ func TestThrottlingPoliciesDeleteNotExists(t *testing.T) {
 				DestAPIM: prod,
 				Update:   false,
 			}
-			adminUsername := superAdminUser
-			adminPassword := superAdminPassword
-			if isTenantUser(args.CtlUser.Username, TENANT1) {
-				adminUsername = adminUsername + "@" + TENANT1
-			}
 
-			testutils.ValidateThrottlingPolicyDeleteNotExists(t, args, adminUsername, adminPassword, apim.AdvancedThrottlePolicyType)
+			testutils.ValidateThrottlingPolicyDeleteNotExists(t, args, apim.AdvancedThrottlePolicyType)
 		})
 	}
 }

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -19,9 +19,10 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/apim"
 	"github.com/wso2/product-apim-tooling/import-export-cli/integration/testutils"
-	"testing"
 )
 
 const (
@@ -452,6 +453,52 @@ func TestExportImportThrottlePolicyWithoutTypeFlag(t *testing.T) {
 				adminUsername = adminUsername + "@" + TENANT1
 			}
 			testutils.ValidateThrottlePolicyExportImport(t, args, adminUsername, adminPassword, apim.AdvancedThrottlePolicyType)
+		})
+	}
+}
+
+// Delete Throttling Policy by comparing the status code.
+func TestThrottlingPoliciesDelete(t *testing.T) {
+
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			args := &testutils.PolicyImportExportTestArgs{
+				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Policy:   throttlePolicy,
+				SrcAPIM:  dev,
+				DestAPIM: prod,
+				Update:   false,
+			}
+
+			testutils.ValidateThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
+		})
+	}
+}
+
+// Delete Non Existing Throttling Policy by comparing the status code.
+func TestNonExistingThrottlingPolicyDelete(t *testing.T) {
+
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType)
+			args := &testutils.PolicyImportExportTestArgs{
+				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Policy:   throttlePolicy,
+				SrcAPIM:  dev,
+				DestAPIM: prod,
+				Update:   false,
+			}
+
+			testutils.ValidateThrottlingPolicyDelete(t, args, apim.AdvancedThrottlePolicyType)
 		})
 	}
 }

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -466,7 +466,7 @@ func TestThrottlingPoliciesDelete(t *testing.T) {
 			dev := GetDevClient()
 			prod := GetProdClient()
 
-			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, false)
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
 			args := &testutils.PolicyImportExportTestArgs{
 				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
 				Policy:   throttlePolicy,

--- a/import-export-cli/integration/throttlePolicy_test.go
+++ b/import-export-cli/integration/throttlePolicy_test.go
@@ -484,3 +484,31 @@ func TestThrottlingPoliciesDelete(t *testing.T) {
 		})
 	}
 }
+
+// Delete Throttling Policy which is not existing.
+func TestThrottlingPoliciesDeleteNotExists(t *testing.T) {
+
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			throttlePolicy := testutils.AddNewThrottlePolicy(t, dev, user.Admin.Username, user.Admin.Password, apim.AdvancedThrottlePolicyType, true)
+			args := &testutils.PolicyImportExportTestArgs{
+				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Policy:   throttlePolicy,
+				SrcAPIM:  dev,
+				DestAPIM: prod,
+				Update:   false,
+			}
+			adminUsername := superAdminUser
+			adminPassword := superAdminPassword
+			if isTenantUser(args.CtlUser.Username, TENANT1) {
+				adminUsername = adminUsername + "@" + TENANT1
+			}
+
+			testutils.ValidateThrottlingPolicyDeleteNotExists(t, args, adminUsername, adminPassword, apim.AdvancedThrottlePolicyType)
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
Fixes: [wso2/api-manager#439](https://github.com/wso2/api-manager/issues/439)

## Approach
Implemented the following tests.
TestThrottlingPoliciesDelete to test the preferred throttling policy is successfully deleted.
TestNonExistingThrottlingPolicyDelete to check whether the deletion gets failed due to policy not found.

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/927