### PR TITLE
Creating SecretCR upon enabling basic-auth for endpoint security

### DIFF
--- a/apim-apk-agent/internal/utils/apis_fetcher.go
+++ b/apim-apk-agent/internal/utils/apis_fetcher.go
@@ -107,15 +107,17 @@ func FetchAPIsOnEvent(conf *config.Config, apiUUID *string, k8sClient client.Cli
 							logger.LoggerUtils.Errorf("Error while decoding the API Project Artifact: %v", decodingError)
 							return nil, err
 						}
-						apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, apkErr := transformer.GenerateAPKConf(artifact.APIJson, artifact.CertArtifact, apiDeployment.OrganizationID)
+
+						apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, endpointSecurityData, apkErr := transformer.GenerateAPKConf(artifact.APIJson, artifact.CertArtifact, apiDeployment.OrganizationID)
 						if apkErr != nil {
 							logger.LoggerUtils.Errorf("Error while generating APK-Conf: %v", apkErr)
 							return nil, err
 						}
-						logger.LoggerUtils.Debugf("APK Conf:", apkConf)
+						logger.LoggerUtils.Debug("APK Conf:", apkConf)
 						certContainer := transformer.CertContainer{
 							ClientCertObj:   artifact.CertMeta,
 							EndpointCertObj: artifact.EndpointCertMeta,
+							SecretData:      endpointSecurityData,
 						}
 						k8ResourceEndpoint := conf.DataPlane.K8ResourceEndpoint
 						crResponse, err := transformer.GenerateCRs(apkConf, artifact.Schema, certContainer, k8ResourceEndpoint, apiDeployment.OrganizationID)

--- a/apim-apk-agent/pkg/transformer/api_model.go
+++ b/apim-apk-agent/pkg/transformer/api_model.go
@@ -17,6 +17,30 @@
 
 package transformer
 
+// CustomParams holds the custom parameter values that has been enabled for the selected security mode
+type CustomParams struct {
+	CustomParamMapping map[string]string `json:"customParamMapping"`
+}
+
+// SecurityObj holds the idividual attribute values for each endpoint security config
+type SecurityObj struct {
+	Enabled          bool                   `json:"enabled"`
+	Type             string                 `json:"type"`
+	Username         string                 `json:"username"`
+	Password         string                 `json:"password"`
+	GrantType        string                 `json:"grantType"`
+	TokenURL         string                 `json:"tokenUrl"`
+	ClientID         string                 `json:"clientId"`
+	ClientSecret     string                 `json:"clientSecret"`
+	CustomParameters map[string]interface{} `json:"customParameters"`
+}
+
+// EndpointSecurityConfig holds security configs enabled for endpoints from the API level
+type EndpointSecurityConfig struct {
+	Production SecurityObj `json:"production"`
+	Sandbox    SecurityObj `json:"sandbox"`
+}
+
 // EndpointDetails represents the details of an endpoint, containing its URL.
 type EndpointDetails struct {
 	URL string `json:"url"`
@@ -24,9 +48,10 @@ type EndpointDetails struct {
 
 // EndpointConfig represents the configuration of an endpoint, including its type, sandbox, and production details.
 type EndpointConfig struct {
-	EndpointType        string          `json:"endpoint_type"`
-	SandboxEndpoints    EndpointDetails `json:"sandbox_endpoints"`
-	ProductionEndpoints EndpointDetails `json:"production_endpoints"`
+	EndpointType        string                 `json:"endpoint_type"`
+	SandboxEndpoints    EndpointDetails        `json:"sandbox_endpoints"`
+	ProductionEndpoints EndpointDetails        `json:"production_endpoints"`
+	EndpointSecurity    EndpointSecurityConfig `json:"endpoint_security"`
 }
 
 // CORSConfiguration represents the CORS (Cross-Origin Resource Sharing) configuration for an API.
@@ -144,4 +169,5 @@ type EndpointCertMetadata struct {
 type CertContainer struct {
 	ClientCertObj   CertMetadata
 	EndpointCertObj EndpointCertMetadata
+	SecretData      EndpointSecurityConfig
 }

--- a/apim-apk-agent/pkg/transformer/apk_model.go
+++ b/apim-apk-agent/pkg/transformer/apk_model.go
@@ -17,6 +17,19 @@
 
 package transformer
 
+// SecretInfo holds the info related to the created secret upon enabling the endpoint security options like basic auth
+type SecretInfo struct {
+	SecretName  string `yaml:"secretName,omitempty"`
+	UsernameKey string `yaml:"userNameKey,omitempty"`
+	PasswordKey string `yaml:"passwordKey,omitempty"`
+}
+
+// EndpointSecurity comtains the information related to endpoint security configurations enabled by a user for a given API
+type EndpointSecurity struct {
+	Enabled      bool       `yaml:"enabled,omitempty"`
+	SecurityType SecretInfo `yaml:"securityType,omitempty"`
+}
+
 // EndpointCertificate struct stores the the alias and the name for a particular endpoint security configuration
 type EndpointCertificate struct {
 	Name string `yaml:"secretName"`
@@ -27,6 +40,7 @@ type EndpointCertificate struct {
 type EndpointConfiguration struct {
 	Endpoint       string              `yaml:"endpoint,omitempty"`
 	EndCertificate EndpointCertificate `yaml:"certificate,omitempty"`
+	EndSecurity    EndpointSecurity    `yaml:"endpointSecurity,omitempty"`
 }
 
 // AdditionalProperty stores the custom properties set by the user for a particular API

--- a/apim-apk-agent/pkg/transformer/transformer_test.go
+++ b/apim-apk-agent/pkg/transformer/transformer_test.go
@@ -145,13 +145,14 @@ func TestAPKConfGeneration(t *testing.T) {
 				assert.NoError(t, err)
 				assert.IsType(t, &APIArtifact{}, apiArtifact)
 
-				apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, apkErr := GenerateAPKConf(apiArtifact.APIJson, apiArtifact.CertArtifact, "default")
+				apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, endpointSecurityData, apkErr := GenerateAPKConf(apiArtifact.APIJson, apiArtifact.CertArtifact, "default")
 
 				assert.NoError(t, apkErr)
 				assert.NotEmpty(t, apkConf)
 				assert.NotEqual(t, "null", apiUUID)
 				assert.NotEqual(t, uint32(0), revisionID)
 				assert.NotNil(t, configuredRateLimitPoliciesMap)
+				assert.IsType(t, EndpointSecurityConfig{}, endpointSecurityData) // Need to be refined maybe
 			}
 		}
 	}
@@ -356,7 +357,7 @@ func TestBrokenZipHandlingFlow(t *testing.T) {
 					assert.Error(t, err)
 				}
 
-				apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, apkErr := GenerateAPKConf(apiArtifact.APIJson, apiArtifact.CertArtifact, "orgID")
+				apkConf, apiUUID, revisionID, configuredRateLimitPoliciesMap, endpointSecurityData, apkErr := GenerateAPKConf(apiArtifact.APIJson, apiArtifact.CertArtifact, "orgID")
 
 				//When all the contents are empty or some properties are missing, an unmarshalling error should occur when creating the apiArtifact
 				if strings.Contains(zipFile.Name, "All_Empty") {
@@ -365,6 +366,7 @@ func TestBrokenZipHandlingFlow(t *testing.T) {
 					assert.Equal(t, uint32(0), revisionID)
 					assert.Error(t, apkErr)
 					assert.NotNil(t, configuredRateLimitPoliciesMap)
+					assert.IsType(t, EndpointSecurityConfig{}, endpointSecurityData) // Need to be refined maybe
 				}
 				// If API_Json is broken then the generate conf is invalid hence it will be failed in CR generation
 				if strings.Contains(zipFile.Name, "Empty_Definition") {

--- a/apim-apk-agent/pkg/transformer/utils.go
+++ b/apim-apk-agent/pkg/transformer/utils.go
@@ -20,6 +20,8 @@ package transformer
 import (
 	"archive/zip"
 	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 
@@ -165,4 +167,13 @@ func StringExists(target string, slice []string) bool {
 	}
 	_, exists := set[target]
 	return exists
+}
+
+// GetUniqueIDForAPI will generate a unique ID for newly created APIs
+func GetUniqueIDForAPI(name, version, organization string) string {
+	concatenatedString := strings.Join([]string{organization, name, version}, "-")
+	hash := sha1.New()
+	hash.Write([]byte(concatenatedString))
+	hashedValue := hash.Sum(nil)
+	return hex.EncodeToString(hashedValue)
 }


### PR DESCRIPTION
## Purpose
> When basic-auth endpoint security is enabled for an API, a secret should be created for holding the relevant credentials. Hence added those mapping logic into transformer module
