### PR TITLE
Add LastUpdatedTimestamp to the APIDTODefinition

### DIFF
--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -71,6 +71,7 @@ type APIDTODefinition struct {
 	CorsConfiguration               interface{}   `json:"corsConfiguration,omitempty" yaml:"corsConfiguration,omitempty"`
 	WorkflowStatus                  []string      `json:"workflowStatus,omitempty" yaml:"workflowStatus,omitempty"`
 	CreatedTime                     string        `json:"createdTime,omitempty" yaml:"createdTime,omitempty"`
+	LastUpdatedTimestamp            string        `json:"lastUpdatedTimestamp,omitempty" yaml:"lastUpdatedTimestamp,omitempty"`
 	LastUpdatedTime                 string        `json:"lastUpdatedTime,omitempty" yaml:"lastUpdatedTime,omitempty"`
 	EndpointConfig                  interface{}   `json:"endpointConfig,omitempty" yaml:"endpointConfig,omitempty"`
 	EndpointImplementationType      string        `json:"endpointImplementationType,omitempty" yaml:"endpointImplementationType,omitempty"`


### PR DESCRIPTION
## Purpose
This PR adds the lastUpdatedTimestamp to API spec of APICTL.

Related issue: https://github.com/wso2/api-manager/issues/1860