### PR TITLE
[4.1.x] Remove Publisher/Consumer properties from MI tests

### DIFF
--- a/import-export-cli/mi/integration/testutils/messageStore_testUtils.go
+++ b/import-export-cli/mi/integration/testutils/messageStore_testUtils.go
@@ -58,8 +58,6 @@ func validateMessageStoreEqual(t *testing.T, messageStoreFromCtl string, message
 	assert.Contains(t, messageStoreFromCtl, messageStore.Name)
 	assert.Contains(t, messageStoreFromCtl, messageStore.Container)
 	assert.Contains(t, messageStoreFromCtl, messageStore.FileName)
-	assert.Contains(t, messageStoreFromCtl, messageStore.Consumer)
-	assert.Contains(t, messageStoreFromCtl, messageStore.Producer)
 	assert.Contains(t, messageStoreFromCtl, fmt.Sprint(messageStore.Size))
 	for key, value := range messageStore.Properties {
 		assert.Contains(t, messageStoreFromCtl, key)


### PR DESCRIPTION
## Purpose
This PR removes Publisher/Consumer properties from MI tests. This due to the change introduced in [1].

[1] https://github.com/wso2/product-apim-tooling/commit/eaf1477928a89fd782fc8b8acf318cde533bdc9e