### PR TITLE
Build ARM64 binary and rename final ZIP file name

### DIFF
--- a/import-export-cli/build.sh
+++ b/import-export-cli/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function showUsageAndExit() {
     echo "Insufficient or invalid options provided"
@@ -87,7 +88,8 @@ fi
 if [ "${full_build}" == "true" ]; then
 # the following line give an error in MacOS
 #    echo "Building "$'\e[1m'"${filename^^}:${build_version}"$'\e[0m'" for all platforms..."
-    platforms="darwin/amd64/macosx/x64 linux/386/linux/i586 linux/amd64/linux/x64 windows/386/windows/i586 windows/amd64/windows/x64"
+    # string format: {GOOS}/{GOARCH}/{ZIP_FILE_OS_NAME}/{ZIP_FILE_ARCH_NAME}
+    platforms="darwin/amd64/darwin/amd64 darwin/arm64/darwin/arm64 linux/386/linux/i586 linux/arm64/linux/arm64 linux/amd64/linux/amd64 windows/386/windows/i586 windows/amd64/windows/x64"
 else
     detectPlatformSpecificBuild
     echo "Building "$'\e[1m'"${filename^^}:${build_version}"$'\e[0m'" for detected "$'\e[1m'"${platform}"$'\e[0m'" platform..."


### PR DESCRIPTION
## Purpose
$ subject
Fix https://github.com/wso2/api-manager/issues/1165

#### GOARCH

Supported GOARCH: https://stackoverflow.com/questions/20728767/all-possible-goos-value

```go
const goosList = "android darwin dragonfly freebsd linux nacl \ 
  netbsd openbsd plan9 solaris windows "

const goarchList = "386 amd64 amd64p32 arm arm64 ppc64 ppc64le \
   mips mipsle mips64 mips64le mips64p32 mips64p32le \ # (new)
   ppc s390 s390x sparc sparc64 " # (new)
```

i386 refers to the 32-bit edition and amd64: https://askubuntu.com/questions/54296/difference-between-the-i386-download-and-the-amd64

#### Naming in other distributions

##### Kubectl

https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/
- AMD: https://dl.k8s.io/release/v1.26.0/bin/darwin/amd64/kubectl
- ARM: https://dl.k8s.io/release/v1.26.0/bin/darwin/arm64/kubectl

##### Istio

https://github.com/istio/istio/releases

- istio-1.16.2-linux-amd64.tar.gz
- istio-1.16.2-linux-arm64.tar.gz
- istio-1.16.2-osx-arm64.tar.gz
- istio-1.16.2-osx.tar.gz
