### PR TITLE
[4.1.x] Add test case for API import with an invalid params file

### DIFF
--- a/import-export-cli/integration/envSpecific_test.go
+++ b/import-export-cli/integration/envSpecific_test.go
@@ -63,6 +63,29 @@ func TestEnvironmentSpecificParamsEndpoint(t *testing.T) {
 	}
 }
 
+// Try to import an API with the external params file with invalid format (missing the configs key)
+func TestInvalidEnvironmentSpecificParamsEndpoint(t *testing.T) {
+	for _, user := range testCaseUsers {
+		t.Run(user.Description, func(t *testing.T) {
+			dev := GetDevClient()
+			prod := GetProdClient()
+
+			api := testutils.AddAPI(t, dev, user.ApiCreator.Username, user.ApiCreator.Password)
+
+			args := &testutils.ApiImportExportTestArgs{
+				ApiProvider: testutils.Credentials{Username: user.ApiCreator.Username, Password: user.ApiCreator.Password},
+				CtlUser:     testutils.Credentials{Username: user.CtlUser.Username, Password: user.CtlUser.Password},
+				Api:         api,
+				SrcAPIM:     dev,
+				DestAPIM:    prod,
+				ParamsFile:  testutils.InvalidAPIEndpointParamsFile,
+			}
+
+			testutils.ValidateAPIImportFailure(t, args)
+		})
+	}
+}
+
 // Add an API to one environment, export it and re-import it to another environment by setting
 // the configs for endpoints using the params file
 func TestEnvironmentSpecificParamsEndpointConfigs(t *testing.T) {

--- a/import-export-cli/integration/testdata/EnvParamsFiles/invalid_api_params_endpoint.yaml
+++ b/import-export-cli/integration/testdata/EnvParamsFiles/invalid_api_params_endpoint.yaml
@@ -1,0 +1,7 @@
+environments:
+    - name: production
+      endpoints:
+          production:
+              url: 'https://prod.wso2.com'
+          sandbox:
+              url: 'https://sand.wso2.com'

--- a/import-export-cli/integration/testutils/testConstants.go
+++ b/import-export-cli/integration/testutils/testConstants.go
@@ -18,7 +18,7 @@
 
 package testutils
 
-//Environment management related test constants
+// Environment management related test constants
 const ApictlInitMessage = "apictl is a Command Line Tool for Importing and Exporting APIs and Applications between " +
 	"different environments of WSO2 API Manager"
 const CustomTestExportDirectory = "CustomExportDirectory"
@@ -33,7 +33,7 @@ const TestMigrationDirectorySuffix = "/migration"
 
 const DefaultApictlTestAppName = "default-apictl-app"
 
-//Export test cases
+// Export test cases
 const DevFirstDefaultAPIName = "SwaggerPetstoreNew"
 const DevFirstSwagger2APIName = "PizzaShackAPI"
 const OpenAPI3DefinitionWithoutEndpointsAPIName = "PizzaShackAPI"
@@ -132,6 +132,9 @@ const APIAwsEndpointWithStoredCredentialsParamsFile = EnvParamsFilesDir + "/api_
 
 // APIDynamicEndpointParamsFile : Dynamic Endpoint with stored credentials in api_params.yaml
 const APIDynamicEndpointParamsFile = EnvParamsFilesDir + "/api_params_dynamic_endpoint.yaml"
+
+// InvalidAPIEndpointParamsFile : Invalid Endpoint URL api_params.yaml
+const InvalidAPIEndpointParamsFile = EnvParamsFilesDir + "/invalid_api_params_endpoint.yaml"
 
 // API types
 const APITypeREST = "HTTP"


### PR DESCRIPTION
## Purpose
This PR adds the test case for API import with an invalid params file.

Related issue: https://github.com/wso2/api-manager/issues/2389
Related PR: https://github.com/wso2/product-apim-tooling/pull/1051