### PR TITLE
[APK] Add API Key Authentication to agent

### DIFF
--- a/apim-apk-agent/pkg/transformer/api_model.go
+++ b/apim-apk-agent/pkg/transformer/api_model.go
@@ -140,6 +140,7 @@ type APIMApi struct {
 	DefaultVersion       bool                   `json:"isDefaultVersion"`
 	Type                 string                 `yaml:"type"`
 	AuthorizationHeader  string                 `yaml:"authorizationHeader"`
+	APIKeyHeader         string                 `yaml:"apiKeyHeader"`
 	SecuritySchemes      []string               `json:"securityScheme"`
 	AdditionalProperties []AdditionalProperties `yaml:"additionalProperties"`
 	// AdditionalPropertiesMap []AdditionalPropertiesMap `yaml:"additionalPropertiesMap"`

--- a/apim-apk-agent/pkg/transformer/apk_model.go
+++ b/apim-apk-agent/pkg/transformer/apk_model.go
@@ -64,7 +64,7 @@ type AuthConfiguration struct {
 	Enabled           bool          `yaml:"enabled"`
 	QueryParamName    string        `yaml:"queryParamName,omitempty"`
 	HeaderEnabled     bool          `yaml:"headerEnable,omitempty"`
-	queryParamEnable  bool          `yaml:"queryParamEnable,omitempty"`
+	QueryParamEnable  bool          `yaml:"queryParamEnable,omitempty"`
 	Certificates      []Certificate `yaml:"certificates,omitempty"`
 	Audience          []string      `yaml:"audience,omitempty"`
 }

--- a/apim-apk-agent/pkg/transformer/constants.go
+++ b/apim-apk-agent/pkg/transformer/constants.go
@@ -28,6 +28,7 @@ const (
 	postHTTPMethod    = "POST"
 	contentTypeHeader = "Content-Type"
 	internalKeyHeader = "internal-key"
+	apiKeyHeader      = "apikey"
 
 	// K8s CRD fields
 	k8sKindField                = "kind"
@@ -51,6 +52,14 @@ const (
 	mTLS   = "mTLS"
 	jwt    = "JWT"
 	oAuth2 = "OAuth2"
+	apiKey = "APIKey"
+
+	// Security Scheme values
+	oAuth2SecScheme    = "oauth2"
+	oAuth2Mandatory    = "oauth_basic_auth_api_key_mandatory"
+	mutualSSL          = "mutualssl"
+	mutualSSLMandatory = "mutualssl_mandatory"
+	apiKeySecScheme    = "api_key"
 
 	// Optionality constants
 	mandatory = "mandatory"


### PR DESCRIPTION
## Purpose
Currently, the CP to DP flow for APK does not support API Key Authentication.
This PR introduces API Key Authentication as a security scheme so that API Key authentication functions as expected.

Fixes https://github.com/wso2/apk/issues/2311