### PR TITLE
[3.2.x] Adding the integration tests for importing locked APIs and when importing an API with an invalid OAS

### DIFF
--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -470,8 +470,8 @@ func TestExportImportApiCrossTenantUser(t *testing.T) {
 // Export an API from one environment as super tenant user with Internal/devops role
 // and import to another environment as cross tenant user with Internal/devops role (without preserve-provider=false)
 func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
-	devopsUsername := devops.UserName
-	devopsPassword := devops.Password
+	superTenantDevopsUsername := devops.UserName
+	superTenantDevopsPassword := devops.Password
 
 	superTenantApiCreator := creator.UserName
 	superTenantApiCreatorPassword := creator.Password
@@ -486,7 +486,7 @@ func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
 
 	args := &testutils.ApiImportExportTestArgs{
 		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
-		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		CtlUser:     testutils.Credentials{Username: superTenantDevopsUsername, Password: superTenantDevopsPassword},
 		Api:         api,
 		SrcAPIM:     dev,
 		DestAPIM:    prod,
@@ -500,6 +500,182 @@ func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
 
 	// Import the API to env2 as tenant admin across domains
 	testutils.ValidateAPIImportFailure(t, args)
+}
+
+// Export an API with the life cycle status as Blocked and import to another environment as a super tenant user with Internal/devops role
+func TestExportImportApiBlockedSuperTenantDevopsUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	superTenantApiPublisher := publisher.UserName
+	superTenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+	testutils.PublishAPI(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID)
+	api = testutils.ChangeAPILifeCycle(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID, "Block")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API with the life cycle status as Blocked and import to another environment as a tenant user with Internal/devops role
+func TestExportImportApiBlockedTenantDevopsUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	tenantApiPublisher := publisher.UserName + "@" + TENANT1
+	tenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+	testutils.PublishAPI(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID)
+	api = testutils.ChangeAPILifeCycle(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID, "Block")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API with the life cycle status as Deprecated and import to another environment as a super tenant user with Internal/devops role
+func TestExportImportApiDeprecatedSuperTenantDevopsUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	superTenantApiPublisher := publisher.UserName
+	superTenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+	testutils.PublishAPI(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID)
+	api = testutils.ChangeAPILifeCycle(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID, "Deprecate")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API with the life cycle status as Deprecated and import to another environment as a tenant user with Internal/devops role
+func TestExportImportApiDeprecatedTenantDevopsUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	tenantApiPublisher := publisher.UserName + "@" + TENANT1
+	tenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+	testutils.PublishAPI(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID)
+	api = testutils.ChangeAPILifeCycle(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID, "Deprecate")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API with the life cycle status as Retired and import to another environment as a super tenant user with Internal/devops role
+func TestExportImportApiRetiredSuperTenantDevopsUser(t *testing.T) {
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	superTenantApiCreator := creator.UserName
+	superTenantApiCreatorPassword := creator.Password
+
+	superTenantApiPublisher := publisher.UserName
+	superTenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, superTenantApiCreator, superTenantApiCreatorPassword)
+	testutils.PublishAPI(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID)
+	testutils.ChangeAPILifeCycle(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID, "Deprecate")
+	api = testutils.ChangeAPILifeCycle(dev, superTenantApiPublisher, superTenantApiPublisherPassword, api.ID, "Retire")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: superTenantApiCreator, Password: superTenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
+}
+
+// Export an API with the life cycle status as Retired and import to another environment as a tenant user with Internal/devops role
+func TestExportImportApiRetiredTenantDevopsUser(t *testing.T) {
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	tenantApiCreator := creator.UserName + "@" + TENANT1
+	tenantApiCreatorPassword := creator.Password
+
+	tenantApiPublisher := publisher.UserName + "@" + TENANT1
+	tenantApiPublisherPassword := publisher.Password
+
+	dev := apimClients[0]
+	prod := apimClients[1]
+
+	api := testutils.AddAPI(t, dev, tenantApiCreator, tenantApiCreatorPassword)
+	testutils.PublishAPI(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID)
+	testutils.ChangeAPILifeCycle(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID, "Deprecate")
+	api = testutils.ChangeAPILifeCycle(dev, tenantApiPublisher, tenantApiPublisherPassword, api.ID, "Retire")
+
+	args := &testutils.ApiImportExportTestArgs{
+		ApiProvider: testutils.Credentials{Username: tenantApiCreator, Password: tenantApiCreatorPassword},
+		CtlUser:     testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		Api:         api,
+		SrcAPIM:     dev,
+		DestAPIM:    prod,
+	}
+
+	testutils.ValidateAPIExportImport(t, args)
 }
 
 func TestListApisAdminSuperTenantUser(t *testing.T) {

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -836,6 +836,29 @@ func (instance *Client) PublishAPI(apiID string) {
 	base.ValidateAndLogResponse("apim.PublishAPI()", response, 200)
 }
 
+// ChangeAPILifeCycle : Change Life Cycle Status of an API in APIM
+func (instance *Client) ChangeAPILifeCycle(apiID, action string) {
+	lifeCycleURL := instance.publisherRestURL + "/apis/change-lifecycle"
+
+	request := base.CreatePostEmptyBody(lifeCycleURL)
+
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+	values := url.Values{}
+	values.Add("action", action)
+	values.Add("apiId", apiID)
+
+	request.URL.RawQuery = values.Encode()
+
+	base.LogRequest("apim.ChangeAPILifeCycle()", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
+	base.ValidateAndLogResponse("apim.ChangeAPILifeCycle()", response, 200)
+}
+
 // DeleteSubscriptions : Delete Subscriptions for an API from APIM
 func (instance *Client) DeleteSubscriptions(apiID string) {
 	subsGetURL := instance.devPortalRestURL + "/subscriptions"

--- a/import-export-cli/integration/base/helper.go
+++ b/import-export-cli/integration/base/helper.go
@@ -103,7 +103,7 @@ func Login(t *testing.T, env string, username string, password string) {
 	Execute(t, "login", env, "-u", username, "-p", password, "-k", "--verbose")
 
 	t.Cleanup(func() {
-		Execute(t, "logout", env)
+		Execute(t, "logout", env, "-k")
 	})
 }
 
@@ -311,7 +311,7 @@ func CreateTempDir(t *testing.T, path string) {
 func GetExportedPathFromOutput(output string) string {
 	//Check directory path to omit changes due to OS differences
 	if strings.Contains(output, ":\\") {
-		arrayOutput := []rune (output)
+		arrayOutput := []rune(output)
 		extractedPath := string(arrayOutput[strings.Index(output, ":\\")-1:])
 		return strings.ReplaceAll(strings.ReplaceAll(extractedPath, "\n", ""), " ", "")
 	} else {

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -131,7 +131,7 @@ func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
 	}
 
 	//Assert that project import to publisher portal is successful
-	testutils.ValidateImportProject(t, args)
+	testutils.ValidateImportProject(t, args, true)
 }
 
 //Import API from initialized project with openAPI 3 definition
@@ -151,7 +151,57 @@ func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	}
 
 	//Assert that project import to publisher portal is successful
-	testutils.ValidateImportProject(t, args)
+	testutils.ValidateImportProject(t, args, true)
+}
+
+// Import an API from initialized project with an invalid Open API 3 definition using a super
+// tenant user with Internal/devops role
+func TestImportProjectCreatedFromInvalidOpenAPI3DefinitionSuperTenantDevopsUser(t *testing.T) {
+	apim := apimClients[0]
+	projectName := base.GenerateRandomName(16)
+
+	devopsUsername := devops.UserName
+	devopsPassword := devops.Password
+
+	args := &testutils.InitTestArgs{
+		CtlUser:   testutils.Credentials{Username: devopsUsername, Password: devopsPassword},
+		SrcAPIM:   apim,
+		InitFlag:  projectName,
+		OasFlag:   testutils.TestInvalidOpenAPI3DefinitionPath,
+		APIName:   base.GenerateRandomName(16) + "API",
+		ForceFlag: false,
+	}
+
+	// Initialize a project with OAS
+	testutils.ValidateInitializeProjectWithOASFlag(t, args)
+
+	// Assert that project import to publisher portal is unsuccessful
+	testutils.ValidateImportProjectWithInvalidSwaggerFailed(t, args, true)
+}
+
+// Import an API from initialized project with an invalid Open API 3 definition using a
+// tenant user with Internal/devops role
+func TestImportProjectCreatedFromInvalidOpenAPI3DefinitionTenantDevopsUser(t *testing.T) {
+	apim := apimClients[0]
+	projectName := base.GenerateRandomName(16)
+
+	tenantDevopsUsername := devops.UserName + "@" + TENANT1
+	tenantDevopsPassword := devops.Password
+
+	args := &testutils.InitTestArgs{
+		CtlUser:   testutils.Credentials{Username: tenantDevopsUsername, Password: tenantDevopsPassword},
+		SrcAPIM:   apim,
+		InitFlag:  projectName,
+		OasFlag:   testutils.TestInvalidOpenAPI3DefinitionPath,
+		APIName:   base.GenerateRandomName(16) + "API",
+		ForceFlag: false,
+	}
+
+	// Initialize a project with OAS
+	testutils.ValidateInitializeProjectWithOASFlag(t, args)
+
+	// Assert that project import to publisher portal is unsuccessful
+	testutils.ValidateImportProjectWithInvalidSwaggerFailed(t, args, false)
 }
 
 //Import API from initialized project from API definition which is already in publisher without --update flag
@@ -171,10 +221,10 @@ func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
 	}
 
 	//Import API for the First time
-	testutils.ValidateImportProject(t, args)
+	testutils.ValidateImportProject(t, args, true)
 
 	//Import API for the second time
-	testutils.ValidateImportProjectFailed(t, args)
+	testutils.ValidateImportProjectFailed(t, args, true)
 }
 
 //Import API from initialized project from API definition which is already in publisher with --update flag
@@ -194,7 +244,7 @@ func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	}
 
 	//Import API for the First time
-	testutils.ValidateImportProject(t, args)
+	testutils.ValidateImportProject(t, args, true)
 
 	//Import API for the second time
 	testutils.ValidateImportUpdateProject(t, args)

--- a/import-export-cli/integration/environmnet_test.go
+++ b/import-export-cli/integration/environmnet_test.go
@@ -80,7 +80,7 @@ func TestChangeExportDirectory(t *testing.T) {
 	}
 
 	//Assert that project import to publisher portal is successful
-	testutils.ValidateImportProject(t, apiArgs)
+	testutils.ValidateImportProject(t, apiArgs, true)
 
 	//Assert that Export directory change is successful by exporting and asserting that
 	testutils.ValidateExportApisPassed(t, apiArgs, changedExportDirectory)

--- a/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
+++ b/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
@@ -1,0 +1,147 @@
+openapi: 3.0.1
+info:
+  title: NoahExpressTimeTableAPI
+  description: | 
+    This is the definition of the API for the public community to get the Noah Express train schedules
+  version: 1.0.0
+servers:
+  - url: http://backend-service:8080/train-operations/v1
+paths:
+  /schedules:
+    get:
+      parameters:
+       - in: query
+         name: from
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: to
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: startTime
+         schema:
+           type: string
+           description: Train starting station
+       - in: query
+         name: endTime
+         schema:
+           type: string
+           description: Train starting station
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleItemList'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScheduleItem'
+        required: true
+      responses:
+        '200':
+          description: ok
+  /schedules/{id1}_{id2}:
+    get:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleItem'
+    put:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+    delete:
+      parameters:
+        - name: id1
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+        - name: id2
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+            format: string
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    ScheduleItem:
+      title: Schedule information 
+      type: object
+      properties:
+        entryId:
+          type: string
+          description: Id of the schedule item.
+        startTime:
+          type: string
+          description: Train starting time.
+        endTime:
+          type: string
+          description: Train destination arrival time.
+        from:
+          type: string
+          description: Train starting station.
+        to:
+          type: string
+          description: Train destination station.
+        trainType:
+          type: string
+          description: Train category.
+    ScheduleItemList:
+        title: List of schedule items information 
+        type: array
+        items:
+          $ref: '#/components/schemas/ScheduleItem'
+            

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -133,6 +133,14 @@ func PublishAPI(client *apim.Client, username string, password string, apiID str
 	client.PublishAPI(apiID)
 }
 
+func ChangeAPILifeCycle(client *apim.Client, username, password, apiID, action string) *apim.API {
+	base.WaitForIndexing()
+	client.Login(username, password)
+	client.ChangeAPILifeCycle(apiID, action)
+	api := client.GetAPI(apiID)
+	return api
+}
+
 func UnsubscribeAPI(client *apim.Client, username string, password string, apiID string) {
 	client.Login(username, password)
 	client.DeleteSubscriptions(apiID)

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -503,9 +503,12 @@ func validateAPIIsDeleted(t *testing.T, api *apim.API, apisListAfterDelete *apim
 	}
 }
 
-func ImportApiFromProject(t *testing.T, projectName string, client *apim.Client, apiName string, credentials *Credentials, isCleanup bool) (string, error) {
+func importApiFromProject(t *testing.T, projectName string, client *apim.Client, apiName string, credentials *Credentials,
+	isCleanup, isPreserveProvider bool) (string, error) {
 	projectPath, _ := filepath.Abs(projectName)
-	output, err := base.Execute(t, "import-api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--verbose")
+
+	output, err := base.Execute(t, "import-api", "-f", projectPath, "-e", client.GetEnvName(), "-k", "--verbose",
+		"--preserve-provider="+strconv.FormatBool(isPreserveProvider))
 
 	base.WaitForIndexing()
 

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -21,6 +21,7 @@ package testutils
 const CustomTestExportDirectory = "CustomExportDirectory"
 const TestSwagger2DefinitionPath = "testdata/swagger2Definition.yaml"
 const TestOpenAPI3DefinitionPath = "testdata/openAPI3Definition.yaml"
+const TestInvalidOpenAPI3DefinitionPath = "testdata/invalidOpenAPI3Definition.yaml"
 const TestOpenAPISpecificationURL = "https://petstore.swagger.io/v2/swagger.json"
 const TestMigrationDirectorySuffix = "/migration"
 const TestApiDefinitionPath = "testdata/testAPIDefinition.yaml"


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/663
Fixes: https://github.com/wso2/api-manager/issues/115

## Goals
Adding the integration tests for importing locked APIs and when importing an API with an invalid OAS.

## Approach
- Added the below tests for importing locked APIs
  - **_TestExportImportApiBlockedSuperTenantDevopsUser_** - Export an API with the life cycle status as Blocked and import to another environment as a super tenant user with Internal/devops role
  - **_TestExportImportApiBlockedTenantDevopsUser_** Export an API with the life cycle status as Blocked and import to another environment as a tenant user with Internal/devops role
  - _**TestExportImportApiDeprecatedSuperTenantDevopsUser**_ - Export an API with the life cycle status as Deprecated and import to another environment as a super tenant user with Internal/devops role
  - **_TestExportImportApiDeprecatedTenantDevopsUser_** - Export an API with the life cycle status as Deprecated and import to another environment as a tenant user with Internal/devops role
  - **_TestExportImportApiRetiredSuperTenantDevopsUser_** - Export an API with the life cycle status as Retired and import to another environment as a super tenant user with Internal/devops role
  - TestExportImportApiRetiredTenantDevopsUser - Export an API with the life cycle status as Retired and import to another environment as a tenant user with Internal/devops role 
- Added tests for invalid Open API Definitions validation
  - **_TestImportProjectCreatedFromInvalidOpenAPI3DefinitionSuperTenantDevopsUser_** - Import an API from initialized project with an invalid Open API 3 definition using a super tenant user with Internal/devops role
  - **_TestImportProjectCreatedFromInvalidOpenAPI3DefinitionTenantDevopsUser_** -  Import an API from initialized project with an invalid Open API 3 definition using a tenant user with Internal/devops role
- The logs for the local test run are attached here [3.2.0-log.txt](https://github.com/wso2/product-apim-tooling/files/9431273/3.2.0-log.txt). All the tests are passing.

## Test environment
- Ubuntu 20.04.3 LTS
- go version go1.16.3 linux/amd64