### PR TITLE
Improving export/import test with Blocked API/API Product status with the update

### DIFF
--- a/import-export-cli/integration/apiProduct_test.go
+++ b/import-export-cli/integration/apiProduct_test.go
@@ -772,6 +772,13 @@ func TestExportImportApiProductBlocked(t *testing.T) {
 			args.UpdateApisFlag = false
 			args.UpdateApiProductFlag = false
 
+			importedApiProduct := testutils.ValidateAPIProductExportImportPreserveProvider(t, args)
+
+			// Change the lifecycle to Published in the prod environment
+			testutils.ChangeAPIProductLifeCycle(prod, user.ApiPublisher.Username, user.ApiPublisher.Password, importedApiProduct.ID, "Re-Publish")
+
+			args.UpdateApiProductFlag = true
+			args.ImportApisFlag = false
 			testutils.ValidateAPIProductExportImportPreserveProvider(t, args)
 		})
 	}

--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -585,6 +585,7 @@ func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
 }
 
 // Export an API with the life cycle status as Blocked and import to another environment
+// and import update it
 func TestExportImportApiBlocked(t *testing.T) {
 	for _, user := range testCaseUsers {
 		t.Run(user.Description, func(t *testing.T) {
@@ -604,6 +605,12 @@ func TestExportImportApiBlocked(t *testing.T) {
 				DestAPIM:    prod,
 			}
 
+			importedApi := testutils.ValidateAPIExportImport(t, args, testutils.APITypeREST)
+
+			// Change the lifecycle to Published in the prod environment
+			testutils.ChangeAPILifeCycle(prod, user.ApiPublisher.Username, user.ApiPublisher.Password, importedApi.ID, "Re-Publish")
+
+			args.Update = true
 			testutils.ValidateAPIExportImport(t, args, testutils.APITypeREST)
 		})
 	}

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -341,6 +341,8 @@ func ValidateAPIProductExportImportPreserveProvider(t *testing.T, args *ApiProdu
 
 	// Validate env 1 and env 2 API Products are equal
 	validateAPIProductsEqual(t, args.ApiProduct, importedAPIProduct)
+
+	return importedAPIProduct
 }
 
 func ValidateAPIProductImportUpdatePreserveProvider(t *testing.T, args *ApiProductImportExportTestArgs) {

--- a/import-export-cli/integration/testutils/apiProduct_testUtils.go
+++ b/import-export-cli/integration/testutils/apiProduct_testUtils.go
@@ -310,7 +310,7 @@ func ValidateAPIProductExportFailure(t *testing.T, args *ApiProductImportExportT
 		args.ApiProduct.Name, utils.DefaultApiProductVersion))
 }
 
-func ValidateAPIProductExportImportPreserveProvider(t *testing.T, args *ApiProductImportExportTestArgs) {
+func ValidateAPIProductExportImportPreserveProvider(t *testing.T, args *ApiProductImportExportTestArgs) *apim.APIProduct {
 	t.Helper()
 
 	// Setup apictl envs

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -452,7 +452,7 @@ func ValidateAPIExportFailureUnauthenticated(t *testing.T, args *ApiImportExport
 		args.Api.Name, args.Api.Version), "Test failed because the API was exported successfully")
 }
 
-func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs, apiType string) {
+func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs, apiType string) *apim.API {
 	t.Helper()
 
 	// Setup apictl envs
@@ -481,6 +481,8 @@ func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs, apiTyp
 
 	// Validate env 1 and env 2 API is equal
 	ValidateAPIsEqual(t, args.Api, importedAPI)
+
+	return importedAPI
 }
 
 func ValidateAPIImportExportForAdvertiseOnlyAPI(t *testing.T, args *ApiImportExportTestArgs, apiType string) {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/713

## Goals
Improving export/import test with Blocked API status with the update

## Approach
Change the existing two test cases in the below way
  - After exporting and importing a Blocked API/API Product, change the API/API Product status to Publish in the second environment and again export and import the Blocked API/API Product with the update.

The complete test run log is attached here. [log-3.2.0.txt](https://github.com/wso2/product-apim-tooling/files/9507651/log-3.2.0.txt)
