### PR TITLE
[CTL-4.0.x] Add URL encoding when exporting an API using the API CTL tool

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -17,7 +17,7 @@ Command Line tool for importing and exporting APIs/Applications/API Products in 
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apictl.go -v 4.0.2 -f` to build for all platforms.
+    Execute `./build.sh -t apictl.go -v 4.0.3 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
 

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -58,13 +58,13 @@ func exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, 
 		query += "&latestRevision=true"
 	}
 
-	url := publisherEndpoint + query
-	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", url)
+	requestURL := publisherEndpoint + query
+	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", requestURL)
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
 
-	resp, err := utils.InvokeGETRequest(url, headers)
+	resp, err := utils.InvokeGETRequest(requestURL, headers)
 
 	if err != nil {
 		return nil, err

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -20,6 +20,7 @@ package impl
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strconv"
 
@@ -45,7 +46,7 @@ func ExportAPIFromEnv(accessToken, name, version, revisionNum, provider, format,
 func exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, accessToken string, preserveStatus,
 	exportLatestRevision bool) (*resty.Response, error) {
 	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
-	query := "apis/export?name=" + name + "&version=" + version + "&providerName=" + provider +
+	query := "apis/export?name=" + url.QueryEscape(name) + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(preserveStatus)
 	if format != "" {
 		query += "&format=" + format

--- a/import-export-cli/integration/README.md
+++ b/import-export-cli/integration/README.md
@@ -49,7 +49,7 @@ rest-api-version: v2
    The version of the apictl that is being integration tested.
 
 ```
-apictl-version: 4.0.2
+apictl-version: 4.0.3
 ```   
 
 
@@ -92,7 +92,7 @@ apictl-version: 4.0.2
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name>
 
-example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz
+example: go test -p 1 -timeout 0 -archive apictl-4.0.3-linux-x64.tar.gz
 
 ```
 
@@ -101,7 +101,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -run <Test function name or partial name regex>
 
-example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz -run TestVersion
+example: go test -p 1 -timeout 0 -archive apictl-4.0.3-linux-x64.tar.gz -run TestVersion
 ```
 
 - Print verbose output
@@ -109,7 +109,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz -run Tes
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -v
 
-example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz -v
+example: go test -p 1 -timeout 0 -archive apictl-4.0.3-linux-x64.tar.gz -v
 ```
 
 - Print http transport request/responses
@@ -117,7 +117,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz -v
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -logtransport
 
-example: go test -p 1 -timeout 0 -archive apictl-4.0.2-linux-x64.tar.gz -logtransport
+example: go test -p 1 -timeout 0 -archive apictl-4.0.3-linux-x64.tar.gz -logtransport
 ```
 
 ---

--- a/import-export-cli/integration/config.yaml
+++ b/import-export-cli/integration/config.yaml
@@ -16,5 +16,5 @@ max-invocation-attempts: 10
 
 dcr-version: v0.17
 rest-api-version: v2
-apictl-version: 4.0.2
+apictl-version: 4.0.3
 

--- a/import-export-cli/mi/integration/README.md
+++ b/import-export-cli/mi/integration/README.md
@@ -62,7 +62,7 @@
 ```
 go test -archive <apictl archive name>
 
-example: go test -archive apictl-4.0.2-linux-x64.tar.gz
+example: go test -archive apictl-4.0.3-linux-x64.tar.gz
 
 ```
 
@@ -71,7 +71,7 @@ example: go test -archive apictl-4.0.2-linux-x64.tar.gz
 ```
 go test -archive <apictl archive name> -test.run <Test function name or partial name regex>
 
-example: go test -archive apictl-4.0.2-linux-x64.tar.gz -test.run TestGetConnectors
+example: go test -archive apictl-4.0.3-linux-x64.tar.gz -test.run TestGetConnectors
 ```
 
 - Print verbose output
@@ -79,7 +79,7 @@ example: go test -archive apictl-4.0.2-linux-x64.tar.gz -test.run TestGetConnect
 ```
 go test  -archive <apictl archive name> -test.v
 
-example: go test -archive apictl-4.0.2-linux-x64.tar.gz -test.v
+example: go test -archive apictl-4.0.3-linux-x64.tar.gz -test.v
 ```
 
 - Print http transport request/responses
@@ -87,5 +87,5 @@ example: go test -archive apictl-4.0.2-linux-x64.tar.gz -test.v
 ```
 go test -archive <apictl archive name> -logtransport
 
-example: go test -archive apictl-4.0.2-linux-x64.tar.gz -logtransport
+example: go test -archive apictl-4.0.3-linux-x64.tar.gz -logtransport
 ```


### PR DESCRIPTION
## Purpose
To fix the issue when trying to export the API in APIM 4.0.0, use the API CTL tool when the API contains Swedish characters such as öäå.

## Goals
Fixes: https://github.com/wso2/api-manager/issues/1827

## Approach
Change the code to URL encode API names before calling the REST APIs from the APIM side.