### PR TITLE
[3.0.x] Add advanceEndpointConfig to endpoint config only when it is present

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -20,7 +20,9 @@ type Configuration struct {
 	Factor *int `yaml:"factor" json:"factor,string"`
 }
 
-type AdvanceConfigForMG struct {
+// Advance endpoint configurations
+type AdvanceEndpointConfiguration struct {
+	// Timeout in milliseconds for endpoint
 	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
 
@@ -28,7 +30,8 @@ type AdvanceConfigForMG struct {
 type Endpoint struct {
 	// Url of the endpoint
 	Url                   *string            `yaml:"url" json:"url"`
-	AdvanceEndpointConfig AdvanceConfigForMG `yaml:"advanceEndpointConfig" json:"advanceEndpointConfig"`
+	// Advance endpoint config of the endpoint
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty" json:"advanceEndpointConfig,omitempty"`
 	// Config of endpoint
 	Config *Configuration `yaml:"config" json:"config"`
 }

--- a/import-export-cli/specs/v2/oai3.go
+++ b/import-export-cli/specs/v2/oai3.go
@@ -65,10 +65,10 @@ func oai3Tags(exts map[string]interface{}) []string {
 type Endpoints struct {
 	Type                  string             `yaml:"type"`
 	Urls                  []string           `yaml:"urls"`
-	AdvanceEndpointConfig AdvanceConfigForMG `yaml:"advanceEndpointConfig"`
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty"`
 }
 
-type AdvanceConfigForMG struct {
+type AdvanceEndpointConfiguration struct {
 	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
 

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -184,13 +184,21 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 	if len(production.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &production.Urls[0]
-		ep.AdvanceEndpointConfig.TimeOutInMillis = production.AdvanceEndpointConfig.TimeOutInMillis
+		if production.AdvanceEndpointConfig != nil && production.AdvanceEndpointConfig.TimeOutInMillis != nil {
+		  ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
+        TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
+      }
+    }
 		_, _ = jsonObj.SetP(ep, "production_endpoints")
 	}
 	if len(sandbox.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &sandbox.Urls[0]
-		ep.AdvanceEndpointConfig.TimeOutInMillis = sandbox.AdvanceEndpointConfig.TimeOutInMillis
+		if sandbox.AdvanceEndpointConfig != nil && sandbox.AdvanceEndpointConfig.TimeOutInMillis != nil {
+      ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
+        TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
+      }
+    }
 		_, _ = jsonObj.SetP(ep, "sandbox_endpoints")
 	}
 	return jsonObj.String()

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -185,20 +185,20 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 		var ep params.Endpoint
 		ep.Url = &production.Urls[0]
 		if production.AdvanceEndpointConfig != nil && production.AdvanceEndpointConfig.TimeOutInMillis != nil {
-		  ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
-        TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
-      }
-    }
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
+				TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "production_endpoints")
 	}
 	if len(sandbox.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &sandbox.Urls[0]
 		if sandbox.AdvanceEndpointConfig != nil && sandbox.AdvanceEndpointConfig.TimeOutInMillis != nil {
-      ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
-        TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
-      }
-    }
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration {
+				TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "sandbox_endpoints")
 	}
 	return jsonObj.String()


### PR DESCRIPTION
## Purpose
This PR adds the change to add advanceEndpointConfig to the endpoint config in api.yaml only when it is present in the OAPI definition.

Related issue: https://github.com/wso2/product-microgateway/issues/3387