### PR TITLE
Update README for APICTL commands

### DIFF
--- a/import-export-cli/docs/apictl_delete.md
+++ b/import-export-cli/docs/apictl_delete.md
@@ -39,4 +39,5 @@ apictl delete app -n TestApplication -o admin -e dev
 * [apictl delete api](apictl_delete_api.md)	 - Delete API
 * [apictl delete api-product](apictl_delete_api-product.md)	 - Delete API Product
 * [apictl delete app](apictl_delete_app.md)	 - Delete App
+* [apictl delete policy](apictl_delete_policy.md)	 - Delete Policy
 

--- a/import-export-cli/docs/apictl_delete_policy.md
+++ b/import-export-cli/docs/apictl_delete_policy.md
@@ -36,4 +36,5 @@ NOTE: Both the flags (--name (-n), and --environment (-e)) are mandatory.
 
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application/Policy in an environment
 * [apictl delete policy api](apictl_delete_policy_api.md) - Delete an API Policy in an environment
+* [apictl delete policy rate-limiting](apictl_delete_policy_rate-limiting.md) - Delete a Throttling Policy in an environment
 

--- a/import-export-cli/docs/apictl_delete_policy.md
+++ b/import-export-cli/docs/apictl_delete_policy.md
@@ -7,7 +7,7 @@ Delete Policy
 Delete a Policy from an environment
 
 ```
-apictl delete policy [policy type] (--environment <environment-from-which-the-application-should-be-deleted>) [flags]
+apictl delete policy [policy type] (--environment <environment-from-which-the-policy-should-be-deleted>) [flags]
 ```
 
 ### Examples

--- a/import-export-cli/docs/apictl_delete_policy.md
+++ b/import-export-cli/docs/apictl_delete_policy.md
@@ -1,0 +1,39 @@
+## apictl delete policy
+
+Delete Policy
+
+### Synopsis
+
+Delete a Policy from an environment
+
+```
+apictl delete policy [policy type] (--environment <environment-from-which-the-application-should-be-deleted>) [flags]
+```
+
+### Examples
+
+```
+apictl delete policy api -n addHeader -e dev
+NOTE: Both the flags (--name (-n), and --environment (-e)) are mandatory.
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from which the Policy should be deleted
+  -h, --help                 help for policy
+  -n, --name string          Name of the Policy to be deleted
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application/Policy in an environment
+* [apictl delete policy api](apictl_delete_policy_api.md) - Delete an API Policy in an environment
+

--- a/import-export-cli/docs/apictl_delete_policy_api.md
+++ b/import-export-cli/docs/apictl_delete_policy_api.md
@@ -1,0 +1,38 @@
+## apictl delete policy api
+
+Delete API Policy
+
+### Synopsis
+
+Export API Policy from an environment
+
+```
+apictl delete policy api (--name <name-of-the-api-policy> --environment <environment-from-which-the-api-policies-should-be-deleted>) [flags]
+```
+
+### Examples
+
+```
+apictl delete policy api -n addHeader -e dev
+NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to which the API Policy should be deleted
+  -h, --help                 help for api policy
+  -n, --name string          Name of the API Policy to be deleted
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl delete policy](apictl_delete_policy.md) - Delete a Policy
+

--- a/import-export-cli/docs/apictl_delete_policy_api.md
+++ b/import-export-cli/docs/apictl_delete_policy_api.md
@@ -7,7 +7,7 @@ Delete API Policy
 Export API Policy from an environment
 
 ```
-apictl delete policy api (--name <name-of-the-api-policy> --environment <environment-from-which-the-api-policies-should-be-deleted>) [flags]
+apictl delete policy api (--name <name-of-the-api-policy> --environment <environment-from-which-the-api-policy-should-be-deleted>) [flags]
 ```
 
 ### Examples
@@ -20,8 +20,8 @@ NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.
 ### Options
 
 ```
-  -e, --environment string   Environment to which the API Policy should be deleted
-  -h, --help                 help for api policy
+  -e, --environment string   Environment from which the API Policy should be deleted
+  -h, --help                 help for API Policy
   -n, --name string          Name of the API Policy to be deleted
 ```
 

--- a/import-export-cli/docs/apictl_delete_policy_rate-limiting.md
+++ b/import-export-cli/docs/apictl_delete_policy_rate-limiting.md
@@ -1,0 +1,39 @@
+## apictl delete policy rate-limiting
+
+Delete Throttling Policy
+
+### Synopsis
+
+Export Throttling Policy from an environment
+
+```
+apictl delete policy rate-limiting (--name <name-of-the-rate-limiting-policy> --type <type-of-the-rate-limiting-policy> --environment <environment-from-which-the-rate-limiting-policy-should-be-deleted>) [flags]
+```
+
+### Examples
+
+```
+apictl delete policy rate-limiting -n addHeader --type advanced -e dev
+NOTE: All the 2 flags (--name (-n), --type and --environment (-e)) are mandatory.
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from which the Throttling Policy should be deleted
+  -h, --help                 help for Throttling Policy
+  -n, --name string          Name of the Throttling Policy to be deleted
+  --type string              Type of the Throttling Policy to be deleted
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl delete policy](apictl_delete_policy.md) - Delete a Policy
+

--- a/import-export-cli/docs/apictl_export_policy.md
+++ b/import-export-cli/docs/apictl_export_policy.md
@@ -4,7 +4,7 @@ Export/Import a Policy
 
 ### Synopsis
 
-Export/Import a Policy in an environment or Import a Policy to an environment
+Export a Policy in an environment or Import a Policy to an environment
 
 ```
 apictl export policy [flags]
@@ -14,6 +14,7 @@ apictl export policy [flags]
 
 ```
 apictl export policy rate-limiting -n Silver -e prod --type subscription
+apictl export policy api -n addHeader -e prod
 ```
 
 ### Options
@@ -33,4 +34,5 @@ apictl export policy rate-limiting -n Silver -e prod --type subscription
 
 * [apictl export](apictl_export.md)	 - Export an API/API Product/Application/Policy in an environment
 * [apictl export policy rate-limiting](apictl_export_policy_rate-limiting.md)	 - Export Throttling Policies
+* [apictl export policy api](apictl_export_policy_api.md)	 - Export an API Policy
 

--- a/import-export-cli/docs/apictl_export_policy_api.md
+++ b/import-export-cli/docs/apictl_export_policy_api.md
@@ -1,0 +1,38 @@
+## apictl export policy api
+
+Export an API Policy
+
+### Synopsis
+
+Export an API Policy from an environment
+
+```
+apictl export policy api (--name <name-of-the-api-policy> --environment <environment-from-which-the-api-policy-should-be-exported>) [flags]
+```
+
+### Examples
+
+```
+apictl export policy api -n addHeader -e dev
+NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.
+```
+
+### Options
+
+```
+  -e, --environment string   Environment to which the API Policies should be exported
+  -h, --help                 help for api policy
+  -n, --name string          Name of the API Policy to be exported
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl export policy](apictl_export_policy.md) - Export/Import a Policy
+

--- a/import-export-cli/docs/apictl_export_policy_api.md
+++ b/import-export-cli/docs/apictl_export_policy_api.md
@@ -23,6 +23,7 @@ NOTE: All the 2 flags (--name (-n) and --environment (-e)) are mandatory.
   -e, --environment string   Environment to which the API Policies should be exported
   -h, --help                 help for api policy
   -n, --name string          Name of the API Policy to be exported
+  --format                   API Policy definition file format to be exported (JSON, YAML)
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_get_policies.md
+++ b/import-export-cli/docs/apictl_get_policies.md
@@ -14,6 +14,7 @@ apictl get policies [flags]
 
 ```
 apictl get policies rate-limiting -e production -q type:sub
+apictl get policies api -e production
 ```
 
 ### Options
@@ -32,5 +33,5 @@ apictl get policies rate-limiting -e production -q type:sub
 ### SEE ALSO
 
 * [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
-* [apictl get policies rate-limiting](apictl_get_policies_rate-limiting.md)	 - Display a list of APIs in an environment
-
+* [apictl get policies rate-limiting](apictl_get_policies_rate-limiting.md)	 - Display a list of Throttling Policies in an environment
+* [apictl get policies api](apictl_get_policies_api.md)	 - Display a list of API Policies in an environment

--- a/import-export-cli/docs/apictl_get_policies_api.md
+++ b/import-export-cli/docs/apictl_get_policies_api.md
@@ -1,0 +1,44 @@
+## apictl get policies api
+
+Display a list of API Policies in an environment
+
+### Synopsis
+
+Display a list of API Policies in the environment specified by the flag --environment, -e
+
+```
+apictl get policies api [flags]
+```
+
+### Examples
+
+```
+apictl get policies api -e production
+apictl get policies api -e prod --all
+apictl get policies api -e prod -l 10
+apictl get policies api -e prod
+apictl get policies api -e prod --format jsonArray
+NOTE: The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment of the API Policies to be fetched
+      --format string        Pretty-print api policies using Go Templates. Use "jsonArray" to list all fields
+  -h, --help                 help for rate-limiting
+  -l, --limit string         Limit the number of policies fetched
+  --all                      Fetch all available API Policies
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get policies](apictl_get_policies.md)	 - Get Policy list
+

--- a/import-export-cli/docs/apictl_get_policies_api.md
+++ b/import-export-cli/docs/apictl_get_policies_api.md
@@ -16,17 +16,17 @@ apictl get policies api [flags]
 apictl get policies api -e production
 apictl get policies api -e prod --all
 apictl get policies api -e prod -l 10
-apictl get policies api -e prod
 apictl get policies api -e prod --format jsonArray
 NOTE: The flag (--environment (-e)) is mandatory
+NOTE: Flags (--all) and (--limit (-l)) cannot be used at the same time
 ```
 
 ### Options
 
 ```
   -e, --environment string   Environment of the API Policies to be fetched
-      --format string        Pretty-print api policies using Go Templates. Use "jsonArray" to list all fields
-  -h, --help                 help for rate-limiting
+      --format string        Pretty-print API Policies using Go Templates. Use "jsonArray" to list all fields
+  -h, --help                 help for API Policies
   -l, --limit string         Limit the number of policies fetched
   --all                      Fetch all available API Policies
 ```

--- a/import-export-cli/docs/apictl_get_policies_rate-limiting.md
+++ b/import-export-cli/docs/apictl_get_policies_rate-limiting.md
@@ -1,6 +1,6 @@
 ## apictl get policies rate-limiting
 
-Display a list of APIs in an environment
+Display a list of Throttling Policies in an environment
 
 ### Synopsis
 
@@ -13,7 +13,7 @@ apictl get policies rate-limiting [flags]
 ### Examples
 
 ```
-apictl get apictl get policies rate-limiting -e production -q type:sub rate-limiting -e dev
+apictl get policies rate-limiting -e production -q type:sub
 apictl get policies rate-limiting -e prod -q type:api
 apictl get policies rate-limiting -e prod -q type:sub
 apictl get policies rate-limiting -e staging -q type:global

--- a/import-export-cli/docs/apictl_import_policy.md
+++ b/import-export-cli/docs/apictl_import_policy.md
@@ -14,6 +14,7 @@ apictl import policy [flags]
 
 ```
 apictl import policy rate-limiting -f ~/CustomPolicy -e production --u
+apictl import policy api -f ~/AddHeader -e production
 ```
 
 ### Options
@@ -32,5 +33,5 @@ apictl import policy rate-limiting -f ~/CustomPolicy -e production --u
 ### SEE ALSO
 
 * [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
-* [apictl import policy rate-limiting](apictl_import_policy_rate-limiting.md)	 - Import Throttling Policy
-
+* [apictl import policy rate-limiting](apictl_import_policy_rate-limiting.md)	 - Import a Throttling Policy
+* [apictl import policy api](apictl_import_policy_api.md)	 - Import an API Policy

--- a/import-export-cli/docs/apictl_import_policy_api.md
+++ b/import-export-cli/docs/apictl_import_policy_api.md
@@ -1,0 +1,39 @@
+## apictl import policy api
+
+Import an API Policy
+
+### Synopsis
+
+Import an API Policy to an environment
+
+```
+apictl import policy api --file <path-to-api-policy> --environment <environment> [flags]
+```
+
+### Examples
+
+```
+apictl import policy api -f add_header_v1.zip -e dev
+apictl import policy api -f AddHeader -e production
+NOTE: Both the flags (--file (-f) and --environment (-e)) are mandatory
+```
+
+### Options
+
+```
+  -e, --environment string   Environment from the which the API Policy should be imported
+  -f, --file string          File path of the API Policy to be imported
+  -h, --help                 help for api policy
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl import policy](apictl_import_policy.md)	 - Import a Policy
+

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -536,6 +536,8 @@
        apictl delete api -n TestAPI -v 1.0.0 -e production
 </code></pre>
     </li>
+</ul>
+<ul>
     <li>
         <h4 id="delete-policy-api">delete policy api</h4>
         <pre><code class="lang-bash">   Flags:
@@ -547,6 +549,21 @@
 </code></pre>
     </li>
 </ul>
+
+<ul>
+    <li>
+        <h4 id="delete-policy-rate-limiting">delete policy rate-limiting</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --name, -n
+           --type
+           --environment, -e
+   Examples:
+       apictl delete policy rate-limiting -n AppPolicy --type app -e staging
+</code></pre>
+    </li>
+</ul>
+
 <ul>
     <li>
         <h4 id="delete-api-product">delete api-product</h4>

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -238,6 +238,35 @@
 </code></pre>
 <ul>
     <li>
+        <h4 id="export-policy-api">export policy api</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+            --name, -n
+            --environment, -e
+       Optional:
+            --format
+   Examples:
+            apictl export policy api -n AddHeader -e dev
+            apictl export policy api -n AddHeader -e prod --format JSON
+</code></pre>
+    </li>
+</ul>
+<ul>
+    <li>
+        <h4 id="import-policy-api">import policy api</h4>
+    </li>
+</ul>
+<pre><code class="lang-bash">        Flags:
+            Required
+                  --file, -f
+                  --environment, -e
+        Examples:
+            apictl import policy api -f dev/add_header_v1.zip -e dev
+            apictl import policy api -f ~/Desktop/add_header_v1.zip -e prod
+            apictl import policy api -f dev/AddHeader -e dev
+</code></pre>
+<ul>
+    <li>
         <h4 id="get-apis">get apis</h4>
         <pre><code class="lang-bash">      Flags:
           Required:
@@ -300,6 +329,22 @@
             apictl get policies rate-limiting -e dev
             apictl get policies rate-limiting -e dev -q type:app
             apictl get policies rate-limiting  -e dev -q type:sub
+
+</code></pre>
+    </li>
+
+    <li>
+        <h4 id="get-policies-api">get policies api</h4>
+        <pre><code class="lang-bash">      Flags:
+          Required
+                  --environment, -e
+            Optional
+                  --all
+                  --limit, -l
+        Examples:
+            apictl get policies api -e dev
+            apictl get policies api -e dev --all
+            apictl get policies api -e dev --limit 10
 
 </code></pre>
     </li>
@@ -489,6 +534,16 @@
    Examples:
        apictl delete api -n TestAPI -v 1.0.0 -r admin -e staging
        apictl delete api -n TestAPI -v 1.0.0 -e production
+</code></pre>
+    </li>
+    <li>
+        <h4 id="delete-policy-api">delete policy api</h4>
+        <pre><code class="lang-bash">   Flags:
+       Required:
+           --name, -n
+           --environment, -e
+   Examples:
+       apictl delete policy api -n AddHeader -e staging
 </code></pre>
     </li>
 </ul>

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -549,7 +549,6 @@
 </code></pre>
     </li>
 </ul>
-
 <ul>
     <li>
         <h4 id="delete-policy-rate-limiting">delete policy rate-limiting</h4>
@@ -563,7 +562,6 @@
 </code></pre>
     </li>
 </ul>
-
 <ul>
     <li>
         <h4 id="delete-api-product">delete api-product</h4>


### PR DESCRIPTION
## Purpose
Fixes: [wso2/api-manager#223](https://github.com/wso2/api-manager/issues/490)

## Approach
Added README docs for the following commands.

- Delete API Policy
- Get API Policies
- Import API Policy
- Export API Policy

## Related PRs
- https://github.com/wso2/product-apim-tooling/pull/924