### PR TITLE
[4.0.x] Add remove existing PNG file to fix test failure

### DIFF
--- a/import-export-cli/integration/devFirst_test.go
+++ b/import-export-cli/integration/devFirst_test.go
@@ -18,6 +18,7 @@
 package integration
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -75,7 +76,7 @@ import (
 //	testutils.ValidateAWSProjectImport(t, args, false)
 //}
 
-//Initialize a project Initialize an API without any flag
+// Initialize a project Initialize an API without any flag
 func TestInitializeProject(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
@@ -91,7 +92,7 @@ func TestInitializeProject(t *testing.T) {
 	testutils.ValidateInitializeProject(t, args)
 }
 
-//Initialize an API with --definition flag
+// Initialize an API with --definition flag
 func TestInitializeAPIWithDefinitionFlag(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -109,7 +110,7 @@ func TestInitializeAPIWithDefinitionFlag(t *testing.T) {
 	testutils.ValidateInitializeProjectWithDefinitionFlag(t, args)
 }
 
-//Initialize an API from Swagger 2 Specification
+// Initialize an API from Swagger 2 Specification
 func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -127,7 +128,7 @@ func TestInitializeAPIFromSwagger2Definition(t *testing.T) {
 	testutils.ValidateInitializeProjectWithOASFlag(t, args)
 }
 
-//Initialize an API from OpenAPI 3 Specification
+// Initialize an API from OpenAPI 3 Specification
 func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -145,7 +146,7 @@ func TestInitializeAPIFromOpenAPI3Definition(t *testing.T) {
 	testutils.ValidateInitializeProjectWithOASFlag(t, args)
 }
 
-//Initialize an API from API Specification URL
+// Initialize an API from API Specification URL
 func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
@@ -163,7 +164,7 @@ func TestInitializeAPIFromAPIDefinitionURL(t *testing.T) {
 	testutils.ValidateInitializeProjectWithOASFlag(t, args)
 }
 
-//Import API from initialized project with swagger 2 definition
+// Import API from initialized project with swagger 2 definition
 func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -183,7 +184,7 @@ func TestImportProjectCreatedFromSwagger2Definition(t *testing.T) {
 	testutils.ValidateImportProject(t, args)
 }
 
-//Import API from initialized project with openAPI 3 definition
+// Import API from initialized project with openAPI 3 definition
 func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -203,7 +204,7 @@ func TestImportProjectCreatedFromOpenAPI3Definition(t *testing.T) {
 	testutils.ValidateImportProject(t, args)
 }
 
-//Import API from initialized project from API definition which is already in publisher without --update flag
+// Import API from initialized project from API definition which is already in publisher without --update flag
 func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -226,7 +227,7 @@ func TestImportProjectCreatedFailWhenAPIIsExisted(t *testing.T) {
 	testutils.ValidateImportProjectFailed(t, args)
 }
 
-//Import API from initialized project from API definition which is already in publisher with --update flag
+// Import API from initialized project from API definition which is already in publisher with --update flag
 func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -249,7 +250,7 @@ func TestImportProjectCreatedPassWhenAPIIsExisted(t *testing.T) {
 	testutils.ValidateImportUpdateProject(t, args)
 }
 
-//Import Api with a Document and Export that Api with a Document
+// Import Api with a Document and Export that Api with a Document
 func TestImportAndExportAPIWithDocument(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
@@ -287,7 +288,7 @@ func TestImportAndExportAPIWithDocument(t *testing.T) {
 		testutils.TestCase1DestPathSuffix)
 }
 
-//Import Api with an Image and Export that Api with an image (.png Type)
+// Import Api with an Image and Export that Api with an image (.png Type)
 func TestImportAndExportAPIWithPngIcon(t *testing.T) {
 	username := superAdminUser
 	password := superAdminPassword
@@ -317,7 +318,7 @@ func TestImportAndExportAPIWithPngIcon(t *testing.T) {
 	testutils.ValidateAPIWithIconIsExported(t, args, testutils.DevFirstDefaultAPIName, testutils.DevFirstDefaultAPIVersion)
 }
 
-//Import Api with an Image and Export that Api with an image (.jpeg Type)
+// Import Api with an Image and Export that Api with an image (.jpeg Type)
 func TestImportAndExportAPIWithJpegImage(t *testing.T) {
 	apim := GetDevClient()
 	projectName := base.GenerateRandomName(16)
@@ -347,7 +348,7 @@ func TestImportAndExportAPIWithJpegImage(t *testing.T) {
 	testutils.ValidateAPIWithImageIsExported(t, args, testutils.DevFirstDefaultAPIName, testutils.DevFirstDefaultAPIVersion)
 }
 
-//Import and export API with updated thumbnail and document and assert that
+// Import and export API with updated thumbnail and document and assert that
 func TestUpdateDocAndImageOfAPIOfExistingAPI(t *testing.T) {
 	apim := GetProdClient()
 	projectName := base.GenerateRandomName(16)
@@ -390,6 +391,9 @@ func TestUpdateDocAndImageOfAPIOfExistingAPI(t *testing.T) {
 	srcPathForDocUpdate, _ := filepath.Abs(testutils.TestCase1DocPath)
 	destPathForDocUpdate := projectPath + testutils.TestCase2DestPathSuffix
 	base.Copy(srcPathForDocUpdate, destPathForDocUpdate)
+
+	//Remove the existing icon.png file
+	_ = os.Remove(destPathForImage)
 
 	//Update image file to created project
 	srcPathForIcon, _ := filepath.Abs(testutils.TestCase2JpegPath)


### PR DESCRIPTION
## Purpose
This PR adds the change to remove the existing PNG file to fix the failure of test TestImportAndExportAPIWithJpegImage.