### PR TITLE
[3.2.x] Add tests for API versioning

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -137,12 +137,20 @@ func (instance *Client) GetTokenURL() string {
 }
 
 // GenerateSampleAPIData : Generate sample Pizzashack API object
-func (instance *Client) GenerateSampleAPIData(provider string) *API {
+func (instance *Client) GenerateSampleAPIData(provider, name, version, context string) *API {
 	api := API{}
-	api.Name = generateRandomString() + "API"
+	if strings.EqualFold(name, "") {
+		api.Name = generateRandomString() + "API"
+	} else {
+		api.Name = name
+	}
 	api.Description = "This is a simple API for Pizza Shack online pizza delivery store."
-	api.Context = getContext(provider)
-	api.Version = "1.0.0"
+	if strings.EqualFold(context, "") {
+		api.Context = getContext(provider)
+	} else {
+		api.Context = context
+	}
+	api.Version = version
 	api.Provider = provider
 	api.Transport = []string{"http", "https"}
 	api.Tags = []string{"pizza"}
@@ -687,6 +695,7 @@ func (instance *Client) GetAPI(apiID string) *API {
 
 	var apiResponse API
 	json.NewDecoder(response.Body).Decode(&apiResponse)
+
 	return &apiResponse
 }
 

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -89,3 +89,6 @@ const DevFirstSampleCaseSequencePath = "testdata/TestArtifactDirectory/DevFirstS
 const DevFirstSampleCaseDestSequencePathSuffix = "/Sequences/in-sequence/Custom/mockSequence.xml"
 const DevFirstUpdatedSampleCaseSequencePath = "testdata/TestArtifactDirectory/DevFirstUpdatedSampleCaseArtifacts/mockSequence.xml"
 const DevFirstUpdatedSampleCaseSequencePathSuffix = "/Sequences/in-sequence/Custom/mockSequence.xml"
+
+//Constant for API versioning tests
+const APIVersion2 = "2.0.0"


### PR DESCRIPTION
## Purpose
> Add tests to check tenant user API versioning using import-api command

When there are more than one APIs in the publisher method **ValidateAPIImport** only validates the first API.  Therefore introduced a new method **ValidateAPIImportForMultipleVersions**, which deletes the API which was imported first and then validate the current API.