### PR TITLE
Change APICTL version to 4.2.1

### DIFF
--- a/import-export-cli/README.md
+++ b/import-export-cli/README.md
@@ -17,7 +17,7 @@ Command Line tool for importing and exporting APIs/Applications/API Products in 
 - ### Building
     `cd` into `product-apim-tooling/import-export-cli`
     
-    Execute `./build.sh -t apictl.go -v 4.2.0 -f` to build for all platforms.
+    Execute `./build.sh -t apictl.go -v 4.2.1 -f` to build for all platforms.
     
     Created packages will be available at `build/target` directory
 
@@ -69,11 +69,11 @@ Command Line tool for importing and exporting APIs/Applications/API Products in 
 
     Usage: `docker build --build-arg version=<version> -t apictl:<version> .`
 
-    Example: `docker build --build-arg version=4.2.0.1 -t apictl:4.2.0.1 .`
+    Example: `docker build --build-arg version=4.2.1.1 -t apictl:4.2.1.1 .`
 
     - ### Using the Docker Image
 
-        `docker run -it -v $(pwd):/git -v ~/.wso2apictl:/root/.wso2apictl -v ~/.wso2apictl.local:/root/.wso2apictl.local apictl:4.2.0.1 <apictl command>`
+        `docker run -it -v $(pwd):/git -v ~/.wso2apictl:/root/.wso2apictl -v ~/.wso2apictl.local:/root/.wso2apictl.local apictl:4.2.1.1 <apictl command>`
 
 ***
 

--- a/import-export-cli/integration/README.md
+++ b/import-export-cli/integration/README.md
@@ -52,7 +52,7 @@ devops-rest-api-version: v0
    The version of the apictl that is being integration tested.
 
 ```
-apictl-version: 4.2.0
+apictl-version: 4.2.1
 ```   
 
 
@@ -95,7 +95,7 @@ apictl-version: 4.2.0
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name>
 
-example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz
+example: go test -p 1 -timeout 0 -archive apictl-4.2.1-linux-x64.tar.gz
 
 ```
 
@@ -104,7 +104,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -run <Test function name or partial name regex>
 
-example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz -run TestVersion
+example: go test -p 1 -timeout 0 -archive apictl-4.2.1-linux-x64.tar.gz -run TestVersion
 ```
 
 - Print verbose output
@@ -112,7 +112,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz -run Tes
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -v
 
-example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz -v
+example: go test -p 1 -timeout 0 -archive apictl-4.2.1-linux-x64.tar.gz -v
 ```
 
 - Print http transport request/responses
@@ -120,7 +120,7 @@ example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz -v
 ```
 go test -p 1 -timeout 0 -archive <apictl archive name> -logtransport
 
-example: go test -p 1 -timeout 0 -archive apictl-4.2.0-linux-x64.tar.gz -logtransport
+example: go test -p 1 -timeout 0 -archive apictl-4.2.1-linux-x64.tar.gz -logtransport
 ```
 
 ---

--- a/import-export-cli/mi/integration/README.md
+++ b/import-export-cli/mi/integration/README.md
@@ -62,7 +62,7 @@
 ```
 go test -archive <apictl archive name>
 
-example: go test -archive apictl-4.2.0-linux-x64.tar.gz
+example: go test -archive apictl-4.2.1-linux-x64.tar.gz
 
 ```
 
@@ -71,7 +71,7 @@ example: go test -archive apictl-4.2.0-linux-x64.tar.gz
 ```
 go test -archive <apictl archive name> -test.run <Test function name or partial name regex>
 
-example: go test -archive apictl-4.2.0-linux-x64.tar.gz -test.run TestGetConnectors
+example: go test -archive apictl-4.2.1-linux-x64.tar.gz -test.run TestGetConnectors
 ```
 
 - Print verbose output
@@ -79,7 +79,7 @@ example: go test -archive apictl-4.2.0-linux-x64.tar.gz -test.run TestGetConnect
 ```
 go test  -archive <apictl archive name> -test.v
 
-example: go test -archive apictl-4.2.0-linux-x64.tar.gz -test.v
+example: go test -archive apictl-4.2.1-linux-x64.tar.gz -test.v
 ```
 
 - Print http transport request/responses
@@ -87,5 +87,5 @@ example: go test -archive apictl-4.2.0-linux-x64.tar.gz -test.v
 ```
 go test -archive <apictl archive name> -logtransport
 
-example: go test -archive apictl-4.2.0-linux-x64.tar.gz -logtransport
+example: go test -archive apictl-4.2.1-linux-x64.tar.gz -logtransport
 ```


### PR DESCRIPTION
$subject as a preparation step for next release apiclt 4.2.1

related issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/3620