### PR TITLE
Prevent deletion of internal key token issuers

### DIFF
--- a/apim-apk-agent/internal/constants/constants.go
+++ b/apim-apk-agent/internal/constants/constants.go
@@ -31,4 +31,5 @@ const (
 	InternalKeyTokenIssuerName = "Internal Key TokenIssuer"
 	InternalKeySecretName      = "apim-apk-issuer-cert"
 	InternalKeySecretKey       = "wso2.crt"
+	InternalKeySuffix          = "-internal-key-issuer"
 )


### PR DESCRIPTION
## Purpose

- Current logic has any token issuers that are not registered on the APIM side deleted upon agent startup.
- This PR stops the deletion of internal key token issuers

Fixes https://github.com/wso2/apk/issues/2255