### PR TITLE
Revert "Revert "Build ARM64 binary and rename final ZIP file name""

### DIFF
--- a/import-export-cli/build.sh
+++ b/import-export-cli/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function showUsageAndExit() {
     echo "Insufficient or invalid options provided"
@@ -87,7 +88,8 @@ fi
 if [ "${full_build}" == "true" ]; then
 # the following line give an error in MacOS
 #    echo "Building "$'\e[1m'"${filename^^}:${build_version}"$'\e[0m'" for all platforms..."
-    platforms="darwin/amd64/macosx/x64 linux/386/linux/i586 linux/amd64/linux/x64 windows/386/windows/i586 windows/amd64/windows/x64"
+    # string format: {GOOS}/{GOARCH}/{ZIP_FILE_OS_NAME}/{ZIP_FILE_ARCH_NAME}
+    platforms="darwin/amd64/darwin/amd64 darwin/arm64/darwin/arm64 linux/386/linux/i586 linux/arm64/linux/arm64 linux/amd64/linux/amd64 windows/386/windows/i586 windows/amd64/windows/x64"
 else
     detectPlatformSpecificBuild
     echo "Building "$'\e[1m'"${filename^^}:${build_version}"$'\e[0m'" for detected "$'\e[1m'"${platform}"$'\e[0m'" platform..."


### PR DESCRIPTION
Reverts wso2/product-apim-tooling#968

Add the original fix https://github.com/wso2/product-apim-tooling/pull/967 back to the tooling repo as the go version has been bumped to 1.20  with https://github.com/wso2/product-apim-tooling/pull/971

