### PR TITLE
Adding the integration tests for importing locked APIs and API Products

### DIFF
--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -753,6 +753,80 @@ func TestExportImportApiProductCrossTenantDevopsWithUpdateApisAndApiProduct(t *t
 	testutils.ValidateAPIProductImportUpdate(t, args)
 }
 
+// Export an API Product with the life cycle status as Blocked and import to another environment
+func TestExportImportApiProductBlocked(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			args := testutils.AddAPIProductWithTwoDependentAPIs(t, dev, &user.ApiCreator, &user.ApiPublisher)
+			testutils.PublishAPIProduct(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, args.ApiProduct.ID)
+			args.ApiProduct = testutils.ChangeAPIProductLifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password,
+				args.ApiProduct.ID, "Block")
+
+			args.CtlUser = user.CtlUser
+			args.DestAPIM = prod
+			args.ImportApisFlag = true
+			args.UpdateApisFlag = false
+			args.UpdateApiProductFlag = false
+
+			testutils.ValidateAPIProductExportImportPreserveProvider(t, args)
+		})
+	}
+}
+
+// Export an API Product with the life cycle status as Deprecated and import to another environment
+func TestExportImportApiProductDeprecated(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			args := testutils.AddAPIProductWithTwoDependentAPIs(t, dev, &user.ApiCreator, &user.ApiPublisher)
+			testutils.PublishAPIProduct(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, args.ApiProduct.ID)
+			args.ApiProduct = testutils.ChangeAPIProductLifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password,
+				args.ApiProduct.ID, "Deprecate")
+
+			args.CtlUser = user.CtlUser
+			args.DestAPIM = prod
+			args.ImportApisFlag = true
+			args.UpdateApisFlag = false
+			args.UpdateApiProductFlag = false
+
+			testutils.ValidateAPIProductExportImportPreserveProvider(t, args)
+		})
+	}
+}
+
+// Export an API Product with the life cycle status as Retired and import to another environment
+func TestExportImportApiProductRetired(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			args := testutils.AddAPIProductWithTwoDependentAPIs(t, dev, &user.ApiCreator, &user.ApiPublisher)
+			testutils.PublishAPIProduct(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, args.ApiProduct.ID)
+			testutils.ChangeAPIProductLifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password,
+				args.ApiProduct.ID, "Deprecate")
+			args.ApiProduct = testutils.ChangeAPIProductLifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password,
+				args.ApiProduct.ID, "Retire")
+
+			args.CtlUser = user.CtlUser
+			args.DestAPIM = prod
+			args.ImportApisFlag = true
+			args.UpdateApisFlag = false
+			args.UpdateApiProductFlag = false
+
+			testutils.ValidateAPIProductExportImportPreserveProvider(t, args)
+		})
+	}
+}
+
 func TestListApiProductsAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -584,6 +584,82 @@ func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
 	testutils.ValidateAPIImportFailure(t, args)
 }
 
+// Export an API with the life cycle status as Blocked and import to another environment
+func TestExportImportApiBlocked(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+			testutils.PublishAPI(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+			api = testutils.ChangeAPILifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID, "Block")
+
+			args := &testutils.ApiImportExportTestArgs{
+				ApiProvider: testutils.Credentials{Username: user.ApiCreator.Username, Password: user.ApiCreator.Password},
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				DestAPIM:    prod,
+			}
+
+			testutils.ValidateAPIExportImport(t, args, testutils.APITypeREST)
+		})
+	}
+}
+
+// Export an API with the life cycle status as Deprecated and import to another environment
+func TestExportImportApiDeprecated(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+			testutils.PublishAPI(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+			api = testutils.ChangeAPILifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID, "Deprecate")
+
+			args := &testutils.ApiImportExportTestArgs{
+				ApiProvider: testutils.Credentials{Username: user.ApiCreator.Username, Password: user.ApiCreator.Password},
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				DestAPIM:    prod,
+			}
+
+			testutils.ValidateAPIExportImport(t, args, testutils.APITypeREST)
+		})
+	}
+}
+
+// Export an API with the life cycle status as Retired and import to another environment
+func TestExportImportApiRetired(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+			testutils.PublishAPI(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID)
+			testutils.ChangeAPILifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID, "Deprecate")
+			api = testutils.ChangeAPILifeCycle(dev, user.ApiPublisher.Username, user.ApiPublisher.Password, api.ID, "Retire")
+
+			args := &testutils.ApiImportExportTestArgs{
+				ApiProvider: testutils.Credentials{Username: user.ApiCreator.Username, Password: user.ApiCreator.Password},
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				DestAPIM:    prod,
+			}
+
+			testutils.ValidateAPIExportImport(t, args, testutils.APITypeREST)
+		})
+	}
+}
+
 func TestListApisAdminSuperTenantUser(t *testing.T) {
 	adminUsername := superAdminUser
 	adminPassword := superAdminPassword

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -919,6 +919,29 @@ func (instance *Client) PublishAPIProduct(apiProductID string) {
 	base.ValidateAndLogResponse("apim.PublishAPIProduct()", response, 200)
 }
 
+// ChangeAPIProductLifeCycle : Change Life Cycle Status of an API Product in APIM
+func (instance *Client) ChangeAPIProductLifeCycle(apiProductID, action string) {
+	lifeCycleURL := instance.publisherRestURL + "/api-products/change-lifecycle"
+
+	request := base.CreatePostEmptyBody(lifeCycleURL)
+
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+	values := url.Values{}
+	values.Add("action", action)
+	values.Add("apiProductId", apiProductID)
+
+	request.URL.RawQuery = values.Encode()
+
+	base.LogRequest("apim.ChangeAPIProductLifeCycle()", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
+	base.ValidateAndLogResponse("apim.ChangeAPIProductLifeCycle()", response, 200)
+}
+
 // GetAPIRevisions : Get API revisions
 func (instance *Client) GetAPIRevisions(apiID, query string) *APIRevisionList {
 	revisioningURL := instance.publisherRestURL + "/apis/" + apiID + "/revisions"
@@ -1384,6 +1407,29 @@ func (instance *Client) PublishAPI(apiID string) {
 	defer response.Body.Close()
 
 	base.ValidateAndLogResponse("apim.PublishAPI()", response, 200)
+}
+
+// ChangeAPILifeCycle : Change Life Cycle Status of an API in APIM
+func (instance *Client) ChangeAPILifeCycle(apiID, action string) {
+	lifeCycleURL := instance.publisherRestURL + "/apis/change-lifecycle"
+
+	request := base.CreatePostEmptyBody(lifeCycleURL)
+
+	base.SetDefaultRestAPIHeaders(instance.accessToken, request)
+
+	values := url.Values{}
+	values.Add("action", action)
+	values.Add("apiId", apiID)
+
+	request.URL.RawQuery = values.Encode()
+
+	base.LogRequest("apim.ChangeAPILifeCycle()", request)
+
+	response := base.SendHTTPRequest(request)
+
+	defer response.Body.Close()
+
+	base.ValidateAndLogResponse("apim.ChangeAPILifeCycle()", response, 200)
 }
 
 // GetApplicationSubscriptions : Get subscriptions of an application

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -62,6 +62,14 @@ func PublishAPIProduct(client *apim.Client, username string, password string, ap
 	client.PublishAPIProduct(apiProductID)
 }
 
+func ChangeAPIProductLifeCycle(client *apim.Client, username, password, apiProductID, action string) *apim.APIProduct {
+	base.WaitForIndexing()
+	client.Login(username, password)
+	client.ChangeAPILifeCycle(apiProductID, action)
+	apiProduct := client.GetAPIProduct(apiProductID)
+	return apiProduct
+}
+
 func CreateAndDeployAPIProductRevision(t *testing.T, client *apim.Client, username, password, apiProductID string) string {
 	client.Login(username, password)
 	revision := client.CreateAPIProductRevision(apiProductID)

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -268,6 +268,14 @@ func PublishAPI(client *apim.Client, username string, password string, apiID str
 	client.PublishAPI(apiID)
 }
 
+func ChangeAPILifeCycle(client *apim.Client, username, password, apiID, action string) *apim.API {
+	base.WaitForIndexing()
+	client.Login(username, password)
+	client.ChangeAPILifeCycle(apiID, action)
+	api := client.GetAPI(apiID)
+	return api
+}
+
 func UnsubscribeAPI(client *apim.Client, username string, password string, apiID string) {
 	client.Login(username, password)
 	client.DeleteSubscriptions(apiID)
@@ -371,9 +379,10 @@ func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 
 	if !args.Update {
 		t.Cleanup(func() {
-			if strings.EqualFold("PUBLISHED", args.Api.LifeCycleStatus) {
+			if strings.EqualFold("DEPRECATED", args.Api.LifeCycleStatus) {
 				args.CtlUser.Username, args.CtlUser.Password =
 					apim.RetrieveAdminCredentialsInsteadCreator(args.CtlUser.Username, args.CtlUser.Password)
+				args.DestAPIM.Login(args.CtlUser.Username, args.CtlUser.Password)
 			}
 			err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/663

## Goals
Adding the integration tests for importing locked APIs and API Products.

## Approach
- Added the below tests for importing locked APIs in the table driven format for the user roles: Super Tenant Admin, Tenant Admin, Super Tenant Devops and Tenant Devops  
  - **_TestExportImportApiBlocked_** - Export an API with the life cycle status as Blocked and import to another environment
  - _**TestExportImportApiDeprecated**_ - Export an API with the life cycle status as Deprecated and import to another environment
  - **_TestExportImportApiRetired_** - Export an API with the life cycle status as Retired and import to another environment
- Added the below tests for importing locked API Products in the table driven format for the user roles: Super Tenant Admin, Tenant Admin, Super Tenant Devops and Tenant Devops  
  - **_TestExportImportApiProductBlocked_** - Export an API Product with the life cycle status as Blocked and import to another environment
  - _**TestExportImportApiProductDeprecated**_ - Export an API Product with the life cycle status as Deprecated and import to another environment
  - **_TestExportImportApiProductRetired_** - Export an API Product with the life cycle status as Retired and import to another environment

## Test environment
- Ubuntu 20.04.3 LTS
- go version go1.16.3 linux/amd64