### PR TITLE
Fixing intermittent failure of TestUndeployAPIRevisionFailure test

### DIFF
--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -103,6 +103,7 @@ func CreateAndDeployAPIRevision(t *testing.T, client *apim.Client, username, pas
 	client.Login(username, password)
 	revision := client.CreateAPIRevision(apiID)
 	client.DeployAPIRevision(t, apiID, "", "", revision.ID)
+	base.WaitForIndexing()
 	return revision.ID
 }
 

--- a/import-export-cli/integration/testutils/gateway_testUtils.go
+++ b/import-export-cli/integration/testutils/gateway_testUtils.go
@@ -125,10 +125,9 @@ func ValidateAPIUndeployFailure(t *testing.T, args *UndeployTestArgs, provider, 
 	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
 	// Execute undeploy API command
-	result, err := undeployAPI(t, args, provider)
+	result, _ := undeployAPI(t, args, provider)
 
-	assert.NotNil(t, err, "Should not return nil error")
-	assert.Contains(t, base.GetValueOfUniformResponse(result), "Exit status 1",
+	assert.Contains(t, base.GetValueOfUniformResponse(result), "Error while undeploying the API",
 		"Test failed because API was undeployed successfully")
 }
 


### PR DESCRIPTION
## Purpose
Earlier an incorrect result was asserted in the test. However, the test was intermittently passing even though we asserted an incorrect result because the indexing was not happening correctly and the API was nowhere to be found. This PR will add indexing correctly to this particular test and corrects the assertion.

## Goals
Fixing intermittent failure of TestUndeployAPIRevisionFailure test