### PR TITLE
[3.2.x] Improving export/import test with Blocked API status with the update

### DIFF
--- a/import-export-cli/integration/api_test.go
+++ b/import-export-cli/integration/api_test.go
@@ -503,6 +503,7 @@ func TestExportImportApiCrossTenantDevopsUser(t *testing.T) {
 }
 
 // Export an API with the life cycle status as Blocked and import to another environment as a super tenant user with Internal/devops role
+// and again import update it
 func TestExportImportApiBlockedSuperTenantDevopsUser(t *testing.T) {
 	devopsUsername := devops.UserName
 	devopsPassword := devops.Password
@@ -528,10 +529,16 @@ func TestExportImportApiBlockedSuperTenantDevopsUser(t *testing.T) {
 		DestAPIM:    prod,
 	}
 
+	importedApi := testutils.ValidateAPIExportImport(t, args)
+
+	// Change the lifecycle to Published in the prod environment
+	testutils.ChangeAPILifeCycle(prod, superTenantApiPublisher, superTenantApiPublisherPassword, importedApi.ID, "Re-Publish")
+	args.Update = true
 	testutils.ValidateAPIExportImport(t, args)
 }
 
 // Export an API with the life cycle status as Blocked and import to another environment as a tenant user with Internal/devops role
+// and again import update it
 func TestExportImportApiBlockedTenantDevopsUser(t *testing.T) {
 	tenantDevopsUsername := devops.UserName + "@" + TENANT1
 	tenantDevopsPassword := devops.Password
@@ -557,6 +564,11 @@ func TestExportImportApiBlockedTenantDevopsUser(t *testing.T) {
 		DestAPIM:    prod,
 	}
 
+	importedApi := testutils.ValidateAPIExportImport(t, args)
+
+	// Change the lifecycle to Published in the prod environment
+	testutils.ChangeAPILifeCycle(prod, tenantApiPublisher, tenantApiPublisherPassword, importedApi.ID, "Re-Publish")
+	args.Update = true
 	testutils.ValidateAPIExportImport(t, args)
 }
 

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -202,16 +202,22 @@ func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 		params = append(params, "--params", args.ParamsFile)
 	}
 
+	if args.Update {
+		params = append(params, "--update=true")
+	}
+
 	output, err := base.Execute(t, params...)
 
-	t.Cleanup(func() {
-		err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
+	if !args.Update {
+		t.Cleanup(func() {
+			err := args.DestAPIM.DeleteAPIByName(args.Api.Name)
 
-		if err != nil {
-			t.Fatal(err)
-		}
-		base.WaitForIndexing()
-	})
+			if err != nil {
+				t.Fatal(err)
+			}
+			base.WaitForIndexing()
+		})
+	}
 
 	return output, err
 }
@@ -249,7 +255,7 @@ func ValidateAPIExportFailure(t *testing.T, args *ApiImportExportTestArgs) {
 		args.Api.Name, args.Api.Version))
 }
 
-func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs) {
+func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs) *apim.API {
 	t.Helper()
 
 	// Setup apictl envs
@@ -277,6 +283,8 @@ func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	// Validate env 1 and env 2 API is equal
 	ValidateAPIsEqual(t, args.Api, importedAPI)
+
+	return importedAPI
 }
 
 func ValidateAPIExport(t *testing.T, args *ApiImportExportTestArgs) {

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -33,6 +33,7 @@ type ApiImportExportTestArgs struct {
 	DestAPIM         *apim.Client
 	OverrideProvider bool
 	ParamsFile       string
+	Update           bool
 }
 
 type ApiProductImportExportTestArgs struct {


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/713

## Goals
Improving export/import test with Blocked API status with the update

## Approach
Change the existing two test cases in the below way
  - After exporting and importing a Blocked API, change the API status to Publish in the second environment and again export and import the Blocked API with the update.

The complete test run log is attached here. [log-3.2.0.txt](https://github.com/wso2/product-apim-tooling/files/9507651/log-3.2.0.txt)
