### PR TITLE
Adding a test to export/import an API Policy with Synapse and Choreo Connect gateways

### DIFF
--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -2474,7 +2474,8 @@ func (instance *Client) GetAPIPolicyID(t *testing.T, policyName, policyVersion s
 }
 
 // AddAPIPolicy : Add new API Policy of different policy types to APIM
-func (instance *Client) AddAPIPolicy(t *testing.T, policySpec []byte, synapseDefFilePath, username, password, cleanUpFunction string, doClean bool) map[string]interface{} {
+func (instance *Client) AddAPIPolicy(t *testing.T, policySpec []byte, synapseDefFilePath, ccDefFilePath, username, password,
+	cleanUpFunction string, doClean bool) map[string]interface{} {
 	var apiPolicyResponse map[string]interface{}
 
 	apiPolicyURL := instance.publisherRestURL + operationPolicyResourcePath
@@ -2497,6 +2498,25 @@ func (instance *Client) AddAPIPolicy(t *testing.T, policySpec []byte, synapseDef
 	_, err = io.Copy(part, synapseDefFile)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if ccDefFilePath != "" {
+		ccDefFile, err := os.Open(ccDefFilePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ccDefFile.Close()
+
+		part, err = writer.CreateFormFile("ccPolicyDefinitionFile", filepath.Base(ccDefFile.Name()))
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = io.Copy(part, ccDefFile)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	part, err = writer.CreateFormField("policySpecFile")

--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -608,19 +608,19 @@ func TestExportImportAPIWithAPIPolicies(t *testing.T) {
 			// Add two versions of the same policy to a map
 			operationPoliciesMap := map[int]testutils.PolicySpecFile{
 				1: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition1Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition1Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
 				},
 				2: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition2Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition2Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
 				},
 			}
 
 			// Add two versions of the same policy to env1
 			for _, policy := range operationPoliciesMap {
 				testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
-					policy.Definition, policy.PolicyFile, true)
+					policy, true)
 			}
 
 			projectName := base.GenerateRandomString()

--- a/import-export-cli/integration/operationPolicy_test.go
+++ b/import-export-cli/integration/operationPolicy_test.go
@@ -35,19 +35,19 @@ func TestExportImportAPIPolicy(t *testing.T) {
 			// Add two versions of the same policy to a map
 			operationPoliciesMap := map[int]testutils.PolicySpecFile{
 				1: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition1Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition1Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
 				},
 				2: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition2Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition2Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
 				},
 			}
 
 			// Export and import two versions of the same policy
 			for _, policy := range operationPoliciesMap {
 				newPolicy := testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
-					policy.Definition, policy.PolicyFile, true)
+					policy, true)
 				operationPolicy, _ := testutils.APIPolicyStructToMap(newPolicy)
 
 				args := &testutils.PolicyImportExportTestArgs{
@@ -58,6 +58,39 @@ func TestExportImportAPIPolicy(t *testing.T) {
 				}
 				testutils.ValidateAPIPolicyExportImport(t, args)
 			}
+		})
+	}
+}
+
+// Export an API Policy that supports both Synapse and Choreo Connect gateways from one environment
+// and import to another environment
+func TestExportImportAPIPolicyWithSynapseChoreoConnectTypes(t *testing.T) {
+
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			// Add a policy that supports both Synapse and Choreo Connect gateways
+			operationPolicyFiles := testutils.PolicySpecFile{
+				Definition:        testutils.TestSynapseChoreoConnectPolicyDefinitionPath,
+				SynapsePolicyFile: testutils.TestSynapseChoreoConnectPolicyPathForSynapseType,
+				CcPolicyFile:      testutils.TestSynapseChoreoConnectPolicyPathForChoreoConnectType,
+			}
+
+			// Export and import the same policy
+			newPolicy := testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
+				operationPolicyFiles, true)
+			operationPolicy, _ := testutils.APIPolicyStructToMap(newPolicy)
+
+			args := &testutils.PolicyImportExportTestArgs{
+				CtlUser:  testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Policy:   operationPolicy,
+				SrcAPIM:  dev,
+				DestAPIM: prod,
+			}
+			testutils.ValidateAPIPolicyExportImport(t, args)
+
 		})
 	}
 }
@@ -115,19 +148,19 @@ func TestExportImportAPIPolicyWithFormatFlag(t *testing.T) {
 			// Add two versions of the same policy to a map
 			operationPoliciesMap := map[int]testutils.PolicySpecFile{
 				1: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition1Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition1Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
 				},
 				2: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition2Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition2Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
 				},
 			}
 
 			// Export and import two versions of the same policy
 			for _, policy := range operationPoliciesMap {
 				newPolicy := testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
-					policy.Definition, policy.PolicyFile, true)
+					policy, true)
 				operationPolicy, _ := testutils.APIPolicyStructToMap(newPolicy)
 
 				args := &testutils.PolicyImportExportTestArgs{
@@ -256,19 +289,19 @@ func TestAPIPolicyDelete(t *testing.T) {
 			// Add two versions of the same policy to a map
 			operationPoliciesMap := map[int]testutils.PolicySpecFile{
 				1: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition1Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition1Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
 				},
 				2: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition2Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition2Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
 				},
 			}
 
 			// Delete two versions of the same policy
 			for _, policy := range operationPoliciesMap {
 				newPolicy := testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
-					policy.Definition, policy.PolicyFile, false)
+					policy, false)
 				operationPolicy, _ := testutils.APIPolicyStructToMap(newPolicy)
 
 				args := &testutils.PolicyImportExportTestArgs{
@@ -313,19 +346,19 @@ func TestAPIPolicyImportFailureWhenPolicyExisted(t *testing.T) {
 			// Add two versions of the same policy to a map
 			operationPoliciesMap := map[int]testutils.PolicySpecFile{
 				1: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition1Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition1Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy1Path,
 				},
 				2: {
-					Definition: testutils.DevSampleCaseOperationPolicyDefinition2Path,
-					PolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
+					Definition:        testutils.DevSampleCaseOperationPolicyDefinition2Path,
+					SynapsePolicyFile: testutils.DevSampleCaseOperationPolicy2Path,
 				},
 			}
 
 			// Export and import two versions of the same policy
 			for _, policy := range operationPoliciesMap {
 				newPolicy := testutils.AddNewAPIPolicy(t, dev, user.ApiCreator.Username, user.ApiCreator.Password,
-					policy.Definition, policy.PolicyFile, true)
+					policy, true)
 				operationPolicy, _ := testutils.APIPolicyStructToMap(newPolicy)
 
 				args := &testutils.PolicyImportExportTestArgs{

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.gotmpl
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.gotmpl
@@ -1,0 +1,5 @@
+definition:
+  action: ADD_QUERY
+  parameters:
+    queryParamName: {{ .paramKey }}
+    queryParamValue: {{ .paramValue }}

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.j2
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.j2
@@ -1,0 +1,12 @@
+<property name="rest_postfix" expression="get-property('axis2', 'REST_URL_POSTFIX')"/>
+<filter regex=".*\?.*" source="get-property('rest_postfix')">
+		<!-- if there are query params already defined -->
+		<then>
+			<property name="REST_URL_POSTFIX" expression="fn:concat(get-property('rest_postfix'), '&amp;{{paramKey}}={{paramValue}}')" scope="axis2" type="STRING"/>
+		</then>
+
+		<!-- if there are no query params defined -->
+		<else>
+			<property name="REST_URL_POSTFIX" expression="fn:concat(get-property('rest_postfix'), '?{{paramKey}}={{paramValue}}')" scope="axis2" type="STRING"/>
+		</else>
+</filter>

--- a/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.yaml
+++ b/import-export-cli/integration/testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts/testSynapseChoreoConnectPolicy.yaml
@@ -1,0 +1,32 @@
+type: operation_policy_specification
+version: v4.2.0
+data:
+  category: Mediation
+  name: testSynapseChoreoConnectPolicy
+  version: v1
+  displayName: Test Synapse Choreo Connect Policy
+  description: This policy allows you to add a query parameter to the request
+  applicableFlows:
+   - request
+  supportedGateways:
+   - Synapse
+   - ChoreoConnect
+  supportedApiTypes:
+   - HTTP
+  policyAttributes:
+   -
+    name: paramKey
+    displayName: Parameter Key
+    description: Query parameter's key in URL encoded format
+    validationRegex: "^([a-zA-Z_\\%][a-zA-Z\\d_\\-\\ \\%]*)$"
+    type: String
+    allowedValues: []
+    required: true
+   -
+    name: paramValue
+    displayName: Parameter Value
+    description: Query parameter's value in URL encoded format
+    validationRegex: "^([a-zA-Z\\d_\\%][a-zA-Z\\d_\\-\\ \\%]*)$"
+    type: String
+    allowedValues: []
+    required: true

--- a/import-export-cli/integration/testutils/operationPolicy_testUtils.go
+++ b/import-export-cli/integration/testutils/operationPolicy_testUtils.go
@@ -279,17 +279,21 @@ func ValidateAPIPolicyExportImportFailureWhenPolicyExisted(t *testing.T, args *P
 }
 
 // Adds a new API Policy to an env
-func AddNewAPIPolicy(t *testing.T, client *apim.Client, username, password, pathToSpec, pathToSynapse string, doClean bool) interface{} {
+func AddNewAPIPolicy(t *testing.T, client *apim.Client, username, password string, policy PolicySpecFile, doClean bool) interface{} {
 	client.Login(username, password)
-	pathToPolicySpecFile, _ := filepath.Abs(pathToSpec)
-	pathToSynapseDefFile, _ := filepath.Abs(pathToSynapse)
+	pathToPolicySpecFile, _ := filepath.Abs(policy.Definition)
+	pathToSynapseDefFile, _ := filepath.Abs(policy.SynapsePolicyFile)
+	pathToChoroConnectDefFile := ""
+	if policy.CcPolicyFile != "" {
+		pathToChoroConnectDefFile, _ = filepath.Abs(policy.CcPolicyFile)
+	}
 	policyContent := readAPIPolicyDefinition(t, pathToPolicySpecFile)
 	policySpecFileData, err := json.Marshal(policyContent)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	createdPolicy := client.AddAPIPolicy(t, policySpecFileData, pathToSynapseDefFile, username, password, CleanUpFunction, doClean)
+	createdPolicy := client.AddAPIPolicy(t, policySpecFileData, pathToSynapseDefFile, pathToChoroConnectDefFile, username, password, CleanUpFunction, doClean)
 	return createdPolicy
 }
 

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -52,6 +52,7 @@ const DevFirstUpdatedSampleCaseDocMetaDataPath = DevFirstUpdatedSampleCaseArtifa
 const DevFirstUpdatedSampleCaseDestMetaDataPathSuffix = DevFirstUpdatedSampleCaseDocName + "/document.yaml"
 const DevFirstSampleCaseArtifactPath = "testdata/TestArtifactDirectory/DevFirstSampleCaseArtifacts"
 const DevFirstSampleCaseOperationPolicyArtifactPath = "testdata/TestArtifactDirectory/DevSampleCaseOperationPolicyArtifacts"
+const TestSynapseChoreoConnectPolicyArtifactsPath = "testdata/TestArtifactDirectory/TestSynapseChoreoConnectPolicyArtifacts"
 const CustomAddLogMessage = "testdata/TestArtifactDirectory/customAddLogMessage"
 const DevSampleCaseOperationPolicyArtifactsWithInconsistentFileNames = "testdata/TestArtifactDirectory/DevSampleCaseOperationPolicyArtifactsWithInconsistentFileNames/customAddLogMessage"
 const DevFirstSampleCaseMalformedOperationPolicyArtifactPath = "testdata/TestArtifactDirectory/DevSampleCaseMalformedOperationPolicyArtifacts/customAddLogMessage"
@@ -190,6 +191,9 @@ const DevFirstSampleCaseDestPolicyDefinition1PathSuffix = PoliciesDirectory + "/
 const DevFirstSampleCaseDestPolicyDefinition2PathSuffix = PoliciesDirectory + "/customAddLogMessage_v2.yaml"
 const DevFirstUpdatedSampleCasePolicy1Path = DevFirstUpdatedSampleCaseArtifactPath + "/customAddLogMessage_v1.j2"
 const DevFirstUpdatedSampleCasePolicyDefinition1Path = DevFirstUpdatedSampleCaseArtifactPath + "/customAddLogMessage_v1.yaml"
+const TestSynapseChoreoConnectPolicyDefinitionPath = TestSynapseChoreoConnectPolicyArtifactsPath + "/testSynapseChoreoConnectPolicy.yaml"
+const TestSynapseChoreoConnectPolicyPathForSynapseType = TestSynapseChoreoConnectPolicyArtifactsPath + "/testSynapseChoreoConnectPolicy.j2"
+const TestSynapseChoreoConnectPolicyPathForChoreoConnectType = TestSynapseChoreoConnectPolicyArtifactsPath + "/testSynapseChoreoConnectPolicy.gotmpl"
 
 const (
 	TestSampleOperationTarget                   = "/pet/{petId}"

--- a/import-export-cli/integration/testutils/testTypes.go
+++ b/import-export-cli/integration/testutils/testTypes.go
@@ -171,6 +171,7 @@ type ApiLoggingTestArgs struct {
 }
 
 type PolicySpecFile struct {
-	Definition string
-	PolicyFile string
+	Definition        string
+	SynapsePolicyFile string
+	CcPolicyFile      string
 }


### PR DESCRIPTION
## Purpose
Related to https://github.com/wso2/api-manager/issues/1274

## Goals
Adding a test to export/import an API Policy with Synapse and Choreo Connect gateways

## Approach
Added a new table-driven test as **TestExportImportAPIPolicyWithSynapseChoreoConnectTypes**