### PR TITLE
[3.2.x] Add support for advance endpoint config

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -31,12 +31,20 @@ type Configuration struct {
 	ActionDuration *int `yaml:"actionDuration,omitempty" json:"actionDuration,omitempty"`
 }
 
+// Advance endpoint config for MGW
+type AdvanceConfigForMG struct {
+	// Timeout in milliseconds for endpoint
+	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
+}
+
 // Endpoint details
 type Endpoint struct {
 	// Type of the endpoints
 	EndpointType string `json:"endpoint_type,omitempty"`
 	// Url of the endpoint
 	Url *string `yaml:"url" json:"url"`
+	// Advance endpoint config of the endpoint
+	AdvanceEndpointConfig *AdvanceConfigForMG `yaml:"advanceEndpointConfig,omitempty" json:"advanceEndpointConfig,omitempty"`
 	// Config of endpoint
 	Config *Configuration `yaml:"config,omitempty" json:"config,omitempty"`
 }

--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -31,8 +31,8 @@ type Configuration struct {
 	ActionDuration *int `yaml:"actionDuration,omitempty" json:"actionDuration,omitempty"`
 }
 
-// Advance endpoint config for MGW
-type AdvanceConfigForMG struct {
+// Advance endpoint configurations
+type AdvanceEndpointConfiguration struct {
 	// Timeout in milliseconds for endpoint
 	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
@@ -44,7 +44,7 @@ type Endpoint struct {
 	// Url of the endpoint
 	Url *string `yaml:"url" json:"url"`
 	// Advance endpoint config of the endpoint
-	AdvanceEndpointConfig *AdvanceConfigForMG `yaml:"advanceEndpointConfig,omitempty" json:"advanceEndpointConfig,omitempty"`
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty" json:"advanceEndpointConfig,omitempty"`
 	// Config of endpoint
 	Config *Configuration `yaml:"config,omitempty" json:"config,omitempty"`
 }

--- a/import-export-cli/specs/v2/oai3.go
+++ b/import-export-cli/specs/v2/oai3.go
@@ -65,10 +65,10 @@ func oai3Tags(exts map[string]interface{}) []string {
 type Endpoints struct {
 	Type string   `yaml:"type"`
 	Urls []string `yaml:"urls"`
-	AdvanceEndpointConfig *AdvanceConfigForMG `yaml:"advanceEndpointConfig,omitempty"`
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty"`
 }
 
-type AdvanceConfigForMG struct {
+type AdvanceEndpointConfiguration struct {
 	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
 

--- a/import-export-cli/specs/v2/oai3.go
+++ b/import-export-cli/specs/v2/oai3.go
@@ -65,6 +65,11 @@ func oai3Tags(exts map[string]interface{}) []string {
 type Endpoints struct {
 	Type string   `yaml:"type"`
 	Urls []string `yaml:"urls"`
+	AdvanceEndpointConfig *AdvanceConfigForMG `yaml:"advanceEndpointConfig,omitempty"`
+}
+
+type AdvanceConfigForMG struct {
+	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
 
 func oai3XWSO2ProductionEndpoints(exts map[string]interface{}) (*Endpoints, bool, error) {

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -186,11 +186,21 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 	if len(production.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &production.Urls[0]
+		if production.AdvanceEndpointConfig != nil && production.AdvanceEndpointConfig.TimeOutInMillis != nil {
+			ep.AdvanceEndpointConfig = &params.AdvanceConfigForMG {
+				TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "production_endpoints")
 	}
 	if len(sandbox.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &sandbox.Urls[0]
+		if sandbox.AdvanceEndpointConfig != nil && sandbox.AdvanceEndpointConfig.TimeOutInMillis != nil {
+			ep.AdvanceEndpointConfig = &params.AdvanceConfigForMG {
+				TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "sandbox_endpoints")
 	}
 	return jsonObj.String()

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -187,7 +187,7 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 		var ep params.Endpoint
 		ep.Url = &production.Urls[0]
 		if production.AdvanceEndpointConfig != nil && production.AdvanceEndpointConfig.TimeOutInMillis != nil {
-			ep.AdvanceEndpointConfig = &params.AdvanceConfigForMG {
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
 				TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
 			}
 		}
@@ -197,7 +197,7 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 		var ep params.Endpoint
 		ep.Url = &sandbox.Urls[0]
 		if sandbox.AdvanceEndpointConfig != nil && sandbox.AdvanceEndpointConfig.TimeOutInMillis != nil {
-			ep.AdvanceEndpointConfig = &params.AdvanceConfigForMG {
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
 				TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
 			}
 		}


### PR DESCRIPTION
## Purpose
This PR adds support to the advanceEndpointConfig in OAPI definitions to be included in the endpoint configurations.

This property is used in MGW when the endpoint config is defined.
```
x-wso2-production-endpoints:
  urls:
   - https://localhost:9443/am/sample/pizzashack/v1/api/
  advanceEndpointConfig:
    timeoutInMillis: 240000
  type: http
```

Related issue: https://github.com/wso2/product-microgateway/issues/3387