### PR TITLE
Fixing the TestImportProjectCreatedFromInvalidOpenAPI3Definition integration test failure

### DIFF
--- a/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
+++ b/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
@@ -143,5 +143,3 @@ components:
         title: List of schedule items information 
         type: array
         items:
-          $ref: '#/components/schemas/ScheduleItem'
-            

--- a/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
+++ b/import-export-cli/integration/testdata/invalidOpenAPI3Definition.yaml
@@ -143,3 +143,4 @@ components:
         title: List of schedule items information 
         type: array
         items:
+


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/api-manager/issues/1292

## Goals
Fixing the TestImportProjectCreatedFromInvalidOpenAPI3Definition integration test failure

## Approach
With the swagger validator update in APIM, the definitions with $ref are considered to be valid. Hence, TestImportProjectCreatedFromInvalidOpenAPI3Definition needs an invalid OAS definition, a $ref entry has been removed from the file.