### PR TITLE
[4.2.x] Add support for advance endpoint config

### DIFF
--- a/import-export-cli/specs/params/params.go
+++ b/import-export-cli/specs/params/params.go
@@ -20,12 +20,20 @@ type Configuration struct {
 	Factor *int `yaml:"factor,omitempty" json:"factor,omitempty"`
 }
 
+// Advance endpoint configurations
+type AdvanceEndpointConfiguration struct {
+	// Timeout in milliseconds for endpoint
+	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
+}
+
 // Endpoint details
 type Endpoint struct {
 	// Type of the endpoints
 	EndpointType string `json:"endpoint_type,omitempty"`
 	// Url of the endpoint
 	Url *string `yaml:"url" json:"url"`
+	// Advance endpoint config of the endpoint
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty" json:"advanceEndpointConfig,omitempty"`
 	// Config of endpoint
 	Config *Configuration `yaml:"config,omitempty" json:"config,omitempty"`
 }
@@ -131,6 +139,7 @@ type APIEndpointConfig struct {
 }
 
 // loads the given file in path and substitutes environment variables that are defined as ${var} or $var in the file.
+//
 //	returns the file as string.
 func GetEnvSubstitutedFileContent(path string) (string, error) {
 	r, err := os.Open(path)
@@ -155,6 +164,7 @@ func GetEnvSubstitutedFileContent(path string) (string, error) {
 
 // LoadApiParamsFromDirectory loads an API Project configuration YAML file located in path when the root
 // directory is provided instead of yaml file.
+//
 //	It returns an error or a valid ApiParams
 func LoadApiParamsFromDirectory(path string) (*ApiParams, error) {
 	paramsFilePath := filepath.Join(path, utils.ParamFile)
@@ -174,6 +184,7 @@ func LoadApiParamsFromDirectory(path string) (*ApiParams, error) {
 }
 
 // LoadApiParamsFromFile loads an API Project configuration YAML file located in path.
+//
 //	It returns an error or a valid ApiParams
 func LoadApiParamsFromFile(path string) (*ApiParams, error) {
 	fileContent, err := GetEnvSubstitutedFileContent(path)
@@ -191,6 +202,7 @@ func LoadApiParamsFromFile(path string) (*ApiParams, error) {
 }
 
 // LoadApiProductParamsFromFile loads an API Product project configuration YAML file located in path.
+//
 //	It returns an error or a valid ApiProductParams
 func LoadApiProductParamsFromFile(path string) (*ApiProductParams, error) {
 	fileContent, err := GetEnvSubstitutedFileContent(path)
@@ -208,6 +220,7 @@ func LoadApiProductParamsFromFile(path string) (*ApiProductParams, error) {
 }
 
 // LoadApplicationParamsFromFile loads an Application project configuration YAML file located in path.
+//
 //	It returns an error or a valid ApplicationParams
 func LoadApplicationParamsFromFile(path string) (*ApplicationParams, error) {
 	fileContent, err := GetEnvSubstitutedFileContent(path)

--- a/import-export-cli/specs/v2/oai3.go
+++ b/import-export-cli/specs/v2/oai3.go
@@ -61,8 +61,13 @@ func oai3Tags(exts map[string]interface{}) []string {
 }
 
 type Endpoints struct {
-	Type string   `yaml:"type"`
-	Urls []string `yaml:"urls"`
+	Type                  string                        `yaml:"type"`
+	Urls                  []string                      `yaml:"urls"`
+	AdvanceEndpointConfig *AdvanceEndpointConfiguration `yaml:"advanceEndpointConfig,omitempty"`
+}
+
+type AdvanceEndpointConfiguration struct {
+	TimeOutInMillis *int `yaml:"timeoutInMillis" json:"timeoutInMillis"`
 }
 
 func oai3XWSO2ProductionEndpoints(exts map[string]interface{}) (*Endpoints, bool, error) {

--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -235,11 +235,21 @@ func buildHttpEndpoint(production *Endpoints, sandbox *Endpoints) string {
 	if len(production.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &production.Urls[0]
+		if production.AdvanceEndpointConfig != nil && production.AdvanceEndpointConfig.TimeOutInMillis != nil {
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration{
+				TimeOutInMillis: production.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "production_endpoints")
 	}
 	if len(sandbox.Urls) > 0 {
 		var ep params.Endpoint
 		ep.Url = &sandbox.Urls[0]
+		if sandbox.AdvanceEndpointConfig != nil && sandbox.AdvanceEndpointConfig.TimeOutInMillis != nil {
+			ep.AdvanceEndpointConfig = &params.AdvanceEndpointConfiguration{
+				TimeOutInMillis: sandbox.AdvanceEndpointConfig.TimeOutInMillis,
+			}
+		}
 		_, _ = jsonObj.SetP(ep, "sandbox_endpoints")
 	}
 	return jsonObj.String()


### PR DESCRIPTION
## Purpose
This PR adds support to the advanceEndpointConfig in OAPI definitions to be included in the endpoint configurations.

This property is used in MGW when the endpoint config is defined.
```
x-wso2-production-endpoints:
  urls:
   - https://localhost:9443/am/sample/pizzashack/v1/api/
  advanceEndpointConfig:
    timeoutInMillis: 240000
  type: http
```

Related issue: https://github.com/wso2/product-microgateway/issues/3387