### PR TITLE
Adding tests for API versioning

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -156,12 +156,20 @@ func (instance *Client) GetTokenURL() string {
 }
 
 // GenerateSampleAPIData : Generate sample Pizzashack API object
-func (instance *Client) GenerateSampleAPIData(provider string) *API {
+func (instance *Client) GenerateSampleAPIData(provider, name, version, context string) *API {
 	api := API{}
-	api.Name = base.GenerateRandomString() + "API"
+	if strings.EqualFold(name, "") {
+		api.Name = base.GenerateRandomString() + "API"
+	} else {
+		api.Name = name
+	}
 	api.Description = "This is a simple API for Pizza Shack online pizza delivery store."
-	api.Context = getContext(provider)
-	api.Version = "1.0.0"
+	if strings.EqualFold(context, "") {
+		api.Context = getContext(provider)
+	} else {
+		api.Context = context
+	}
+	api.Version = version
 	api.Provider = provider
 	api.Transport = []string{"http", "https"}
 	api.Tags = []string{"pizza"}

--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -40,16 +40,24 @@ func GetAPIById(t *testing.T, client *apim.Client, username, password, apiId str
 	return client.GetAPI(apiId)
 }
 
-func AddAPI(t *testing.T, client *apim.Client, username string, password string) *apim.API {
+func AddAPI(t *testing.T, client *apim.Client, username, password string) *apim.API {
 	client.Login(username, password)
-	api := client.GenerateSampleAPIData(username)
+	api := client.GenerateSampleAPIData(username, "", DevFirstDefaultAPIVersion, "")
 	doClean := true
 	id := client.AddAPI(t, api, username, password, doClean)
 	api = client.GetAPI(id)
 	return api
 }
 
-func UpdateAPI(t *testing.T, client *apim.Client, api *apim.API, username string, password string) *apim.API {
+func AddCustomAPI(t *testing.T, client *apim.Client, username, password, name, version, context string) *apim.API {
+	client.Login(username, password)
+	api := client.GenerateSampleAPIData(username, name, version, context)
+	id := client.AddAPI(t, api, username, password, true)
+	api = client.GetAPI(id)
+	return api
+}
+
+func UpdateAPI(t *testing.T, client *apim.Client, api *apim.API, username, password string) *apim.API {
 	client.Login(username, password)
 	id := client.UpdateAPI(t, api, username, password)
 	api = client.GetAPI(id)
@@ -139,7 +147,7 @@ func GetGatewayEnvironments(apiRevisions *apim.APIRevisionList) []string {
 
 func AddAPIWithoutCleaning(t *testing.T, client *apim.Client, username string, password string) *apim.API {
 	client.Login(username, password)
-	api := client.GenerateSampleAPIData(username)
+	api := client.GenerateSampleAPIData(username, "", DevFirstDefaultAPIVersion, "")
 	doClean := false
 	id := client.AddAPI(t, api, username, password, doClean)
 	api = client.GetAPI(id)
@@ -148,7 +156,7 @@ func AddAPIWithoutCleaning(t *testing.T, client *apim.Client, username string, p
 
 func AddAPIToTwoEnvs(t *testing.T, client1 *apim.Client, client2 *apim.Client, username string, password string) (*apim.API, *apim.API) {
 	client1.Login(username, password)
-	api := client1.GenerateSampleAPIData(username)
+	api := client1.GenerateSampleAPIData(username, "", DevFirstDefaultAPIVersion, "")
 	doClean := true
 	id1 := client1.AddAPI(t, api, username, password, doClean)
 	api1 := client1.GetAPI(id1)
@@ -354,7 +362,7 @@ func ValidateAllApisOfATenantIsExported(t *testing.T, args *ApiImportExportTestA
 	})
 }
 
-func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
+func importAPI(t *testing.T, args *ApiImportExportTestArgs, doClean bool) (string, error) {
 	var fileName string
 	if args.ImportFilePath == "" {
 		fileName = base.GetAPIArchiveFilePath(t, args.SrcAPIM.GetEnvName(), args.Api.Name, args.Api.Version)
@@ -378,7 +386,7 @@ func importAPI(t *testing.T, args *ApiImportExportTestArgs) (string, error) {
 
 	output, err := base.Execute(t, params...)
 
-	if !args.Update {
+	if !args.Update && doClean {
 		t.Cleanup(func() {
 			if strings.EqualFold("DEPRECATED", args.Api.LifeCycleStatus) {
 				args.CtlUser.Username, args.CtlUser.Password =
@@ -470,7 +478,7 @@ func ValidateAPIExportImport(t *testing.T, args *ApiImportExportTestArgs, apiTyp
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	result, err := importAPI(t, args)
+	result, err := importAPI(t, args, true)
 	assert.Nil(t, err, "Error while importing the API")
 	assert.Contains(t, result, "Successfully imported API", "Error while importing the API")
 
@@ -503,7 +511,7 @@ func ValidateAPIImportExportForAdvertiseOnlyAPI(t *testing.T, args *ApiImportExp
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	result, err := importAPI(t, args)
+	result, err := importAPI(t, args, true)
 	assert.Nil(t, err, "Error while importing the API")
 	assert.Contains(t, result, "Successfully imported API", "Error while importing the API")
 
@@ -533,7 +541,7 @@ func ValidateAPIRevisionExportImport(t *testing.T, args *ApiImportExportTestArgs
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	importAPI(t, args)
+	importAPI(t, args, true)
 
 	// Give time for newly imported API to get indexed, or else GetAPI by name will fail
 	base.WaitForIndexing()
@@ -732,7 +740,7 @@ func GetImportedAPI(t *testing.T, args *ApiImportExportTestArgs) *apim.API {
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	_, err := importAPI(t, args)
+	_, err := importAPI(t, args, true)
 
 	if err != nil {
 		t.Fatal(err)
@@ -800,7 +808,7 @@ func ValidateAPIImport(t *testing.T, args *ApiImportExportTestArgs) {
 	// Import api to env 2
 	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	importAPI(t, args)
+	importAPI(t, args, true)
 
 	// Give time for newly imported API to get indexed, or else GetAPI by name will fail
 	base.WaitForIndexing()
@@ -810,6 +818,40 @@ func ValidateAPIImport(t *testing.T, args *ApiImportExportTestArgs) {
 
 	// Validate env 1 and env 2 API is equal
 	validateAPIsEqualCrossTenant(t, args.Api, importedAPI)
+}
+
+func ValidateAPIImportForMultipleVersions(t *testing.T, args *ApiImportExportTestArgs, firstImportedAPIId string) *apim.API {
+
+	t.Helper()
+
+	isFirstImport := false
+	if strings.EqualFold(firstImportedAPIId, "") {
+		isFirstImport = true
+	}
+
+	// Add env2
+	base.SetupEnv(t, args.DestAPIM.GetEnvName(), args.DestAPIM.GetApimURL(), args.DestAPIM.GetTokenURL())
+
+	// Import api to env 2
+	base.Login(t, args.DestAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
+
+	importAPI(t, args, isFirstImport)
+
+	// Give time for newly imported API to get indexed, or else getAPI by name will fail
+	base.WaitForIndexing()
+
+	if !isFirstImport {
+		args.DestAPIM.DeleteAPI(firstImportedAPIId)
+		base.WaitForIndexing()
+	}
+
+	// Get App from env 2
+	importedAPI := GetAPI(t, args.DestAPIM, args.Api.Name, args.ApiProvider.Username, args.ApiProvider.Password)
+
+	// Validate env 1 and env 2 API is equal
+	validateAPIsEqualCrossTenant(t, args.Api, importedAPI)
+
+	return importedAPI
 }
 
 func ValidateAPIImportFailure(t *testing.T, args *ApiImportExportTestArgs) {

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -216,3 +216,6 @@ const DefaultAPIPolicyVersion = "v1"
 const TestAPIPolicyOffset = "0"
 const TestAPIPolicyLimit = "5"
 const CleanUpFunction = "cleanup"
+
+//Constant for API versioning tests
+const APIVersion2 = "2.0.0"


### PR DESCRIPTION
## Purpose
Adding tests for API versioning use case in apictl.
Related to: https://github.com/wso2/api-manager/issues/282

## Goals
Adding tests for API versioning

## Approach
- Frontporting [1].
- Adding new table-driven test named **TestApiVersioning**.

[1] https://github.com/wso2/product-apim-tooling/pull/953