### PR TITLE
Adding the correlation log configuration support

### DIFF
--- a/import-export-cli/cmd/get.go
+++ b/import-export-cli/cmd/get.go
@@ -27,7 +27,7 @@ const queryParamSeparator = " "
 
 // Get command related usage Info
 const GetCmdLiteral = "get"
-const getCmdShortDesc = "Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments"
+const getCmdShortDesc = "Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments"
 
 const getCmdLongDesc = `Display a list containing all the APIs available in the environment specified by flag (--environment, -e)/
 Display a list containing all the API Products available in the environment specified by flag (--environment, -e)/
@@ -35,7 +35,8 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
 Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
-Get the log level of each API in the environment specified by flag (--environment, -e)
+Get the log level of each API in the environment specified by flag (--environment, -e)/
+Get the correlation log configurations in the environment specified by flag (--environment, -e)
 OR
 List all the environments`
 
@@ -47,7 +48,8 @@ const getCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetEnvsCm
 ` + utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetAPIProductRevisionsCmdLiteral + ` -n PizzaProduct -v 1.0.0 -e dev
 ` + utils.ProjectName + " " + GetCmdLiteral + " " + GetKeysCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev
 ` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` -e dev --tenant-domain carbon.super
-` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --tenant-domain carbon.super`
+` + utils.ProjectName + " " + GetCmdLiteral + " " + GetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --tenant-domain carbon.super
+` + utils.ProjectName + " " + GetCmdLiteral + " " + GetCorrelationLoggingCmdLiteral + ` -e dev` 
 
 // ListCmd represents the list command
 var GetCmd = &cobra.Command{

--- a/import-export-cli/cmd/getCorrelationLogging.go
+++ b/import-export-cli/cmd/getCorrelationLogging.go
@@ -30,7 +30,8 @@ var getCorrelationLoggingCmdFormat string
 
 const GetCorrelationLoggingCmdLiteral = "correlation-logging"
 const getCorrelationLoggingCmdShortDesc = "Display a list of correlation logging components in an environment"
-const getCorrelationLoggingCmdLongDesc = `Display a list of correlation logging components available in the environment specified`
+const getCorrelationLoggingCmdLongDesc = `Display a list of correlation logging components available in the environment specified
+NOTE: The flag (--environment (-e)) is mandatory.`
 
 var getCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetCorrelationLoggingCmdLiteral + ` -e dev `
 
@@ -51,11 +52,11 @@ var getCorrelationLoggingCmd = &cobra.Command{
 
 func executeGetCorrelationLoggingCmd(credential credentials.Credential) {
 	components, err := impl.GetCorrelationLogComponentListFromEnv(credential, getCorrelationLoggingEnvironment)
-	
+
 	if err == nil {
 		impl.PrintCorrelationLoggers(components, getCorrelationLoggingCmdFormat)
 	} else {
-		utils.Logln(utils.LogPrefixError + "Getting list of correlation log configurations", err)
+		utils.Logln(utils.LogPrefixError+"Getting list of correlation log configurations", err)
 		utils.HandleErrorAndExit("Error while getting list of correlation log configurations", err)
 	}
 }
@@ -65,7 +66,7 @@ func init() {
 
 	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingEnvironment, "environment", "e",
 		"", "Environment which the correlation logging components should be displayed")
-	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingCmdFormat, "format", "", "", "Pretty-print Correlation loggers "+
-		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
+	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingCmdFormat, "format", "", "",
+		"Pretty-print correlation logging components using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
 	_ = getCorrelationLoggingCmd.MarkFlagRequired("environment")
 }

--- a/import-export-cli/cmd/getCorrelationLogging.go
+++ b/import-export-cli/cmd/getCorrelationLogging.go
@@ -1,0 +1,71 @@
+/*
+*  Copyright (c) WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 LLC licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var getCorrelationLoggingEnvironment string
+var getCorrelationLoggingCmdFormat string
+
+const GetCorrelationLoggingCmdLiteral = "correlation-logging"
+const getCorrelationLoggingCmdShortDesc = "Display a list of correlation logging components in an environment"
+const getCorrelationLoggingCmdLongDesc = `Display a list of correlation logging components available in the environment specified`
+
+var getCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + GetCmdLiteral + ` ` + GetCorrelationLoggingCmdLiteral + ` -e dev `
+
+var getCorrelationLoggingCmd = &cobra.Command{
+	Use:     GetCorrelationLoggingCmdLiteral,
+	Short:   getCorrelationLoggingCmdShortDesc,
+	Long:    getCorrelationLoggingCmdLongDesc,
+	Example: getCorrelationLoggingCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + GetCmdLiteral + " " + GetCorrelationLoggingCmdLiteral + " called")
+		cred, err := GetCredentials(getCorrelationLoggingEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeGetCorrelationLoggingCmd(cred)
+	},
+}
+
+func executeGetCorrelationLoggingCmd(credential credentials.Credential) {
+	components, err := impl.GetCorrelationLogComponentListFromEnv(credential, getCorrelationLoggingEnvironment)
+	
+	if err == nil {
+		impl.PrintCorrelationLoggers(components, getCorrelationLoggingCmdFormat)
+	} else {
+		utils.Logln(utils.LogPrefixError + "Getting list of correlation log configurations", err)
+		utils.HandleErrorAndExit("Error while getting list of correlation log configurations", err)
+	}
+}
+
+func init() {
+	GetCmd.AddCommand(getCorrelationLoggingCmd)
+
+	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingEnvironment, "environment", "e",
+		"", "Environment which the correlation logging components should be displayed")
+	getCorrelationLoggingCmd.Flags().StringVarP(&getCorrelationLoggingCmdFormat, "format", "", "", "Pretty-print Correlation loggers "+
+		"using Go Templates. Use \"{{ jsonPretty . }}\" to list all fields")
+	_ = getCorrelationLoggingCmd.MarkFlagRequired("environment")
+}

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -43,7 +43,7 @@ const flagVCSDeploymentRepoPathName = "vcs-deployment-repo-path"
 
 // Set command related Info
 const SetCmdLiteral = "set"
-const setCmdShortDesc = "Set configuration parameters or per API log levels"
+const setCmdShortDesc = "Set configuration parameters, per API log levels or correlation component configurations"
 
 const setCmdLongDesc = `Set configuration parameters. You can use one of the following flags
 * --http-request-timeout <time-in-milli-seconds>
@@ -62,7 +62,8 @@ const setCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` --http-reques
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-config-path /home/user/custom/vcs-config.yaml
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-deployment-repo-path /home/user/custom/deployment
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-source-repo-path /home/user/custom/source
-` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super`
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetApiLoggingCmdLiteral + ` --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name http --enable true -e dev`
 
 // SetCmd represents the 'set' command
 var SetCmd = &cobra.Command{

--- a/import-export-cli/cmd/setCorrelationLogging.go
+++ b/import-export-cli/cmd/setCorrelationLogging.go
@@ -1,0 +1,93 @@
+/*
+*  Copyright (c) WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+*
+*  WSO2 LLC licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var setCorrelationLoggingEnvironment string
+var setCorrelationLoggingComponentName string
+var setCorrelationLoggingDeniedThreads string
+var setCorrelationLoggingEnabled string
+
+const SetCorrelationLoggingCmdLiteral = "correlation-logging"
+const setCorrelationLoggingCmdShortDesc = "Set the correlation configs for a correlation logging component in an environment"
+const setCorrelationLoggingCmdLongDesc = `Set the correlation configs for a correlation logging component the environment specified`
+
+var setCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name http --enable true -e dev
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer  -e dev`
+
+var setCorrelationLoggingCmd = &cobra.Command{
+	Use:     SetCorrelationLoggingCmdLiteral,
+	Short:   setCorrelationLoggingCmdShortDesc,
+	Long:    setCorrelationLoggingCmdLongDesc,
+	Example: setCorrelationLoggingCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + SetCmdLiteral + " " + SetCorrelationLoggingCmdLiteral + " called")
+		cred, err := GetCredentials(setCorrelationLoggingEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeSetCorrelationLoggingCmd(cred)
+	},
+}
+
+func executeSetCorrelationLoggingCmd(credential credentials.Credential) {
+	resp, err := impl.SetCorrelationLoggingComponent(credential, setCorrelationLoggingEnvironment, setCorrelationLoggingComponentName, setCorrelationLoggingEnabled, setCorrelationLoggingDeniedThreads)
+	if err != nil {
+		utils.Logln(utils.LogPrefixError+"Setting the correlation log component configs", err)
+		utils.HandleErrorAndExit("Error while setting the correlation log component configs", err)
+	}
+	// Print info on response
+	utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp)
+	if resp.StatusCode() == http.StatusOK { 
+		// 200 OK
+		if strings.ToLower(setCorrelationLoggingEnabled) == "true" {
+			fmt.Println("Correlation component " + setCorrelationLoggingComponentName + " is successfully enabled.")
+		} else {
+			fmt.Println("Correlation component " + setCorrelationLoggingComponentName + " is successfully disabled.")
+		}
+	} else {
+		fmt.Println("Setting the correlation components : ", resp.Status(), "\n", string(resp.Body()))
+	}
+}
+
+func init() {
+	SetCmd.AddCommand(setCorrelationLoggingCmd)
+
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingComponentName, "component-name", "i",
+		"", "Component Name")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingEnabled, "enable", "",
+		"", "Enable - true or false")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingDeniedThreads, "denied-threads", "",
+		"", "Denied Threads")
+	setCorrelationLoggingCmd.Flags().StringVarP(&setCorrelationLoggingEnvironment, "environment", "e",
+		"", "Environment where the correlation component configuration should be set")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("environment")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("component-name")
+	_ = setCorrelationLoggingCmd.MarkFlagRequired("enabled")
+}

--- a/import-export-cli/cmd/setCorrelationLogging.go
+++ b/import-export-cli/cmd/setCorrelationLogging.go
@@ -36,10 +36,11 @@ var setCorrelationLoggingEnabled string
 
 const SetCorrelationLoggingCmdLiteral = "correlation-logging"
 const setCorrelationLoggingCmdShortDesc = "Set the correlation configs for a correlation logging component in an environment"
-const setCorrelationLoggingCmdLongDesc = `Set the correlation configs for a correlation logging component the environment specified`
+const setCorrelationLoggingCmdLongDesc = `Set the correlation configs for a correlation logging component in the environment specified
+NOTE: The flags (--component-name (-i), --enable and --environment (-e)) are mandatory.`
 
 var setCorrelationLoggingCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name http --enable true -e dev
-` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer  -e dev`
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` ` + SetCorrelationLoggingCmdLiteral + ` --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer -e dev`
 
 var setCorrelationLoggingCmd = &cobra.Command{
 	Use:     SetCorrelationLoggingCmdLiteral,
@@ -64,7 +65,7 @@ func executeSetCorrelationLoggingCmd(credential credentials.Credential) {
 	}
 	// Print info on response
 	utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp)
-	if resp.StatusCode() == http.StatusOK { 
+	if resp.StatusCode() == http.StatusOK {
 		// 200 OK
 		if strings.ToLower(setCorrelationLoggingEnabled) == "true" {
 			fmt.Println("Correlation component " + setCorrelationLoggingComponentName + " is successfully enabled.")

--- a/import-export-cli/cmd/setCorrelationLogging.go
+++ b/import-export-cli/cmd/setCorrelationLogging.go
@@ -58,7 +58,8 @@ var setCorrelationLoggingCmd = &cobra.Command{
 }
 
 func executeSetCorrelationLoggingCmd(credential credentials.Credential) {
-	resp, err := impl.SetCorrelationLoggingComponent(credential, setCorrelationLoggingEnvironment, setCorrelationLoggingComponentName, setCorrelationLoggingEnabled, setCorrelationLoggingDeniedThreads)
+	resp, err := impl.SetCorrelationLoggingComponent(credential, setCorrelationLoggingEnvironment,
+		setCorrelationLoggingComponentName, setCorrelationLoggingEnabled, setCorrelationLoggingDeniedThreads)
 	if err != nil {
 		utils.Logln(utils.LogPrefixError+"Setting the correlation log component configs", err)
 		utils.HandleErrorAndExit("Error while setting the correlation log component configs", err)

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -28,7 +28,7 @@ apictl [flags]
 * [apictl delete](apictl_delete.md)	 - Delete an API/APIProduct/Application in an environment
 * [apictl export](apictl_export.md)	 - Export an API/API Product/Application/Policy in an environment
 * [apictl gen](apictl_gen.md)	 - Generate deployment directory for VM and K8S operator
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 * [apictl import](apictl_import.md)	 - Import an API/API Product/Application to an environment
 * [apictl init](apictl_init.md)	 - Initialize a new project in given path
 * [apictl k8s](apictl_k8s.md)	 - Kubernetes mode based commands
@@ -38,7 +38,7 @@ apictl [flags]
 * [apictl mi](apictl_mi.md)	 - Micro Integrator related commands
 * [apictl remove](apictl_remove.md)	 - Remove an environment
 * [apictl secret](apictl_secret.md)	 - Manage sensitive information
-* [apictl set](apictl_set.md)	 - Set configuration parameters or per API log levels
+* [apictl set](apictl_set.md)	 - Set configuration parameters, per API log levels or correlation component configurations
 * [apictl undeploy](apictl_undeploy.md)	 - Undeploy an API/API Product revision from a gateway environment
 * [apictl vcs](apictl_vcs.md)	 - Checks status and deploys projects
 * [apictl version](apictl_version.md)	 - Display Version on current apictl

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -1,6 +1,6 @@
 ## apictl get
 
-Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 
 ### Synopsis
 
@@ -10,7 +10,8 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
 Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
-Get the log level of each API in the environment specified by flag (--environment, -e)
+Get the log level of each API in the environment specified by flag (--environment, -e)/
+Get the correlation log configurations in the environment specified by flag (--environment, -e)
 OR
 List all the environments
 
@@ -30,6 +31,7 @@ apictl get api-product-revisions -n PizzaProduct -v 1.0.0 -e dev
 apictl get keys -n TwitterAPI -v 1.0.0 -e dev
 apictl get api-logging -e dev --tenant-domain carbon.super
 apictl get api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --tenant-domain carbon.super
+apictl get correlation-logging -e dev
 ```
 
 ### Options
@@ -54,6 +56,7 @@ apictl get api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --te
 * [apictl get api-revisions](apictl_get_api-revisions.md)	 - Display a list of Revisions for the API
 * [apictl get apis](apictl_get_apis.md)	 - Display a list of APIs in an environment
 * [apictl get apps](apictl_get_apps.md)	 - Display a list of Applications in an environment specific to an owner
+* [apictl get correlation-logging](apictl_get_correlation-logging.md)	 - Display a list of correlation logging components in an environment
 * [apictl get envs](apictl_get_envs.md)	 - Display the list of environments
 * [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API or API Product
 * [apictl get policies](apictl_get_policies.md)	 - Get Policy list

--- a/import-export-cli/docs/apictl_get_api-logging.md
+++ b/import-export-cli/docs/apictl_get_api-logging.md
@@ -36,5 +36,5 @@ apictl get api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 -e dev --te
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_api-product-revisions.md
+++ b/import-export-cli/docs/apictl_get_api-product-revisions.md
@@ -39,5 +39,5 @@ NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are m
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_api-products.md
+++ b/import-export-cli/docs/apictl_get_api-products.md
@@ -40,5 +40,5 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_api-revisions.md
+++ b/import-export-cli/docs/apictl_get_api-revisions.md
@@ -40,5 +40,5 @@ NOTE: All the 3 flags (--name (-n), --version (-v) and --environment (-e)) are m
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_apis.md
+++ b/import-export-cli/docs/apictl_get_apis.md
@@ -40,5 +40,5 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_apps.md
+++ b/import-export-cli/docs/apictl_get_apps.md
@@ -40,5 +40,5 @@ NOTE: The flag (--environment (-e)) is mandatory
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_correlation-logging.md
+++ b/import-export-cli/docs/apictl_get_correlation-logging.md
@@ -1,0 +1,38 @@
+## apictl get correlation-logging
+
+Display a list of correlation logging components in an environment
+
+### Synopsis
+
+Display a list of correlation logging components available in the environment specified
+NOTE: The flag (--environment (-e)) is mandatory.
+
+```
+apictl get correlation-logging [flags]
+```
+
+### Examples
+
+```
+apictl get correlation-logging -e dev 
+```
+
+### Options
+
+```
+  -e, --environment string   Environment which the correlation logging components should be displayed
+      --format string        Pretty-print correlation logging components using Go Templates. Use "{{ jsonPretty . }}" to list all fields
+  -h, --help                 help for correlation-logging
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
+

--- a/import-export-cli/docs/apictl_get_envs.md
+++ b/import-export-cli/docs/apictl_get_envs.md
@@ -32,5 +32,5 @@ apictl list envs
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_keys.md
+++ b/import-export-cli/docs/apictl_get_keys.md
@@ -38,5 +38,5 @@ You can override the default token endpoint using --token (-t) optional flag pro
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 

--- a/import-export-cli/docs/apictl_get_policies.md
+++ b/import-export-cli/docs/apictl_get_policies.md
@@ -31,7 +31,7 @@ apictl get policies rate-limiting -e production -q type:sub
 
 ### SEE ALSO
 
-* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the log level of each API in an environment or Get the environments
+* [apictl get](apictl_get.md)	 - Get APIs/APIProducts/Applications or revisions of a specific API/APIProduct in an environment or Get the Correlation Log Configurations or Get the log level of each API in an environment or Get the environments
 * [apictl get policies api](apictl_get_policies_api.md)	 - Display a list of API Policies
 * [apictl get policies rate-limiting](apictl_get_policies_rate-limiting.md)	 - Display a list of APIs in an environment
 

--- a/import-export-cli/docs/apictl_import_policy.md
+++ b/import-export-cli/docs/apictl_import_policy.md
@@ -14,7 +14,7 @@ apictl import policy [flags]
 
 ```
 apictl import policy rate-limiting -f ~/CustomPolicy -e production -u
-apictl import policy api -f ~/AddHeader -e production
+apictl import policy api  -f ~/AddHeader -e production
 ```
 
 ### Options

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -1,6 +1,6 @@
 ## apictl set
 
-Set configuration parameters or per API log levels
+Set configuration parameters, per API log levels or correlation component configurations
 
 ### Synopsis
 
@@ -29,6 +29,7 @@ apictl set --vcs-config-path /home/user/custom/vcs-config.yaml
 apictl set --vcs-deployment-repo-path /home/user/custom/deployment
 apictl set --vcs-source-repo-path /home/user/custom/source
 apictl set api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super
+apictl set correlation-logging --component-name http --enable true -e dev
 ```
 
 ### Options
@@ -55,4 +56,5 @@ apictl set api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level
 
 * [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
 * [apictl set api-logging](apictl_set_api-logging.md)	 - Set the log level for an API in an environment
+* [apictl set correlation-logging](apictl_set_correlation-logging.md)	 - Set the correlation configs for a correlation logging component in an environment
 

--- a/import-export-cli/docs/apictl_set_api-logging.md
+++ b/import-export-cli/docs/apictl_set_api-logging.md
@@ -36,5 +36,5 @@ apictl set api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level
 
 ### SEE ALSO
 
-* [apictl set](apictl_set.md)	 - Set configuration parameters or per API log levels
+* [apictl set](apictl_set.md)	 - Set configuration parameters, per API log levels or correlation component configurations
 

--- a/import-export-cli/docs/apictl_set_correlation-logging.md
+++ b/import-export-cli/docs/apictl_set_correlation-logging.md
@@ -1,0 +1,41 @@
+## apictl set correlation-logging
+
+Set the correlation configs for a correlation logging component in an environment
+
+### Synopsis
+
+Set the correlation configs for a correlation logging component in the environment specified
+NOTE: The flags (--component-name (-i), --enable and --environment (-e)) are mandatory.
+
+```
+apictl set correlation-logging [flags]
+```
+
+### Examples
+
+```
+apictl set correlation-logging --component-name http --enable true -e dev
+apictl set correlation-logging --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer -e dev
+```
+
+### Options
+
+```
+  -i, --component-name string   Component Name
+      --denied-threads string   Denied Threads
+      --enable string           Enable - true or false
+  -e, --environment string      Environment where the correlation component configuration should be set
+  -h, --help                    help for correlation-logging
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl set](apictl_set.md)	 - Set configuration parameters, per API log levels or correlation component configurations
+

--- a/import-export-cli/impl/logger.go
+++ b/import-export-cli/impl/logger.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"os"
+	"strings"
 	"text/template"
 
 	"net/http"
@@ -40,7 +40,7 @@ const (
 	loggingApiContextHeader  = "API_CONTEXT"
 	loggingApiLogLevelHeader = "LOG_LEVEL"
 
-	defaultLoggingApiTableFormat = "table {{.Id}}\t{{.Context}}\t{{.LogLevel}}"
+	defaultLoggingApiTableFormat         = "table {{.Id}}\t{{.Context}}\t{{.LogLevel}}"
 	defaultLoggingCorrelationTableFormat = "table {{.Name}}\t{{.Enabled}}\t{{.Properties}}"
 )
 
@@ -51,17 +51,16 @@ type loggingApi struct {
 	logLevel string
 }
 
-
 type loggingCorrelationComponent struct {
-	name 			string
-	enabled 		string
-	properties 		string
+	name       string
+	enabled    string
+	properties string
 }
 
 func newLoggingCorrelationComponentFromComponent(component utils.CorrelationComponent) *loggingCorrelationComponent {
 	if len(component.Properties) > 0 {
-		return &loggingCorrelationComponent{component.Name, component.Enabled, component.Properties[len(component.Properties)-1].Name + 
-			" : "  + strings.Join(component.Properties[len(component.Properties)-1].Value, ", ")}
+		return &loggingCorrelationComponent{component.Name, component.Enabled, component.Properties[len(component.Properties)-1].Name +
+			" : " + strings.Join(component.Properties[len(component.Properties)-1].Value, ", ")}
 	}
 	return &loggingCorrelationComponent{component.Name, component.Enabled, "-"}
 }
@@ -234,20 +233,20 @@ func SetAPILoggingLevel(credential credentials.Credential, environment, apiId, t
 	}
 }
 
-// GET Correlation Components List 
+// GET Correlation Components List
 func GetCorrelationLogComponentListFromEnv(credential credentials.Credential, environment string) (components []utils.CorrelationComponent, err error) {
 	// Base64 encoding the credentials
 	b64encodedCredentials := credentials.GetBasicAuth(credential)
 	// Prepping the headers
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
-	
+
 	correlationDevOpsEP := utils.GetCorrelationLoggingEndPointOfEnv(environment, utils.MainConfigFilePath)
-	utils.Logln(utils.LogPrefixInfo+"URL : " + correlationDevOpsEP)
+	utils.Logln(utils.LogPrefixInfo + "URL : " + correlationDevOpsEP)
 	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
 
 	if err != nil {
-		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+		utils.HandleErrorAndExit("Unable to connect to "+correlationDevOpsEP, err)
 	}
 
 	utils.Logln(utils.LogPrefixInfo + "Response : " + resp.Status())
@@ -257,13 +256,12 @@ func GetCorrelationLogComponentListFromEnv(credential credentials.Credential, en
 		unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
 
 		if unmarshalError != nil {
-			utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+			utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
 		}
-		return correlationComponentsResponse.Components, nil 
+		return correlationComponentsResponse.Components, nil
 	}
 	return nil, errors.New(string(resp.Body()))
 }
-
 
 func PrintCorrelationLoggers(components []utils.CorrelationComponent, format string) {
 	if format == "" {
@@ -272,7 +270,7 @@ func PrintCorrelationLoggers(components []utils.CorrelationComponent, format str
 
 	formatContext := formatter.NewContext(os.Stdout, format)
 
-	renderer := func (w io.Writer, t *template.Template) error {
+	renderer := func(w io.Writer, t *template.Template) error {
 		for _, component := range components {
 			if err := t.Execute(w, newLoggingCorrelationComponentFromComponent(component)); err != nil {
 				return err
@@ -281,10 +279,10 @@ func PrintCorrelationLoggers(components []utils.CorrelationComponent, format str
 		}
 		return nil
 	}
-	
+
 	correlationTableHeaders := map[string]string{
-		"Name": "COMPONENT_NAME", 
-		"Enabled": "ENABLED",
+		"Name":       "COMPONENT_NAME",
+		"Enabled":    "ENABLED",
 		"Properties": "PROPERTIES",
 	}
 
@@ -306,7 +304,7 @@ func SetCorrelationLoggingComponent(credential credentials.Credential, environme
 	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
 
 	if err != nil {
-		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+		utils.HandleErrorAndExit("Unable to connect to "+correlationDevOpsEP, err)
 	}
 
 	utils.Logln(utils.LogPrefixInfo + "GET Response : " + resp.Status())
@@ -319,30 +317,30 @@ func SetCorrelationLoggingComponent(credential credentials.Credential, environme
 	unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
 
 	if unmarshalError != nil {
-		utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+		utils.HandleErrorAndExit(utils.LogPrefixError+"invalid JSON response", unmarshalError)
 	}
 
 	responseComponents := correlationComponentsResponse.Components
-	requestComponents  := make([]utils.CorrelationComponent,0)
+	requestComponents := make([]utils.CorrelationComponent, 0)
 
-	for  _ , cc := range  responseComponents{
+	for _, cc := range responseComponents {
 		if cc.Name == componentName {
 			cc.Enabled = enabled
-			if(len(cc.Properties)>0){
-				if(cc.Properties[len(cc.Properties)-1].Name == "deniedThreads"){
+			if len(cc.Properties) > 0 {
+				if cc.Properties[len(cc.Properties)-1].Name == "deniedThreads" {
 					cc.Properties[len(cc.Properties)-1].Value = strings.Split(deniedThreads, ",")
 				}
 			}
 		}
 		requestComponents = append(requestComponents, cc)
 	}
-	
-	b,err := json.Marshal(requestComponents)
+
+	b, err := json.Marshal(requestComponents)
 	if err != nil {
-		utils.Logln("Error when creating a json ")		
-		return nil, nil 
+		utils.Logln("Error when creating a json ")
+		return nil, nil
 	}
-	
+
 	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
 	body := string(b)
 	body = "{\"components\":" + body + "}"

--- a/import-export-cli/impl/logger.go
+++ b/import-export-cli/impl/logger.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"os"
 	"text/template"
 
@@ -40,6 +41,7 @@ const (
 	loggingApiLogLevelHeader = "LOG_LEVEL"
 
 	defaultLoggingApiTableFormat = "table {{.Id}}\t{{.Context}}\t{{.LogLevel}}"
+	defaultLoggingCorrelationTableFormat = "table {{.Name}}\t{{.Enabled}}\t{{.Properties}}"
 )
 
 // LoggingApi holds information about an API for outputting
@@ -47,6 +49,33 @@ type loggingApi struct {
 	id       string
 	context  string
 	logLevel string
+}
+
+
+type loggingCorrelationComponent struct {
+	name 			string
+	enabled 		string
+	properties 		string
+}
+
+func newLoggingCorrelationComponentFromComponent(component utils.CorrelationComponent) *loggingCorrelationComponent {
+	if len(component.Properties) > 0 {
+		return &loggingCorrelationComponent{component.Name, component.Enabled, component.Properties[len(component.Properties)-1].Name + 
+			" : "  + strings.Join(component.Properties[len(component.Properties)-1].Value, ", ")}
+	}
+	return &loggingCorrelationComponent{component.Name, component.Enabled, "-"}
+}
+
+func (component loggingCorrelationComponent) Name() string {
+	return component.name
+}
+
+func (component loggingCorrelationComponent) Enabled() string {
+	return component.enabled
+}
+
+func (component loggingCorrelationComponent) Properties() string {
+	return component.properties
 }
 
 // Creates a new api from utils.APILogger
@@ -203,4 +232,129 @@ func SetAPILoggingLevel(credential credentials.Credential, environment, apiId, t
 	} else {
 		return nil, errors.New(string(resp.Body()))
 	}
+}
+
+// GET Correlation Components List 
+func GetCorrelationLogComponentListFromEnv(credential credentials.Credential, environment string) (components []utils.CorrelationComponent, err error) {
+	// Base64 encoding the credentials
+	b64encodedCredentials := credentials.GetBasicAuth(credential)
+	// Prepping the headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+	
+	correlationDevOpsEP := utils.GetCorrelationLoggingEndPointOfEnv(environment, utils.MainConfigFilePath)
+	utils.Logln(utils.LogPrefixInfo+"URL : " + correlationDevOpsEP)
+	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo + "Response : " + resp.Status())
+
+	if resp.StatusCode() == http.StatusOK {
+		correlationComponentsResponse := &utils.CorrelationComponentList{}
+		unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
+
+		if unmarshalError != nil {
+			utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+		}
+		return correlationComponentsResponse.Components, nil 
+	}
+	return nil, errors.New(string(resp.Body()))
+}
+
+
+func PrintCorrelationLoggers(components []utils.CorrelationComponent, format string) {
+	if format == "" {
+		format = defaultLoggingCorrelationTableFormat
+	}
+
+	formatContext := formatter.NewContext(os.Stdout, format)
+
+	renderer := func (w io.Writer, t *template.Template) error {
+		for _, component := range components {
+			if err := t.Execute(w, newLoggingCorrelationComponentFromComponent(component)); err != nil {
+				return err
+			}
+			_, _ = w.Write([]byte{'\n'})
+		}
+		return nil
+	}
+	
+	correlationTableHeaders := map[string]string{
+		"Name": "COMPONENT_NAME", 
+		"Enabled": "ENABLED",
+		"Properties": "PROPERTIES",
+	}
+
+	if err := formatContext.Write(renderer, correlationTableHeaders); err != nil {
+		fmt.Println("Error executing template", err.Error())
+	}
+}
+func SetCorrelationLoggingComponent(credential credentials.Credential, environment, componentName, enabled, deniedThreads string) (*resty.Response, error) {
+	// Base64 encoding the credentials
+	b64encodedCredentials := credentials.GetBasicAuth(credential)
+
+	correlationDevOpsEP := utils.GetCorrelationLoggingEndPointOfEnv(environment, utils.MainConfigFilePath)
+
+	// Prepping the headers
+	headers := make(map[string]string)
+	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBasicPrefix + " " + b64encodedCredentials
+	headers[utils.HeaderAccept] = utils.HeaderValueApplicationJSON
+
+	resp, err := utils.InvokeGETRequest(correlationDevOpsEP, headers)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to " + correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo + "GET Response : " + resp.Status())
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, errors.New(string(resp.Body()))
+	}
+
+	correlationComponentsResponse := &utils.CorrelationComponentList{}
+	unmarshalError := json.Unmarshal([]byte(resp.Body()), &correlationComponentsResponse)
+
+	if unmarshalError != nil {
+		utils.HandleErrorAndExit(utils.LogPrefixError + "invalid JSON response", unmarshalError)
+	}
+
+	responseComponents := correlationComponentsResponse.Components
+	requestComponents  := make([]utils.CorrelationComponent,0)
+
+	for  _ , cc := range  responseComponents{
+		if cc.Name == componentName {
+			cc.Enabled = enabled
+			if(len(cc.Properties)>0){
+				if(cc.Properties[len(cc.Properties)-1].Name == "deniedThreads"){
+					cc.Properties[len(cc.Properties)-1].Value = strings.Split(deniedThreads, ",")
+				}
+			}
+		}
+		requestComponents = append(requestComponents, cc)
+	}
+	
+	b,err := json.Marshal(requestComponents)
+	if err != nil {
+		utils.Logln("Error when creating a json ")		
+		return nil, nil 
+	}
+	
+	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
+	body := string(b)
+	body = "{\"components\":" + body + "}"
+	putResp, err := utils.InvokePutRequest(nil, correlationDevOpsEP, headers, body)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Unable to connect to "+correlationDevOpsEP, err)
+	}
+
+	utils.Logln(utils.LogPrefixInfo+"PUT Response:", putResp.Status())
+	if putResp.StatusCode() == http.StatusOK {
+		return putResp, nil
+	}
+	return nil, errors.New(string(putResp.Body()))
 }

--- a/import-export-cli/resources/README.html
+++ b/import-export-cli/resources/README.html
@@ -402,6 +402,19 @@
         </code></pre>
     </li>
     <li>
+        <h4 id="get-correlation-logging">get correlation-logging</h4>
+        <pre><code class="lang-bash">
+     Flags:
+         Required
+                 --environment, -e
+
+         Optional
+                 --format
+     Examples:
+         apictl get correlation-logging -e dev
+        </code></pre>
+    </li>
+    <li>
         <h4 id="get-envs">get envs</h4>
         <pre><code class="lang-bash">     Flags:
          None
@@ -502,6 +515,23 @@
       Examples:
           apictl set api-logging -e dev --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full
           apictl set api-logging -e dev --tenant-domain test.com --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full
+</code></pre>
+    </li>
+    <li>
+        <h4 id="set-correlation-logging">set correlation-logging</h4>
+        <pre><code class="lang-bash">
+      Flags:      
+        Required:
+            --environment, -e
+            --component-name, -i
+            --enable
+
+        Optional:
+            --denied-threads
+
+      Examples:
+          apictl set correlation-logging --component-name http --enable true -e dev
+          apictl set correlation-logging --component-name jdbc --enable true --denied-threads MessageDeliveryTaskThreadPool,HumanTaskServer,BPELServer  -e dev
 </code></pre>
     </li>
 </ul>

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -2024,6 +2024,45 @@ _apictl_get_apps()
     noun_aliases=()
 }
 
+_apictl_get_correlation-logging()
+{
+    last_command="apictl_get_correlation-logging"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--format=")
+    two_word_flags+=("--format")
+    local_nonpersistent_flags+=("--format")
+    local_nonpersistent_flags+=("--format=")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_get_envs()
 {
     last_command="apictl_get_envs"
@@ -2299,6 +2338,7 @@ _apictl_get()
     commands+=("api-revisions")
     commands+=("apis")
     commands+=("apps")
+    commands+=("correlation-logging")
     commands+=("envs")
     commands+=("help")
     commands+=("keys")
@@ -5896,6 +5936,57 @@ _apictl_set_api-logging()
     noun_aliases=()
 }
 
+_apictl_set_correlation-logging()
+{
+    last_command="apictl_set_correlation-logging"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--component-name=")
+    two_word_flags+=("--component-name")
+    two_word_flags+=("-i")
+    local_nonpersistent_flags+=("--component-name")
+    local_nonpersistent_flags+=("--component-name=")
+    local_nonpersistent_flags+=("-i")
+    flags+=("--denied-threads=")
+    two_word_flags+=("--denied-threads")
+    local_nonpersistent_flags+=("--denied-threads")
+    local_nonpersistent_flags+=("--denied-threads=")
+    flags+=("--enable=")
+    two_word_flags+=("--enable")
+    local_nonpersistent_flags+=("--enable")
+    local_nonpersistent_flags+=("--enable=")
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--component-name=")
+    must_have_one_flag+=("-i")
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_set_help()
 {
     last_command="apictl_set_help"
@@ -5928,6 +6019,7 @@ _apictl_set()
 
     commands=()
     commands+=("api-logging")
+    commands+=("correlation-logging")
     commands+=("help")
 
     flags=()

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -109,6 +109,7 @@ const defaultTokenEndPoint = "oauth2/token"
 const defaultRevokeEndpointSuffix = "oauth2/revoke"
 const defaultAPILoggingBaseEndpoint = "api/am/devops/v0/tenant-logs"
 const defaultAPILoggingApisEndpoint = "apis"
+const defaultCorrelationLoggingEndpoint = "api/am/devops/v0/config/correlation"
 
 const DefaultEnvironmentName = "default"
 const DefaultTenantDomain = "carbon.super"

--- a/import-export-cli/utils/envManagementUtils.go
+++ b/import-export-cli/utils/envManagementUtils.go
@@ -334,6 +334,18 @@ func GetAPILoggingSetEndpointOfEnv(env, apiId, tenantDomain, filePath string) st
 	}
 }
 
+func GetCorrelationLoggingEndPointOfEnv(env, filePath string) string {
+	envEndpoints, _ := GetEndpointsOfEnvironment(env, filePath)	
+	if !(envEndpoints.PublisherEndpoint == "" || envEndpoints == nil) {
+		envEndpoints.PublisherEndpoint = AppendSlashToString(envEndpoints.PublisherEndpoint)
+		return envEndpoints.PublisherEndpoint + defaultCorrelationLoggingEndpoint
+	} else {
+		apiManagerEndpoint := GetApiManagerEndpointOfEnv(env, filePath)
+		apiManagerEndpoint = AppendSlashToString(apiManagerEndpoint)
+		return apiManagerEndpoint + defaultCorrelationLoggingEndpoint
+	}	
+}
+
 // Get username of an environment given the environment
 func GetUsernameOfEnv(env, filePath string) string {
 	envKeys, _ := GetKeysOfEnvironment(env, filePath)

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -97,6 +97,21 @@ type Application struct {
 	GroupID string `json:"groupId"`
 }
 
+type CorrelationComponent struct {
+	Name		string `json:"name"`
+	Enabled		string `json:"enabled"`
+	Properties	[]CorrelationProperties `json:"properties"`
+}
+
+type CorrelationProperties struct {
+	Name		string `json:"name"`
+	Value		[]string `json:"value"`
+}
+
+type CorrelationComponentList struct {
+	Components	[]CorrelationComponent `json:"components"`
+}
+
 type APILogger struct {
 	ID       string `json:"apiId"`
 	Context  string `json:"context"`


### PR DESCRIPTION
## Purpose
Fixes: wso2/api-manager#275
Fixes: wso2/api-manager#566

## Goals
Adding the correlation log support of APIM to APICTL

## Approach
Refactoring the draft PR in [1].
- Introduced a command to get correlation logging configurations of different components in an environment.
- Introduced a command to set correlation logging configurations of different components in an environment.

[1] https://github.com/wso2/product-apim-tooling/pull/930