### PR TITLE
Adding the enableSubscriberVerification property to API DTO

### DIFF
--- a/import-export-cli/integration/apim/apiDTO.go
+++ b/import-export-cli/integration/apim/apiDTO.go
@@ -77,6 +77,7 @@ type API struct {
 	GatewayVendor                   string            `json:"gatewayVendor,omitempty" yaml:"gatewayVendor,omitempty"`
 	AsyncTransportProtocols         []string          `json:"asyncTransportProtocols,omitempty" yaml:"asyncTransportProtocols,omitempty"`
 	GatewayType                     string            `json:"gatewayType,omitempty" yaml:"gatewayType,omitempty"`
+	EnableSubscriberVerification    bool              `json:"enableSubscriberVerification,omitempty" yaml:"enableSubscriberVerification,omitempty"`
 }
 
 // GetProductionURL : Get APIs production URL

--- a/import-export-cli/integration/testdata/sample-api.yaml
+++ b/import-export-cli/integration/testdata/sample-api.yaml
@@ -172,4 +172,5 @@ data: # Contains the meta data of the API
   gatewayVendor: wso2 # Gateway vendor
   asyncTransportProtocols: [] # Async transport protocols
   gatewayType: wso2/synapse # The gateway type selected for the API policies
+  enableSubscriberVerification: false # To enable subscriber verification of WebSub APIs
   

--- a/import-export-cli/integration/testdata/sample-revisioned-api.yaml
+++ b/import-export-cli/integration/testdata/sample-revisioned-api.yaml
@@ -173,3 +173,4 @@ data: # Contains the meta data of the API
   gatewayVendor: wso2 # Gateway vendor
   asyncTransportProtocols: [] # Async transport protocols
   gatewayType: wso2/synapse # The gateway type selected for the API policies
+  enableSubscriberVerification: false # To enable subscriber verification of WebSub APIs

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -84,6 +84,7 @@ type APIDTODefinition struct {
 	GatewayVendor                   string        `json:"gatewayVendor,omitempty" yaml:"gatewayVendor,omitempty"`
 	AsyncTransportProtocols         []string      `json:"asyncTransportProtocols,omitempty" yaml:"asyncTransportProtocols,omitempty"`
 	GatewayType                     string        `json:"gatewayType,omitempty" yaml:"gatewayType,omitempty"`
+	EnableSubscriberVerification    bool          `json:"enableSubscriberVerification,omitempty" yaml:"enableSubscriberVerification,omitempty"`
 }
 
 type CorsConfiguration struct {


### PR DESCRIPTION
## Purpose
Fixing test failures due to the modification of API DTO in API Manager

## Goals
Adding the enableSubscriberVerification property to API DTO