### PR TITLE
Add the correlation log configuration support

### DIFF
--- a/import-export-cli/cmd/get.go
+++ b/import-export-cli/cmd/get.go
@@ -27,7 +27,7 @@ const queryParamSeparator = " "
 
 // Get command related usage Info
 const GetCmdLiteral = "get"
-const getCmdShortDesc = "Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments"
+const getCmdShortDesc = "Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments"
 
 const getCmdLongDesc = `Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
 Display a list containing all the API Products available in the environment specified by flag (--environment, -e)/
@@ -35,7 +35,8 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
 Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
-Get the log level of each API in the environment specified by flag (--environment, -e)
+Get the log level of each API in the environment specified by flag (--environment, -e)/
+Get the correlation log configurations in the environment specified by flag (--environment, -e)
 OR
 List all the environments`
 
@@ -47,7 +48,8 @@ const getCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetEnvsCm
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n PizzaProduct -v 1.0.0 -e dev
 ` + utils.ProjectName + " " + GetCmdLiteral + " " + GetKeysCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev
 ` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` -e dev --tenant-domain carbon.super
-` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --tenant-domain carbon.super`
+` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --tenant-domain carbon.super
+` + utils.ProjectName + " " + GetCmdLiteral + " " + GetCorrelationLoggingCmdLiteral + ` -e dev` 
 
 // ListCmd represents the list command
 var GetCmd = &cobra.Command{

--- a/import-export-cli/cmd/getCorrelationLogging.go
+++ b/import-export-cli/cmd/getCorrelationLogging.go
@@ -1,0 +1,71 @@
+/*
+*  Copyright (c) WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 LLC licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getCorrelationLoggingEnvironment string
+var getCorrelationLoggingCmdFormat string
+
+const GetCorrelationLoggingCmdLiteral = "correlation-logging"
+const getCorrelationLoggingCmdShortDesc = "Display a list of correlation logging components in an environment"
+const getCorrelationLoggingCmdLongDesc = `Display a list of correlation logging components available in the environment specified`
+
+var getCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetCorrelationLoggingCmdLiteral + ` -e dev `
+
+var getCorrelationLoggingCmd = &cobra.Command{
+	Use:     GetCorrelationLoggingCmdLiteral,
+	Short:   getCorrelationLoggingCmdShortDesc,
+	Long:    getCorrelationLoggingCmdLongDesc,
+	Example: getCorrelationLoggingCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + GetCmdLiteral + " " + GetCorrelationLoggingCmdLiteral + " called")
+		cred, err := GetCredentials(getCorrelationLoggingEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeGetCorrelationLoggingCmd(cred)
+	},
+}
+
+func executeGetCorrelationLoggingCmd(credential credentials.Credential) {
+	components, err := impl.GetCorrelationLogComponentListFromEnv(credential, getCorrelationLoggingEnvironment)
+	
+	if err == nil {
+		impl.PrintCorrelationLoggers(components, getCorrelationLoggingCmdFormat)
+	} else {
+		utils.Logln(utils.LogPrefixError + "Getting list of correlation log configurations", err)
+		utils.HandleErrorAndExit("Error while getting list of correlation log configurations", err)
+	}
+}
+
+func init() {
+	GetCmd.AddCommand(getCorrelationLoggingCmd)
+
+	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingEnvironment, "environment", "e",
+		"", "Environment which the correlation logging components should be displayed")
+	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingCmdFormat, "format", "", "", "Pretty-print Correlation loggers "+
+		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
+	_ = getCorrelationLoggingCmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -43,7 +43,7 @@ const flagVCSDeploymentRepoPathName = "vcs-deployment-repo-path"
 
 // Set command related Info
 const SetCmdLiteral = "set"
-const setCmdShortDesc = "Set configuration parameters or per API log levels"
+const setCmdShortDesc = "Set configuration parameters, per API log levels or correlation component configurations"
 
 const setCmdLongDesc = `Set configuration parameters. You can use one of the following flags
 * --http-request-timeout <time-in-milli-seconds>
@@ -62,7 +62,8 @@ const setCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` --http-reques
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-config-path /home/user/custom/vcs-config.yaml
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-deployment-repo-path /home/user/custom/deployment
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-source-repo-path /home/user/custom/source
-` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super`
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name http --enable true -e dev`
 
 // SetCmd represents the 'set' command
 var SetCmd = &cobra.Command{

--- a/import-export-cli/cmd/setCorrelationLogging.go
+++ b/import-export-cli/cmd/setCorrelationLogging.go
@@ -1,0 +1,93 @@
+/*
+*  Copyright (c) WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 LLC licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var setCorrelationLoggingEnvironment string
+var setCorrelationLoggingComponentName string
+var setCorrelationLoggingDeniedThreads string
+var setCorrelationLoggingEnabled string
+
+const SetCorrelationLoggingCmdLiteral = "correlation-logging"
+const setCorrelationLoggingCmdShortDesc = "Set the correlation configs for a correlation logging component in an environment"
+const setCorrelationLoggingCmdLongDesc = `Set the correlation configs for a correlation logging component the environment specified`
+
+var setCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name http --enable true -e dev
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer  -e dev`
+
+var setCorrelationLoggingCmd = &cobra.Command{
+	Use:     SetCorrelationLoggingCmdLiteral,
+	Short:   setCorrelationLoggingCmdShortDesc,
+	Long:    setCorrelationLoggingCmdLongDesc,
+	Example: setCorrelationLoggingCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + SetCmdLiteral + " " + SetCorrelationLoggingCmdLiteral + " called")
+		cred, err := GetCredentials(setCorrelationLoggingEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeSetCorrelationLoggingCmd(cred)
+	},
+}
+
+func executeSetCorrelationLoggingCmd(credential credentials.Credential) {
+	resp, err := impl.SetCorrelationLoggingComponent(credential, setCorrelationLoggingEnvironment, setCorrelationLoggingComponentName, setCorrelationLoggingEnabled, setCorrelationLoggingDeniedThreads)
+	if err != nil {
+		utils.Logln(utils.LogPrefixError+"Setting the correlation log component configs", err)
+		utils.HandleErrorAndExit("Error while setting the correlation log component configs", err)
+	}
+	// Print info on response
+	utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp)
+	if resp.StatusCode() == http.StatusOK { 
+		// 200 OK
+		if strings.ToLower(setCorrelationLoggingEnabled) == "true" {
+			fmt.Println("Correlation component " + setCorrelationLoggingComponentName + " is successfully enabled.")
+		} else {
+			fmt.Println("Correlation component " + setCorrelationLoggingComponentName + " is successfully disabled.")
+		}
+	} else {
+		fmt.Println("Setting the correlation components : ", resp.Status(), "\n", string(resp.Body()))
+	}
+}
+
+func init() {
+	SetCmd.AddCommand(setCorrelationLoggingCmd)
+
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingComponentName, "component-name", "i",
+		"", "Component Name")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingEnabled, "enable", "",
+		"", "Enable - true or false")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingDeniedThreads, "denied-threads", "",
+		"", "Denied Threads")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingEnvironment, "environment", "e",
+		"", "Environment where the correlation component configuration should be set")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("environment")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("component-name")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("enabled")
+}

--- a/import-export-cli/impl/logger.go
+++ b/import-export-cli/impl/logger.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"os"
 	"text/template"
 
@@ -40,6 +41,7 @@ const (
 	loggingApiLogLevelHeader = "LOG_LEVEL"
 
 	defaultLoggingApiTableFormat = "table {{.Id}}\t{{.Context}}\t{{.LogLevel}}"
+	defaultLoggingCorrelationTableFormat = "table {{.Name}}\t{{.Enabled}}\t{{.Properties}}"
 )
 
 // LoggingApi holds information about an API for outputting
@@ -47,6 +49,33 @@ type loggingApi struct {
 	id       string
 	context  string
 	logLevel string
+}
+
+
+type loggingCorrelationComponent struct {
+	name 			string
+	enabled 		string
+	properties 		string
+}
+
+func newLoggingCorrelationComponentFromComponent(component utils.CorrelationComponent) *loggingCorrelationComponent {
+	if len(component.Properties) > 0 {
+		return &loggingCorrelationComponent{component.Name, component.Enabled, component.Properties[len(component.Properties)-1].Name + 
+			" : "  + strings.Join(component.Properties[len(component.Properties)-1].Value, ", ")}
+	}
+	return &loggingCorrelationComponent{component.Name, component.Enabled, "-"}
+}
+
+func (component loggingCorrelationComponent) Name() string {
+	return component.name
+}
+
+func (component loggingCorrelationComponent) Enabled() string {
+	return component.enabled
+}
+
+func (component loggingCorrelationComponent) Properties() string {
+	return component.properties
 }
 
 // Creates a new api from utils.APILogger
@@ -203,4 +232,129 @@ func SetAPILoggingLevel(credential credentials.Credential, environment, apiId, t
 	} else {
 		return nil, errors.New(string(resp.Body()))
 	}
+}
+
+// GET Correlation Components List 
+func GetCorrelationLogComponentListFromEnv(credential credentials.Credential, environment string) (components []utils.CorrelationComponent, err error) {
+	// Base64 encoding the credentials
+	b64encodedCredentials := credentials.GetBasicAuth(credential)
+	// Prepping the headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+	
+	correlationDevOpsEP := utils.GetCorrelationLoggingEndPointOfEnv(environment, utils.MainConfigFilePath)
+	utils.Logln(utils.LogPrefixInfo+"URL : " + correlationDevOpsEP)
+	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo + "Response : " + resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		correlationComponentsResponse := &utils.CorrelationComponentList{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+		}
+		return correlationComponentsResponse.Components, nil 
+	}
+	return nil, errors.New(string(resp.Body()))
+}
+
+
+func PrintCorrelationLoggers(components []utils.CorrelationComponent, format string) {
+	if format == "" {
+		format = defaultLoggingCorrelationTableFormat
+	}
+
+	formatContext := formatter.NewContext(os.Stdout, format)
+
+	renderer := func (w io.Writer, t *template.Template) error {
+		for _, component := range components {
+			if err := t.Execute(w, newLoggingCorrelationComponentFromComponent(component)); err != nil {
+				return err
+			}
+			_, _ = w.Write([]byte{'\n'})
+		}
+		return nil
+	}
+	
+	correlationTableHeaders := map[string]string{
+		"Name": "COMPONENT_NAME", 
+		"Enabled": "ENABLED",
+		"Properties": "PROPERTIES",
+	}
+
+	if err := formatContext.Write(renderer, correlationTableHeaders); err != nil {
+		fmt.Println("Error executing template", err.Error())
+	}
+}
+func SetCorrelationLoggingComponent(credential credentials.Credential, environment, componentName, enabled, deniedThreads string) (*resty.Response, error) {
+	// Base64 encoding the credentials
+	b64encodedCredentials := credentials.GetBasicAuth(credential)
+
+	correlationDevOpsEP := utils.GetCorrelationLoggingEndPointOfEnv(environment, utils.MainConfigFilePath)
+
+	// Prepping the headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+	headers[utils.HeaderAccept] = utils.HeaderValueApplicationJSON
+
+	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo + "GET Response : " + resp.Status())
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, errors.New(string(resp.Body()))
+	}
+
+	correlationComponentsResponse := &utils.CorrelationComponentList{}
+	unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
+
+	if unmarshalError != nil {
+		utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+	}
+
+	responseComponents := correlationComponentsResponse.Components
+	requestComponents  := make([]utils.CorrelationComponent,0)
+
+	for  _ , cc := range  responseComponents{
+		if cc.Name == componentName {
+			cc.Enabled = enabled
+			if(len(cc.Properties)>0){
+				if(cc.Properties[len(cc.Properties)-1].Name == "deniedThreads"){
+					cc.Properties[len(cc.Properties)-1].Value = strings.Split(deniedThreads, ",")
+				}
+			}
+		}
+		requestComponents = append(requestComponents, cc)
+	}
+	
+	b,err := json.Marshal(requestComponents)
+	if err != nil {
+		utils.Logln("Error when creating a json ")		
+		return nil, nil 
+	}
+	
+	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
+	body := string(b)
+	body = "{\"components\":" + body + "}"
+	putResp, err := utils.InvokePutRequest(nil, correlationDevOpsEP, headers, body)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"PUT Response:", putResp.Status())
+	if putResp.StatusCode() == http.StatusOK {
+		return putResp, nil
+	}
+	return nil, errors.New(string(putResp.Body()))
 }

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -107,6 +107,7 @@ const defaultTokenEndPoint = "oauth2/token"
 const defaultRevokeEndpointSuffix = "oauth2/revoke"
 const defaultAPILoggingBaseEndpoint = "api/am/devops/v0/tenant-logs"
 const defaultAPILoggingApisEndpoint = "apis"
+const defaultCorrelationLoggingEndpoint = "api/am/devops/v0/config/correlation"
 
 const DefaultEnvironmentName = "default"
 const DefaultTenantDomain = "carbon.super"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -321,6 +321,18 @@ func GetAPILoggingSetEndpointOfEnv(env, apiId, tenantDomain, filePath string) st
 	}
 }
 
+func GetCorrelationLoggingEndPointOfEnv(env, filePath string) string {
+	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)	
+	if !(envEndpoints.PublisherEndpoint == "" || envEndpoints == nil) {
+		envEndpoints.PublisherEndpoint = AppendSlashToString(envEndpoints.PublisherEndpoint)
+		return envEndpoints.PublisherEndpoint + defaultCorrelationLoggingEndpoint
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint + defaultCorrelationLoggingEndpoint
+	}	
+}
+
 // Get username of an environment given the environment
 func GetUsernameOfEnv(env, filePath string) string {
 	envKeys, _ := GetKeysOfEnvironment(env, filePath)

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -97,6 +97,21 @@ type Application struct {
 	GroupID string `json:"groupId"`
 }
 
+type CorrelationComponent struct {
+	Name		string `json:"name"`
+	Enabled		string `json:"enabled"`
+	Properties	[]CorrelationProperties `json:"properties"`
+}
+
+type CorrelationProperties struct {
+	Name		string `json:"name"`
+	Value		[]string `json:"value"`
+}
+
+type CorrelationComponentList struct {
+	Components	[]CorrelationComponent `json:"components"`
+}
+
 type APILogger struct {
 	ID       string `json:"apiId"`
 	Context  string `json:"context"`


### PR DESCRIPTION
Add Correlation Log configuration of APIM to the CLI

getCorrelationLoggging to retrieve the correlation log configurations
of the different components.
setCorrelationLogging to update the correlation configurations of a
specific correlation log component.

> Fix: wso2/api-manager#275
> Fix: wso2/api-manager#566