### PR TITLE
[CTL-4.2.x] Add URL encoding when exporting an API using the API CTL tool

### DIFF
--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -20,6 +20,7 @@ package impl
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strconv"
 
@@ -45,7 +46,7 @@ func ExportAPIFromEnv(accessToken, name, version, revisionNum, provider, format,
 func exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, accessToken string, preserveStatus,
 	exportLatestRevision bool) (*resty.Response, error) {
 	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
-	query := "apis/export?name=" + name + "&version=" + version + "&providerName=" + provider +
+	query := "apis/export?name=" + url.QueryEscape(name) + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(preserveStatus)
 	if format != "" {
 		query += "&format=" + format
@@ -57,13 +58,13 @@ func exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, 
 		query += "&latestRevision=true"
 	}
 
-	url := publisherEndpoint + query
-	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", url)
+	requestURL := publisherEndpoint + query
+	utils.Logln(utils.LogPrefixInfo+"ExportAPI: URL:", requestURL)
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 	headers[utils.HeaderAccept] = utils.HeaderValueApplicationZip
 
-	resp, err := utils.InvokeGETRequest(url, headers)
+	resp, err := utils.InvokeGETRequest(requestURL, headers)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Purpose
To fix the issue when trying to export the API in APIM 4.2.0, use the API CTL tool when the API contains Swedish characters such as öäå.

## Goals
Fixes: https://github.com/wso2/api-manager/issues/1827

## Approach
Change the code to URL encode API names before calling the REST APIs from the APIM side.