### PR TITLE
Add AI upload and delete commands

### DIFF
--- a/import-export-cli/cmd/ai.go
+++ b/import-export-cli/cmd/ai.go
@@ -1,0 +1,49 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Ai command related usage Info
+const AiCmdLiteral = "ai"
+const AiCmdShortDesc = "Command for AI related operations."
+const AiCmdLongDesc = `Perform AI related operations such as uploading APIs and API Products to a vector database to provide context to the marketplace assistant.`
+const AiCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
+` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+// AiCmd represents the Ai command
+var AiCmd = &cobra.Command{
+	Use:     AiCmdLiteral,
+	Short:   AiCmdShortDesc,
+	Long:    AiCmdLongDesc,
+	Example: AiCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + AiCmdLiteral + " called")
+
+	},
+}
+
+// init using Cobra
+func init() {
+	RootCmd.AddCommand(AiCmd)
+}

--- a/import-export-cli/cmd/ai.go
+++ b/import-export-cli/cmd/ai.go
@@ -25,13 +25,13 @@ import (
 
 // Ai command related usage Info
 const AiCmdLiteral = "ai"
-const AiCmdShortDesc = "Command for AI related operations."
+const AiCmdShortDesc = "AI related commands."
 const AiCmdLongDesc = `Perform AI related operations such as uploading APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.`
 const AiCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
 ` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
 ` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
 ` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e -endpoint https://dev-tools.wso2.com/apim-ai-service production --all
-NOTE:The 2 flags (--token and --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 // AiCmd represents the Ai command
 var AiCmd = &cobra.Command{

--- a/import-export-cli/cmd/ai.go
+++ b/import-export-cli/cmd/ai.go
@@ -26,10 +26,12 @@ import (
 // Ai command related usage Info
 const AiCmdLiteral = "ai"
 const AiCmdShortDesc = "Command for AI related operations."
-const AiCmdLongDesc = `Perform AI related operations such as uploading APIs and API Products to a vector database to provide context to the marketplace assistant.`
+const AiCmdLongDesc = `Perform AI related operations such as uploading APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.`
 const AiCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
 ` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e -endpoint https://dev-tools.wso2.com/apim-ai-service production --all
+NOTE:The 2 flags (--token and --environment (-e)) are mandatory`
 
 // AiCmd represents the Ai command
 var AiCmd = &cobra.Command{

--- a/import-export-cli/cmd/aiDelete.go
+++ b/import-export-cli/cmd/aiDelete.go
@@ -1,0 +1,47 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Purge command related usage Info
+const PurgeCmdLiteral = "delete"
+const PurgeCmdShortDesc = "Purge APIs and API Products available in an environment from the vector database."
+const PurgeCmdLongDesc = `Purge APIs and API Products available in the environment specified by flag (--environment, -e)`
+const PurgeCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+				NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+// PurgeCmd represents the Purge command
+var PurgeCmd = &cobra.Command{
+	Use:     PurgeCmdLiteral,
+	Short:   PurgeCmdShortDesc,
+	Long:    PurgeCmdLongDesc,
+	Example: PurgeCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + PurgeCmdLiteral + " called")
+	},
+}
+
+// init using Cobra
+func init() {
+	AiCmd.AddCommand(PurgeCmd)
+}

--- a/import-export-cli/cmd/aiDelete.go
+++ b/import-export-cli/cmd/aiDelete.go
@@ -25,10 +25,10 @@ import (
 
 // Purge command related usage Info
 const PurgeCmdLiteral = "delete"
-const PurgeCmdShortDesc = "Purge APIs and API Products available in an environment from the vector database."
-const PurgeCmdLongDesc = `Purge APIs and API Products available in the environment specified by flag (--environment, -e)`
+const PurgeCmdShortDesc = "Purge APIs and API Products of a tenant from one environment from the vector database."
+const PurgeCmdLongDesc = `Purge APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
 const PurgeCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-				NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+NOTE: The 2 flags (--token and --environment (-e)) are mandatory`
 
 // PurgeCmd represents the Purge command
 var PurgeCmd = &cobra.Command{

--- a/import-export-cli/cmd/aiDelete.go
+++ b/import-export-cli/cmd/aiDelete.go
@@ -28,7 +28,7 @@ const PurgeCmdLiteral = "delete"
 const PurgeCmdShortDesc = "Purge APIs and API Products of a tenant from one environment from the vector database."
 const PurgeCmdLongDesc = `Purge APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
 const PurgeCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-NOTE: The 2 flags (--token and --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 // PurgeCmd represents the Purge command
 var PurgeCmd = &cobra.Command{

--- a/import-export-cli/cmd/aiDeleteApis.go
+++ b/import-export-cli/cmd/aiDeleteApis.go
@@ -30,10 +30,10 @@ import (
 const PurgeAPIsCmdLiteral = "apis"
 const purgeAPIsCmdShortDesc = "Purge APIs and API Products in an environment from a vector database."
 
-const purgeAPIsCmdLongDesc = "Purge APIs and API Products in an environment from a vector database."
-const PurgeAPIsCmdLongDesc = `Purge APIs and API Products available in the environment specified by flag (--environment, -e)`
-const purgeAPIsCmdExamples = utils.ProjectName + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
-							NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+const purgeAPIsCmdLongDesc = "Purge APIs and API Products of a tenant from one environment from a vector database."
+const PurgeAPIsCmdLongDesc = `Purge APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
+const purgeAPIsCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
+							NOTE: The 2 flags (--token and --environment (-e)) are mandatory`
 
 var PurgeAPIsCmd = &cobra.Command{
 	Use: PurgeAPIsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +

--- a/import-export-cli/cmd/aiDeleteApis.go
+++ b/import-export-cli/cmd/aiDeleteApis.go
@@ -28,12 +28,12 @@ import (
 )
 
 const PurgeAPIsCmdLiteral = "apis"
-const purgeAPIsCmdShortDesc = "Purge APIs and API Products in an environment from a vector database."
+const purgeAPIsCmdShortDesc = "Purge APIs and API Products of a tenant from one environment from a vector database."
 
 const purgeAPIsCmdLongDesc = "Purge APIs and API Products of a tenant from one environment from a vector database."
 const PurgeAPIsCmdLongDesc = `Purge APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
 const purgeAPIsCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
-							NOTE: The 2 flags (--token and --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 var PurgeAPIsCmd = &cobra.Command{
 	Use: PurgeAPIsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +
@@ -60,7 +60,7 @@ func executeAIDeleteAPIsCmd(credential credentials.Credential, token, endpoint s
 	} else {
 		Tenant = strings.Split(credential.Username, "@")[1]
 	}
-	impl.AIDeleteAPIs(token, endpoint, Tenant)
+	impl.AIDeleteAPIs(credential, CmdPurgeEnvironment, token, endpoint, Tenant)
 }
 
 func init() {
@@ -70,6 +70,4 @@ func init() {
 	PurgeAPIsCmd.Flags().StringVarP(&token, "token", "", "", "on-prem-key of the organization")
 	PurgeAPIsCmd.Flags().StringVarP(&endpoint, "endpoint", "", "", "endpoint of the marketplace assistant service")
 	_ = PurgeAPIsCmd.MarkFlagRequired("environment")
-	_ = PurgeAPIsCmd.MarkFlagRequired("token")
-	_ = PurgeAPIsCmd.MarkFlagRequired("endpoint")
 }

--- a/import-export-cli/cmd/aiDeleteApis.go
+++ b/import-export-cli/cmd/aiDeleteApis.go
@@ -1,0 +1,75 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const PurgeAPIsCmdLiteral = "apis"
+const purgeAPIsCmdShortDesc = "Purge APIs and API Products in an environment from a vector database."
+
+const purgeAPIsCmdLongDesc = "Purge APIs and API Products in an environment from a vector database."
+const PurgeAPIsCmdLongDesc = `Purge APIs and API Products available in the environment specified by flag (--environment, -e)`
+const purgeAPIsCmdExamples = utils.ProjectName + ` ` + PurgeCmdLiteral + ` ` + PurgeAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
+							NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+var PurgeAPIsCmd = &cobra.Command{
+	Use: PurgeAPIsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +
+		"<environment-from-which-artifacts-should-be-purgeed>)",
+	Short:   purgeAPIsCmdShortDesc,
+	Long:    purgeAPIsCmdLongDesc,
+	Example: purgeAPIsCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + PurgeAPIsCmdLiteral + " called")
+
+		cred, err := GetCredentials(CmdPurgeEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeAIDeleteAPIsCmd(cred, token, endpoint)
+	},
+}
+
+// Do operations to Purge APIs to the vector database
+func executeAIDeleteAPIsCmd(credential credentials.Credential, token, endpoint string) {
+	var Tenant string
+	if !strings.Contains(credential.Username, "@") {
+		Tenant = "carbon.super"
+	} else {
+		Tenant = strings.Split(credential.Username, "@")[1]
+	}
+	impl.AIDeleteAPIs(token, endpoint, Tenant)
+}
+
+func init() {
+	PurgeCmd.AddCommand(PurgeAPIsCmd)
+	PurgeAPIsCmd.Flags().StringVarP(&CmdPurgeEnvironment, "environment", "e",
+		"", "Environment from which the APIs should be Purgeed")
+	PurgeAPIsCmd.Flags().StringVarP(&token, "token", "", "", "on-prem-key of the organization")
+	PurgeAPIsCmd.Flags().StringVarP(&endpoint, "endpoint", "", "", "endpoint of the marketplace assistant service")
+	_ = PurgeAPIsCmd.MarkFlagRequired("environment")
+	_ = PurgeAPIsCmd.MarkFlagRequired("token")
+	_ = PurgeAPIsCmd.MarkFlagRequired("endpoint")
+}

--- a/import-export-cli/cmd/aiDeleteArtifacts.go
+++ b/import-export-cli/cmd/aiDeleteArtifacts.go
@@ -27,7 +27,7 @@ import (
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
-const PurgeAPIsCmdLiteral = "apis"
+const PurgeAPIsCmdLiteral = "artifacts"
 const purgeAPIsCmdShortDesc = "Purge APIs and API Products of a tenant from one environment from a vector database."
 
 const purgeAPIsCmdLongDesc = "Purge APIs and API Products of a tenant from one environment from a vector database."

--- a/import-export-cli/cmd/aiUpload.go
+++ b/import-export-cli/cmd/aiUpload.go
@@ -1,0 +1,49 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+// Upload command related usage Info
+const UploadCmdLiteral = "upload"
+const UploadCmdShortDesc = "Upload APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
+const UploadCmdLongDesc = `Upload APIs and API Products available in the environment specified by flag (--environment, -e)`
+const UploadCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+						NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+
+// UploadCmd represents the Upload command
+var UploadCmd = &cobra.Command{
+	Use:     UploadCmdLiteral,
+	Short:   UploadCmdShortDesc,
+	Long:    UploadCmdLongDesc,
+	Example: UploadCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + UploadCmdLiteral + " called")
+
+	},
+}
+
+// init using Cobra
+func init() {
+	AiCmd.AddCommand(UploadCmd)
+}

--- a/import-export-cli/cmd/aiUpload.go
+++ b/import-export-cli/cmd/aiUpload.go
@@ -25,11 +25,11 @@ import (
 
 // Upload command related usage Info
 const UploadCmdLiteral = "upload"
-const UploadCmdShortDesc = "Upload APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
-const UploadCmdLongDesc = `Upload APIs and API Products available in the environment specified by flag (--environment, -e)`
-const UploadCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-						NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
-
+const UploadCmdShortDesc = "Upload APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant."
+const UploadCmdLongDesc = `Upload APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
+const UploadCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+NOTE: The 2 flags (--token --environment (-e)) are mandatory`
 
 // UploadCmd represents the Upload command
 var UploadCmd = &cobra.Command{

--- a/import-export-cli/cmd/aiUpload.go
+++ b/import-export-cli/cmd/aiUpload.go
@@ -29,7 +29,7 @@ const UploadCmdShortDesc = "Upload APIs and API Products of a tenant from one en
 const UploadCmdLongDesc = `Upload APIs and API Products of a tenant from one environment specified by flag (--environment, -e)`
 const UploadCmdExamples = utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
 ` + utils.ProjectName + ` ` + AiCmdLiteral + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
-NOTE: The 2 flags (--token --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 // UploadCmd represents the Upload command
 var UploadCmd = &cobra.Command{

--- a/import-export-cli/cmd/aiUploadApiProducts.go
+++ b/import-export-cli/cmd/aiUploadApiProducts.go
@@ -1,0 +1,69 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const UploadAPIProductsCmdLiteral = "api-products"
+const uploadAPIProductsCmdShortDesc = "Upload APIs and API Products to a vector database."
+
+// const uploadAPIProductsCmdLongDesc = "Upload public APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
+const uploadAPIProductsCmdLongDesc = `Upload public APIs and API Products available in the environment specified by flag (--environment, -e)`
+const uploadAPIProductsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+							 NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+var UploadAPIProductsCmd = &cobra.Command{
+	Use: UploadAPIProductsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +
+		"<environment-from-which-artifacts-should-be-uploaded>)",
+	Short:   uploadAPIProductsCmdShortDesc,
+	Long:    uploadAPIProductsCmdLongDesc,
+	Example: uploadAPIProductsCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + UploadAPIsCmdLiteral + " called")
+
+		cred, err := GetCredentials(CmdUploadEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeAIUploadAPIProductsCmd(cred, token, endpoint)
+	},
+}
+
+// Do operations to upload APIs to the vector database
+func executeAIUploadAPIProductsCmd(credential credentials.Credential, token, endpoint string) {
+	impl.AIUploadAPIs(credential, CmdUploadEnvironment, token, endpoint, uploadAll, true)
+}
+
+func init() {
+	UploadCmd.AddCommand(UploadAPIProductsCmd)
+	UploadAPIProductsCmd.Flags().StringVarP(&CmdUploadEnvironment, "environment", "e",
+		"", "Environment from which the APIs should be uploaded")
+	UploadAPIProductsCmd.Flags().StringVarP(&token, "token", "", "", "on-prem-key of the organization")
+	UploadAPIProductsCmd.Flags().StringVarP(&endpoint, "endpoint", "", "", "endpoint of the marketplace assistant service")
+	UploadAPIProductsCmd.Flags().BoolVarP(&uploadAll, "all", "", false,
+		"Upload both apis and api products")
+	_ = UploadAPIProductsCmd.MarkFlagRequired("environment")
+	_ = UploadAPIProductsCmd.MarkFlagRequired("token")
+
+}

--- a/import-export-cli/cmd/aiUploadApiProducts.go
+++ b/import-export-cli/cmd/aiUploadApiProducts.go
@@ -33,7 +33,7 @@ const uploadAPIProductsCmdLongDesc = `Upload public API Products of a tenant fro
 const uploadAPIProductsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
 ` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
 ` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
-NOTE: The 2 flags (--token, --endpoint and --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 var UploadAPIProductsCmd = &cobra.Command{
 	Use: UploadAPIProductsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +
@@ -66,6 +66,5 @@ func init() {
 	UploadAPIProductsCmd.Flags().BoolVarP(&uploadAll, "all", "", false,
 		"Upload both apis and api products")
 	_ = UploadAPIProductsCmd.MarkFlagRequired("environment")
-	_ = UploadAPIProductsCmd.MarkFlagRequired("token")
 
 }

--- a/import-export-cli/cmd/aiUploadApiProducts.go
+++ b/import-export-cli/cmd/aiUploadApiProducts.go
@@ -26,12 +26,14 @@ import (
 )
 
 const UploadAPIProductsCmdLiteral = "api-products"
-const uploadAPIProductsCmdShortDesc = "Upload APIs and API Products to a vector database."
+const uploadAPIProductsCmdShortDesc = "Upload API Products of a tenant from one environment to a vector database."
 
 // const uploadAPIProductsCmdLongDesc = "Upload public APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
-const uploadAPIProductsCmdLongDesc = `Upload public APIs and API Products available in the environment specified by flag (--environment, -e)`
-const uploadAPIProductsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-							 NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+const uploadAPIProductsCmdLongDesc = `Upload public API Products of a tenant from one environment specified by flag (--environment, -e)`
+const uploadAPIProductsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIProductsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
+NOTE: The 2 flags (--token, --endpoint and --environment (-e)) are mandatory`
 
 var UploadAPIProductsCmd = &cobra.Command{
 	Use: UploadAPIProductsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +

--- a/import-export-cli/cmd/aiUploadApis.go
+++ b/import-export-cli/cmd/aiUploadApis.go
@@ -1,0 +1,72 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/impl"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const UploadAPIsCmdLiteral = "apis"
+const uploadAPIsCmdShortDesc = "Upload APIs and API Products to a vector database."
+
+const uploadAPIsCmdLongDesc = "Upload public APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
+const uploadAPIsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+							NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+
+var token string
+var endpoint string
+var uploadAll bool
+var uploadProducts bool
+
+var UploadAPIsCmd = &cobra.Command{
+	Use: UploadAPIsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +
+		"<environment-from-which-artifacts-should-be-uploaded> --all)",
+	Short:   uploadAPIsCmdShortDesc,
+	Long:    uploadAPIsCmdLongDesc,
+	Example: uploadAPIsCmdExamples,
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.Logln(utils.LogPrefixInfo + UploadAPIsCmdLiteral + " called")
+
+		cred, err := GetCredentials(CmdUploadEnvironment)
+		if err != nil {
+			utils.HandleErrorAndExit("Error getting credentials", err)
+		}
+		executeAIUploadAPIsCmd(cred, token, endpoint)
+	},
+}
+
+// Do operatioSns to upload APIs to the vector database
+func executeAIUploadAPIsCmd(credential credentials.Credential, token, endpoint string) {
+	impl.AIUploadAPIs(credential, CmdUploadEnvironment, token, endpoint, uploadAll, false)
+}
+
+func init() {
+	UploadCmd.AddCommand(UploadAPIsCmd)
+	UploadAPIsCmd.Flags().StringVarP(&CmdUploadEnvironment, "environment", "e",
+		"", "Environment from which the APIs should be uploaded")
+	UploadAPIsCmd.Flags().StringVarP(&token, "token", "", "", "on-prem-key of the organization")
+	UploadAPIsCmd.Flags().StringVarP(&endpoint, "endpoint", "", "", "endpoint of the marketplace assistant service")
+	UploadAPIsCmd.Flags().BoolVarP(&uploadAll, "all", "", false,
+		"Upload both apis and api products")
+	_ = UploadAPIsCmd.MarkFlagRequired("environment")
+	_ = UploadAPIsCmd.MarkFlagRequired("token")
+}

--- a/import-export-cli/cmd/aiUploadApis.go
+++ b/import-export-cli/cmd/aiUploadApis.go
@@ -26,16 +26,19 @@ import (
 )
 
 const UploadAPIsCmdLiteral = "apis"
-const uploadAPIsCmdShortDesc = "Upload APIs and API Products to a vector database."
+const uploadAPIsCmdShortDesc = "Upload APIs of a tenant from one environment to a vector database."
 
-const uploadAPIsCmdLongDesc = "Upload public APIs and API Products in an environment to a vector database to provide context to the marketplace assistant."
-const uploadAPIsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
-							NOTE: All the flags (--token, --endpoint and --environment (-e)) are mandatory`
+const uploadAPIsCmdLongDesc = "Upload APIs of a tenant from one environment to a vector database to provide context to the marketplace assistant."
+const uploadAPIsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
+NOTE: The 2 flags (--token, --endpoint and --environment (-e)) are mandatory`
 
-var token string
-var endpoint string
-var uploadAll bool
-var uploadProducts bool
+var (
+	token     string
+	endpoint  string
+	uploadAll bool
+)
 
 var UploadAPIsCmd = &cobra.Command{
 	Use: UploadAPIsCmdLiteral + " (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment " +

--- a/import-export-cli/cmd/aiUploadApis.go
+++ b/import-export-cli/cmd/aiUploadApis.go
@@ -32,7 +32,7 @@ const uploadAPIsCmdLongDesc = "Upload APIs of a tenant from one environment to a
 const uploadAPIsCmdExamples = utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
 ` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
 ` + utils.ProjectName + ` ` + UploadCmdLiteral + ` ` + UploadAPIsCmdLiteral + ` --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
-NOTE: The 2 flags (--token, --endpoint and --environment (-e)) are mandatory`
+NOTE:The flag (--environment (-e)) is mandatory`
 
 var (
 	token     string
@@ -71,5 +71,4 @@ func init() {
 	UploadAPIsCmd.Flags().BoolVarP(&uploadAll, "all", "", false,
 		"Upload both apis and api products")
 	_ = UploadAPIsCmd.MarkFlagRequired("environment")
-	_ = UploadAPIsCmd.MarkFlagRequired("token")
 }

--- a/import-export-cli/cmd/deprecated/exportAPIs.go
+++ b/import-export-cli/cmd/deprecated/exportAPIs.go
@@ -87,7 +87,7 @@ func executeExportAPIsCmd(credential credentials.Credential, exportDirectory str
 	}
 
 	impl.ExportAPIs(credential, exportRelatedFilesPath, cmd.CmdExportEnvironment, cmd.CmdResourceTenantDomain, exportAPIsFormat, cmd.CmdUsername,
-		apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, false)
+		apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, false, false)
 }
 
 func init() {

--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -87,7 +87,7 @@ func executeExportAPIsCmd(credential credentials.Credential, exportDirectory str
 	}
 
 	impl.ExportAPIs(credential, exportRelatedFilesPath, CmdExportEnvironment, CmdResourceTenantDomain, exportAPIsFormat,
-		CmdUsername, apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, exportAPIsAllRevisions)
+		CmdUsername, apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, exportAPIsAllRevisions, false)
 }
 
 func init() {

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -48,6 +48,8 @@ var insecure bool
 var cmdPassword string
 var CmdUsername string
 var CmdExportEnvironment string
+var CmdUploadEnvironment string
+var CmdPurgeEnvironment string
 var CmdResourceTenantDomain string
 var CmdForceStartFromBegin bool
 
@@ -142,12 +144,13 @@ func createConfigFiles() {
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)
 		mainConfig.Config = utils.Config{HttpRequestTimeout: utils.DefaultHttpRequestTimeout,
-			ExportDirectory:      utils.DefaultExportDirPath,
-			KubernetesMode:       k8sUtils.DefaultKubernetesMode,
-			TokenType:            utils.DefaultTokenType,
-			VCSDeletionEnabled:   false,
-			VCSConfigFilePath:    "",
-			TLSRenegotiationMode: utils.TLSRenegotiationNever}
+			MarketplaceAssistantThreadCount: utils.DefaultMarketplaceAssistantThreadCount,
+			ExportDirectory:                 utils.DefaultExportDirPath,
+			KubernetesMode:                  k8sUtils.DefaultKubernetesMode,
+			TokenType:                       utils.DefaultTokenType,
+			VCSDeletionEnabled:              false,
+			VCSConfigFilePath:               "",
+			TLSRenegotiationMode:            utils.TLSRenegotiationNever}
 
 		utils.WriteConfigFile(mainConfig, utils.MainConfigFilePath)
 	}
@@ -199,7 +202,7 @@ func initConfig() {
 	*/
 }
 
-//disable flags when the mode set to kubernetes
+// disable flags when the mode set to kubernetes
 func isK8sEnabled() bool {
 	//Get config to check mode
 	configVars := utils.GetMainConfigFromFileSilently(utils.MainConfigFilePath)
@@ -210,7 +213,7 @@ func isK8sEnabled() bool {
 	}
 }
 
-//execute kubernetes commands
+// execute kubernetes commands
 func ExecuteKubernetes(arg ...string) {
 	cmd := exec.Command(
 		k8sUtils.Kubectl,

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -151,7 +151,7 @@ func createConfigFiles() {
 			VCSConfigFilePath:    "",
 			TLSRenegotiationMode: utils.TLSRenegotiationNever,
 			AIThreadCount:        utils.DefaultAIThreadCount,
-			OnPremKey:            utils.OnPremKey}
+			AIToken:              utils.AIToken}
 
 		utils.WriteConfigFile(mainConfig, utils.MainConfigFilePath)
 	}

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -144,13 +144,14 @@ func createConfigFiles() {
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)
 		mainConfig.Config = utils.Config{HttpRequestTimeout: utils.DefaultHttpRequestTimeout,
-			MarketplaceAssistantThreadCount: utils.DefaultMarketplaceAssistantThreadCount,
 			ExportDirectory:                 utils.DefaultExportDirPath,
 			KubernetesMode:                  k8sUtils.DefaultKubernetesMode,
 			TokenType:                       utils.DefaultTokenType,
 			VCSDeletionEnabled:              false,
 			VCSConfigFilePath:               "",
-			TLSRenegotiationMode:            utils.TLSRenegotiationNever}
+			TLSRenegotiationMode:            utils.TLSRenegotiationNever,
+			MarketplaceAssistantThreadCount: utils.DefaultMarketplaceAssistantThreadCount,
+			OnPremKey:                       utils.OnPremKey}
 
 		utils.WriteConfigFile(mainConfig, utils.MainConfigFilePath)
 	}

--- a/import-export-cli/cmd/root.go
+++ b/import-export-cli/cmd/root.go
@@ -144,14 +144,14 @@ func createConfigFiles() {
 	if !utils.IsFileExist(utils.MainConfigFilePath) {
 		var mainConfig = new(utils.MainConfig)
 		mainConfig.Config = utils.Config{HttpRequestTimeout: utils.DefaultHttpRequestTimeout,
-			ExportDirectory:                 utils.DefaultExportDirPath,
-			KubernetesMode:                  k8sUtils.DefaultKubernetesMode,
-			TokenType:                       utils.DefaultTokenType,
-			VCSDeletionEnabled:              false,
-			VCSConfigFilePath:               "",
-			TLSRenegotiationMode:            utils.TLSRenegotiationNever,
-			MarketplaceAssistantThreadCount: utils.DefaultMarketplaceAssistantThreadCount,
-			OnPremKey:                       utils.OnPremKey}
+			ExportDirectory:      utils.DefaultExportDirPath,
+			KubernetesMode:       k8sUtils.DefaultKubernetesMode,
+			TokenType:            utils.DefaultTokenType,
+			VCSDeletionEnabled:   false,
+			VCSConfigFilePath:    "",
+			TLSRenegotiationMode: utils.TLSRenegotiationNever,
+			AIThreadCount:        utils.DefaultAIThreadCount,
+			OnPremKey:            utils.OnPremKey}
 
 		utils.WriteConfigFile(mainConfig, utils.MainConfigFilePath)
 	}

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -28,6 +28,7 @@ import (
 )
 
 var flagHttpRequestTimeout int
+var flagMarketplaceAssistantThreadCount int
 var flagExportDirectory string
 var flagKubernetesMode string
 var flagTLSRenegotiationMode string
@@ -47,6 +48,7 @@ const setCmdShortDesc = "Set configuration parameters, per API log levels or cor
 
 const setCmdLongDesc = `Set configuration parameters. You can use one of the following flags
 * --http-request-timeout <time-in-milli-seconds>
+* --marketplace-assistant-thread-count <number-of-threads>
 * --tls-renegotiation-mode <never|once|freely>
 * --export-directory <path-to-directory-where-apis-should-be-saved>
 * --vcs-deletion-enabled <enable-or-disable-project-deletion-via-vcs>
@@ -57,6 +59,7 @@ const setCmdLongDesc = `Set configuration parameters. You can use one of the fol
 const setCmdExamples = utils.ProjectName + ` ` + SetCmdLiteral + ` --http-request-timeout 3600 --export-directory /home/user/exported-apis
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --http-request-timeout 5000 --export-directory C:\Documents\exported
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --http-request-timeout 5000
+` + utils.ProjectName + ` ` + SetCmdLiteral + ` --marketplace-assistant-thread-count 5
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --tls-renegotiation-mode freely
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-deletion-enabled=true
 ` + utils.ProjectName + ` ` + SetCmdLiteral + ` --vcs-config-path /home/user/custom/vcs-config.yaml
@@ -89,6 +92,16 @@ func executeSetCmd(mainConfigFilePath string, cmd *cobra.Command) {
 		configVars.Config.HttpRequestTimeout = flagHttpRequestTimeout
 	} else {
 		fmt.Println("Invalid input for flag --http-request-timeout")
+	}
+
+	if flagMarketplaceAssistantThreadCount > 0 {
+		//Check whether the provided Http time out value is not equal to default value
+		if flagMarketplaceAssistantThreadCount != configVars.Config.MarketplaceAssistantThreadCount {
+			fmt.Println("Marketplace Assistant Thread Size is set to : ", flagMarketplaceAssistantThreadCount)
+		}
+		configVars.Config.MarketplaceAssistantThreadCount = flagMarketplaceAssistantThreadCount
+	} else {
+		fmt.Println("Invalid input for flag --marketplace-assistant-thread-count")
 	}
 
 	//Change Export Directory path
@@ -160,6 +173,7 @@ func init() {
 	RootCmd.AddCommand(SetCmd)
 
 	var defaultHttpRequestTimeout int
+	var defaultMarketplaceAssistantThreadCount int
 	var defaultExportDirectory string
 
 	// read current values in file to be passed into default values for flags below
@@ -169,12 +183,18 @@ func init() {
 		defaultHttpRequestTimeout = mainConfig.Config.HttpRequestTimeout
 	}
 
+	if mainConfig.Config.MarketplaceAssistantThreadCount != 0 {
+		defaultMarketplaceAssistantThreadCount = mainConfig.Config.MarketplaceAssistantThreadCount
+	}
+
 	if mainConfig.Config.ExportDirectory != "" {
 		defaultExportDirectory = mainConfig.Config.ExportDirectory
 	}
 
 	SetCmd.Flags().IntVar(&flagHttpRequestTimeout, "http-request-timeout", defaultHttpRequestTimeout,
 		"Timeout for HTTP Client")
+	SetCmd.Flags().IntVar(&flagMarketplaceAssistantThreadCount, "marketplace-assistant-thread-count", defaultMarketplaceAssistantThreadCount,
+		"No of threads to be used by Marketplace Assistant for parallel processing")
 	SetCmd.Flags().StringVar(&flagExportDirectory, "export-directory", defaultExportDirectory,
 		"Path to directory where APIs should be saved")
 	SetCmd.Flags().StringVar(&flagTLSRenegotiationMode, "tls-renegotiation-mode", utils.TLSRenegotiationNever,

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -220,5 +220,5 @@ func init() {
 	SetCmd.Flags().IntVar(&flagAIThreadCount, "ai-thread-count", defaultAIThreadCount,
 		"No of threads to be used by Marketplace Assistant for parallel processing")
 	SetCmd.Flags().StringVar(&flagAIToken, flagAITokenName, "",
-		"Token (On prem key) of ai features")
+		"Token (On prem key) of AI features")
 }

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -28,7 +28,7 @@ import (
 )
 
 var flagHttpRequestTimeout int
-var flagMarketplaceAssistantThreadCount int
+var flagAIThreadCount int
 var flagOnPremKey string
 var flagExportDirectory string
 var flagKubernetesMode string
@@ -97,12 +97,12 @@ func executeSetCmd(mainConfigFilePath string, cmd *cobra.Command) {
 		fmt.Println("Invalid input for flag --http-request-timeout")
 	}
 
-	if flagMarketplaceAssistantThreadCount > 0 {
+	if flagAIThreadCount > 0 {
 		//Check whether the provided Http time out value is not equal to default value
-		if flagMarketplaceAssistantThreadCount != configVars.Config.MarketplaceAssistantThreadCount {
-			fmt.Println("Marketplace Assistant Thread Size is set to : ", flagMarketplaceAssistantThreadCount)
+		if flagAIThreadCount != configVars.Config.AIThreadCount {
+			fmt.Println("Marketplace Assistant Thread Size is set to : ", flagAIThreadCount)
 		}
-		configVars.Config.MarketplaceAssistantThreadCount = flagMarketplaceAssistantThreadCount
+		configVars.Config.AIThreadCount = flagAIThreadCount
 	} else {
 		fmt.Println("Invalid input for flag --ai-thread-count")
 	}
@@ -187,7 +187,7 @@ func init() {
 	RootCmd.AddCommand(SetCmd)
 
 	var defaultHttpRequestTimeout int
-	var defaultMarketplaceAssistantThreadCount int
+	var defaultAIThreadCount int
 	var defaultOnPremKey string
 	var defaultExportDirectory string
 
@@ -198,8 +198,8 @@ func init() {
 		defaultHttpRequestTimeout = mainConfig.Config.HttpRequestTimeout
 	}
 
-	if mainConfig.Config.MarketplaceAssistantThreadCount != 0 {
-		defaultMarketplaceAssistantThreadCount = mainConfig.Config.MarketplaceAssistantThreadCount
+	if mainConfig.Config.AIThreadCount != 0 {
+		defaultAIThreadCount = mainConfig.Config.AIThreadCount
 	}
 
 	if mainConfig.Config.OnPremKey != "" {
@@ -228,7 +228,7 @@ func init() {
 		"Path to the source repository to be considered during VCS deploy")
 	SetCmd.Flags().StringVar(&flagVCSDeploymentRepoPath, flagVCSDeploymentRepoPathName, "",
 		"Path to the deoployment repository to be considered during VCS deploy")
-	SetCmd.Flags().IntVar(&flagMarketplaceAssistantThreadCount, "ai-thread-count", defaultMarketplaceAssistantThreadCount,
+	SetCmd.Flags().IntVar(&flagAIThreadCount, "ai-thread-count", defaultAIThreadCount,
 		"No of threads to be used by Marketplace Assistant for parallel processing")
 	SetCmd.Flags().StringVar(&flagOnPremKey, "ai-token", defaultOnPremKey,
 		"On prem key of ai features")

--- a/import-export-cli/cmd/set.go
+++ b/import-export-cli/cmd/set.go
@@ -29,7 +29,7 @@ import (
 
 var flagHttpRequestTimeout int
 var flagAIThreadCount int
-var flagOnPremKey string
+var flagAIToken string
 var flagExportDirectory string
 var flagKubernetesMode string
 var flagTLSRenegotiationMode string
@@ -42,6 +42,7 @@ var flagVCSDeploymentRepoPath string
 const flagVCSConfigPathName = "vcs-config-path"
 const flagVCSSourceRepoPathName = "vcs-source-repo-path"
 const flagVCSDeploymentRepoPathName = "vcs-deployment-repo-path"
+const flagAITokenName = "ai-token"
 
 // Set command related Info
 const SetCmdLiteral = "set"
@@ -108,17 +109,6 @@ func executeSetCmd(mainConfigFilePath string, cmd *cobra.Command) {
 	}
 
 	//Change Export Directory path
-	if flagOnPremKey != "" && utils.IsValid(flagOnPremKey) {
-		//Check whether the provided export directory is not equal to default value
-		if flagOnPremKey != configVars.Config.OnPremKey {
-			fmt.Println("On Prem Key is set to  : ", flagOnPremKey)
-		}
-		configVars.Config.OnPremKey = flagOnPremKey
-	} else {
-		fmt.Println("Invalid input for flag --ai-token")
-	}
-
-	//Change Export Directory path
 	if flagExportDirectory != "" && utils.IsValid(flagExportDirectory) {
 		//Check whether the provided export directory is not equal to default value
 		if flagExportDirectory != configVars.Config.ExportDirectory {
@@ -178,6 +168,10 @@ func executeSetCmd(mainConfigFilePath string, cmd *cobra.Command) {
 		configVars.Config.VCSDeploymentRepoPath = flagVCSDeploymentRepoPath
 		fmt.Println("VCS deployment repo path is set to : " + flagVCSDeploymentRepoPath)
 	}
+	if cmd.Flags().Changed(flagAITokenName) {
+		configVars.Config.AIToken = flagAIToken
+		fmt.Println("AI token is set to  : " + flagAIToken)
+	}
 
 	utils.WriteConfigFile(configVars, mainConfigFilePath)
 }
@@ -188,7 +182,6 @@ func init() {
 
 	var defaultHttpRequestTimeout int
 	var defaultAIThreadCount int
-	var defaultOnPremKey string
 	var defaultExportDirectory string
 
 	// read current values in file to be passed into default values for flags below
@@ -200,10 +193,6 @@ func init() {
 
 	if mainConfig.Config.AIThreadCount != 0 {
 		defaultAIThreadCount = mainConfig.Config.AIThreadCount
-	}
-
-	if mainConfig.Config.OnPremKey != "" {
-		defaultOnPremKey = mainConfig.Config.OnPremKey
 	}
 
 	if mainConfig.Config.ExportDirectory != "" {
@@ -230,6 +219,6 @@ func init() {
 		"Path to the deoployment repository to be considered during VCS deploy")
 	SetCmd.Flags().IntVar(&flagAIThreadCount, "ai-thread-count", defaultAIThreadCount,
 		"No of threads to be used by Marketplace Assistant for parallel processing")
-	SetCmd.Flags().StringVar(&flagOnPremKey, "ai-token", defaultOnPremKey,
-		"On prem key of ai features")
+	SetCmd.Flags().StringVar(&flagAIToken, flagAITokenName, "",
+		"Token (On prem key) of ai features")
 }

--- a/import-export-cli/docs/apictl.md
+++ b/import-export-cli/docs/apictl.md
@@ -22,6 +22,7 @@ apictl [flags]
 ### SEE ALSO
 
 * [apictl add](apictl_add.md)	 - Add Environment to Config file
+* [apictl ai](apictl_ai.md)	 - AI related commands.
 * [apictl aws](apictl_aws.md)	 - AWS Api-gateway related commands
 * [apictl bundle](apictl_bundle.md)	 - Archive any source project artifact to zip format
 * [apictl change-status](apictl_change-status.md)	 - Change Status of an API or API Product

--- a/import-export-cli/docs/apictl_ai.md
+++ b/import-export-cli/docs/apictl_ai.md
@@ -1,0 +1,41 @@
+## apictl ai
+
+AI related commands.
+
+### Synopsis
+
+Perform AI related operations such as uploading APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+
+```
+apictl ai [flags]
+```
+
+### Examples
+
+```
+apictl ai upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
+apictl ai upload api-products --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+apictl ai upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+apictl ai delete apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e -endpoint https://dev-tools.wso2.com/apim-ai-service production --all
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -h, --help   help for ai
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl](apictl.md)	 - CLI for Importing and Exporting APIs and Applications and Managing WSO2 Micro Integrator
+* [apictl ai delete](apictl_ai_delete.md)	 - Purge APIs and API Products of a tenant from one environment from the vector database.
+* [apictl ai upload](apictl_ai_upload.md)	 - Upload APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+

--- a/import-export-cli/docs/apictl_ai_delete.md
+++ b/import-export-cli/docs/apictl_ai_delete.md
@@ -1,0 +1,37 @@
+## apictl ai delete
+
+Purge APIs and API Products of a tenant from one environment from the vector database.
+
+### Synopsis
+
+Purge APIs and API Products of a tenant from one environment specified by flag (--environment, -e)
+
+```
+apictl ai delete [flags]
+```
+
+### Examples
+
+```
+apictl ai delete artifacts --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl ai](apictl_ai.md)	 - AI related commands.
+* [apictl ai delete artifacts](apictl_ai_delete_artifacts.md)	 - Purge APIs and API Products of a tenant from one environment from a vector database.
+

--- a/import-export-cli/docs/apictl_ai_delete_artifacts.md
+++ b/import-export-cli/docs/apictl_ai_delete_artifacts.md
@@ -1,0 +1,39 @@
+## apictl ai delete artifacts
+
+Purge APIs and API Products of a tenant from one environment from a vector database.
+
+### Synopsis
+
+Purge APIs and API Products of a tenant from one environment from a vector database.
+
+```
+apictl ai delete artifacts (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment <environment-from-which-artifacts-should-be-purgeed>) [flags]
+```
+
+### Examples
+
+```
+apictl ai delete artifacts --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+      --endpoint string      endpoint of the marketplace assistant service
+  -e, --environment string   Environment from which the APIs should be Purgeed
+  -h, --help                 help for artifacts
+      --token string         on-prem-key of the organization
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl ai delete](apictl_ai_delete.md)	 - Purge APIs and API Products of a tenant from one environment from the vector database.
+

--- a/import-export-cli/docs/apictl_ai_upload.md
+++ b/import-export-cli/docs/apictl_ai_upload.md
@@ -1,0 +1,39 @@
+## apictl ai upload
+
+Upload APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+
+### Synopsis
+
+Upload APIs and API Products of a tenant from one environment specified by flag (--environment, -e)
+
+```
+apictl ai upload [flags]
+```
+
+### Examples
+
+```
+apictl ai upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+apictl ai upload api-products --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+  -h, --help   help for upload
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl ai](apictl_ai.md)	 - AI related commands.
+* [apictl ai upload api-products](apictl_ai_upload_api-products.md)	 - Upload API Products of a tenant from one environment to a vector database.
+* [apictl ai upload apis](apictl_ai_upload_apis.md)	 - Upload APIs of a tenant from one environment to a vector database.
+

--- a/import-export-cli/docs/apictl_ai_upload_api-products.md
+++ b/import-export-cli/docs/apictl_ai_upload_api-products.md
@@ -1,0 +1,42 @@
+## apictl ai upload api-products
+
+Upload API Products of a tenant from one environment to a vector database.
+
+### Synopsis
+
+Upload public API Products of a tenant from one environment specified by flag (--environment, -e)
+
+```
+apictl ai upload api-products (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment <environment-from-which-artifacts-should-be-uploaded>) [flags]
+```
+
+### Examples
+
+```
+apictl upload api-products --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+apictl upload api-products --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+apictl upload api-products --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+      --all                  Upload both apis and api products
+      --endpoint string      endpoint of the marketplace assistant service
+  -e, --environment string   Environment from which the APIs should be uploaded
+  -h, --help                 help for api-products
+      --token string         on-prem-key of the organization
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl ai upload](apictl_ai_upload.md)	 - Upload APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+

--- a/import-export-cli/docs/apictl_ai_upload_apis.md
+++ b/import-export-cli/docs/apictl_ai_upload_apis.md
@@ -1,0 +1,42 @@
+## apictl ai upload apis
+
+Upload APIs of a tenant from one environment to a vector database.
+
+### Synopsis
+
+Upload APIs of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+
+```
+apictl ai upload apis (--endpoint <endpoint-url> --token <on-prem-key-of-the-organization> --environment <environment-from-which-artifacts-should-be-uploaded> --all) [flags]
+```
+
+### Examples
+
+```
+apictl upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production --all
+apictl upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 --endpoint https://dev-tools.wso2.com/apim-ai-service -e production 
+apictl upload apis --token 2fdca1b6-6a28-4aea-add6-77c97033bdb9 -e production 
+NOTE:The flag (--environment (-e)) is mandatory
+```
+
+### Options
+
+```
+      --all                  Upload both apis and api products
+      --endpoint string      endpoint of the marketplace assistant service
+  -e, --environment string   Environment from which the APIs should be uploaded
+  -h, --help                 help for apis
+      --token string         on-prem-key of the organization
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --insecure   Allow connections to SSL endpoints without certs
+      --verbose    Enable verbose mode
+```
+
+### SEE ALSO
+
+* [apictl ai upload](apictl_ai_upload.md)	 - Upload APIs and API Products of a tenant from one environment to a vector database to provide context to the marketplace assistant.
+

--- a/import-export-cli/docs/apictl_set.md
+++ b/import-export-cli/docs/apictl_set.md
@@ -12,6 +12,8 @@ Set configuration parameters. You can use one of the following flags
 * --vcs-config-path <path-to-custom-vcs-config-file>
 * --vcs-deployment-repo-path <path-to-deployment-repo-for-vcs>
 * --vcs-source-repo-path <path-to-source-repo-for-vcs>
+* --ai-thread-count <number-of-threads>
+* --ai-token <on-prem-key-of-ai-features>
 
 ```
 apictl set [flags]
@@ -30,14 +32,18 @@ apictl set --vcs-deployment-repo-path /home/user/custom/deployment
 apictl set --vcs-source-repo-path /home/user/custom/source
 apictl set api-logging --api-id bf36ca3a-0332-49ba-abce-e9992228ae06 --log-level full -e dev --tenant-domain carbon.super
 apictl set correlation-logging --component-name http --enable true -e dev
+apictl set --ai-thread-count 5
+apictl set --ai-token ad232sda-asa2a-assdsd-sds43
 ```
 
 ### Options
 
 ```
-      --export-directory string           Path to directory where APIs should be saved (default "/Users/wso2user/.wso2apictl/exported")
+      --ai-thread-count int               No of threads to be used by Marketplace Assistant for parallel processing (default 5)
+      --ai-token string                   Token (On prem key) of AI features
+      --export-directory string           Path to directory where APIs should be saved (default "/home/thenujan/.wso2apictl/exported")
   -h, --help                              help for set
-      --http-request-timeout int          Timeout for HTTP Client (default 10000)
+      --http-request-timeout int          Timeout for HTTP Client (default 100000)
       --tls-renegotiation-mode string     Supported TLS renegotiation mode (default "never")
       --vcs-config-path string            Path to the VCS Configuration yaml file which keeps the VCS meta data
       --vcs-deletion-enabled              Specifies whether project deletion is allowed during deployment.

--- a/import-export-cli/impl/aiDeleteApis.go
+++ b/import-export-cli/impl/aiDeleteApis.go
@@ -59,7 +59,7 @@ func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 
 	getAPIList(credential, cmdUploadEnvironment, "")
 
-	fmt.Println("Removing existing APIs and API Products from vector DB for tenant:", tenant)
+	fmt.Println("Removing existing APIs and API Products from vector database for tenant:", tenant)
 
 	headers := make(map[string]string)
 	headers["API-KEY"] = OnPremKey
@@ -93,7 +93,7 @@ func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 			continue
 		}
 
-		fmt.Printf("Removed %d APIs and API Products successfully from vector database (attempt %d)\n", jsonResp["message"]["delete_count"], attempt)
+		fmt.Printf("Removed %d APIs and API Products successfully from vector database for tenant: %s (attempt %d)\n", jsonResp["message"]["delete_count"], tenant, attempt)
 		return
 	}
 

--- a/import-export-cli/impl/aiDeleteApis.go
+++ b/import-export-cli/impl/aiDeleteApis.go
@@ -28,7 +28,7 @@ import (
 
 func AIDeleteAPIs(OnPremKey, Endpoint, Tenant string) error {
 
-	fmt.Println("Removing existing APIs from vector DB for tenant:", Tenant)
+	fmt.Println("Removing existing APIs and API Products from vector DB for tenant:", Tenant)
 
 	headers := make(map[string]string)
 	headers["API-KEY"] = OnPremKey
@@ -40,12 +40,12 @@ func AIDeleteAPIs(OnPremKey, Endpoint, Tenant string) error {
 	for attempt := 1; attempt <= 2; attempt++ {
 		resp, deleteErr = utils.InvokeDELETERequest(Endpoint+"/ai/spec-populator/bulk-remove", headers)
 		if deleteErr != nil {
-			fmt.Printf("Error removing existing APIs (attempt %d): %v\n", attempt, deleteErr)
+			fmt.Printf("Error removing existing APIs and API Products (attempt %d): %v\n", attempt, deleteErr)
 			continue
 		}
 
 		if resp.StatusCode() != 200 {
-			fmt.Printf("Removing existing APIs failed with status %d %s (attempt %d)\n", resp.StatusCode(), resp.Body(), attempt)
+			fmt.Printf("Removing existing APIs and API Products failed with status %d %s (attempt %d)\n", resp.StatusCode(), resp.Body(), attempt)
 			continue
 		}
 
@@ -58,12 +58,12 @@ func AIDeleteAPIs(OnPremKey, Endpoint, Tenant string) error {
 			continue
 		}
 
-		fmt.Printf("Removed %d APIs successfully from vector database (attempt %d)\n", jsonResp["message"]["delete_count"], attempt)
+		fmt.Printf("Removed %d APIs and API Products successfully from vector database (attempt %d)\n", jsonResp["message"]["delete_count"], attempt)
 		return nil
 	}
 
 	if deleteErr != nil {
-		return fmt.Errorf("Error removing existing APIs after retry: %v", deleteErr)
+		return fmt.Errorf("Error removing existing APIs and API Products after retry: %v", deleteErr)
 	}
-	return fmt.Errorf("Removing existing APIs failed after retry")
+	return fmt.Errorf("Removing existing APIs and API Products failed after retry")
 }

--- a/import-export-cli/impl/aiDeleteApis.go
+++ b/import-export-cli/impl/aiDeleteApis.go
@@ -1,0 +1,69 @@
+/*
+*  Copyright (c) WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package impl
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+func AIDeleteAPIs(OnPremKey, Endpoint, Tenant string) error {
+
+	fmt.Println("Removing existing APIs from vector DB for tenant:", Tenant)
+
+	headers := make(map[string]string)
+	headers["API-KEY"] = OnPremKey
+	headers["TENANT-DOMAIN"] = Tenant
+
+	var resp *resty.Response
+	var deleteErr error
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp, deleteErr = utils.InvokeDELETERequest(Endpoint+"/ai/spec-populator/bulk-remove", headers)
+		if deleteErr != nil {
+			fmt.Printf("Error removing existing APIs (attempt %d): %v\n", attempt, deleteErr)
+			continue
+		}
+
+		if resp.StatusCode() != 200 {
+			fmt.Printf("Removing existing APIs failed with status %d %s (attempt %d)\n", resp.StatusCode(), resp.Body(), attempt)
+			continue
+		}
+
+		jsonResp := map[string]map[string]int32{}
+
+		err := json.Unmarshal(resp.Body(), &jsonResp)
+
+		if err != nil {
+			utils.HandleErrorAndContinue("Error in unmarshalling response:", err)
+			continue
+		}
+
+		fmt.Printf("Removed %d APIs successfully from vector database (attempt %d)\n", jsonResp["message"]["delete_count"], attempt)
+		return nil
+	}
+
+	if deleteErr != nil {
+		return fmt.Errorf("Error removing existing APIs after retry: %v", deleteErr)
+	}
+	return fmt.Errorf("Removing existing APIs failed after retry")
+}

--- a/import-export-cli/impl/aiDeleteArtifacts.go
+++ b/import-export-cli/impl/aiDeleteArtifacts.go
@@ -57,8 +57,6 @@ func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, aiTok
 		os.Exit(1)
 	}
 
-	getAPIList(credential, cmdUploadEnvironment, "")
-
 	fmt.Println("Removing existing APIs and API Products from vector database for tenant:", tenant)
 
 	headers := make(map[string]string)

--- a/import-export-cli/impl/aiDeleteArtifacts.go
+++ b/import-export-cli/impl/aiDeleteArtifacts.go
@@ -35,25 +35,25 @@ var (
 	CmdUploadEnvironment string
 	UploadProducts       bool
 	UploadAll            bool
-	OnPremKey            string
+	AIToken              string
 	Tenant               string
 	Endpoint             = utils.DefaultAIEndpoint
 )
 
-func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, onPremKey, endpointUrl, tenant string) {
+func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, aiToken, endpointUrl, tenant string) {
 
 	if endpointUrl != "" {
 		Endpoint = endpointUrl
 	}
 
-	if onPremKey != "" {
-		OnPremKey = onPremKey
+	if aiToken != "" {
+		AIToken = aiToken
 	} else {
-		OnPremKey = utils.OnPremKey
+		AIToken = utils.AIToken
 	}
 
-	if OnPremKey == "" {
-		fmt.Println("You have to provide your on prem key (that you generated for ai features) to do this operation.")
+	if AIToken == "" {
+		fmt.Println("You have to provide your on prem key (token that you have generated in choreo for ai features) to do this operation.")
 		os.Exit(1)
 	}
 
@@ -62,7 +62,7 @@ func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 	fmt.Println("Removing existing APIs and API Products from vector database for tenant:", tenant)
 
 	headers := make(map[string]string)
-	headers["API-KEY"] = OnPremKey
+	headers["API-KEY"] = AIToken
 	headers["TENANT-DOMAIN"] = tenant
 
 	var resp *resty.Response

--- a/import-export-cli/impl/aiDeleteArtifacts.go
+++ b/import-export-cli/impl/aiDeleteArtifacts.go
@@ -53,7 +53,7 @@ func AIDeleteAPIs(credential credentials.Credential, cmdUploadEnvironment, aiTok
 	}
 
 	if AIToken == "" {
-		fmt.Println("You have to provide your on prem key (token that you have generated in choreo for ai features) to do this operation.")
+		fmt.Println("You have to provide your on prem key (token that you have generated in choreo for AI features) to do this operation.")
 		os.Exit(1)
 	}
 

--- a/import-export-cli/impl/aiUploadApiProducts.go
+++ b/import-export-cli/impl/aiUploadApiProducts.go
@@ -1,0 +1,171 @@
+package impl
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cast"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+var apiProducts []utils.APIProduct
+
+func AddAPIProductsToQueue(apiListQueue chan<- []map[string]interface{}) {
+	fmt.Println("Uploading API Products..!")
+	if count == 0 {
+		fmt.Println("No APIs available to be exported..!")
+		return
+	}
+
+	var counterSuceededAPIs int32
+	for count > 0 {
+		accessToken, preCommandErr := credentials.GetOAuthAccessToken(Credential, CmdUploadEnvironment)
+		if preCommandErr != nil {
+			fmt.Println("Error getting OAuth Tokens : " + preCommandErr.Error())
+			return
+		}
+
+		apiList := []map[string]interface{}{}
+		for i := startingApiIndexFromList; i < len(apiProducts); i++ {
+			apiPayload := GetAPIPayload(apiProducts[i], accessToken, CmdUploadEnvironment, true)
+			if apiPayload != nil {
+				apiList = append(apiList, apiPayload)
+			}
+			atomic.AddInt32(&counterSuceededAPIs, 1)
+		}
+		atomic.AddInt32(&totalAPIs, int32(len(apiList)))
+		if len(apiList) > 0 {
+			apiListQueue <- apiList
+		}
+
+		apiListOffset += utils.MaxAPIsToExportOnce
+		count, apiProducts, _ = GetAPIProductListFromEnv(accessToken, CmdUploadEnvironment, "", strconv.Itoa(utils.MaxAPIsToExportOnce)+"&offset="+strconv.Itoa(apiListOffset))
+		startingApiIndexFromList = 0
+	}
+
+	fmt.Println("\nTotal number of API Products processed: " + cast.ToString(counterSuceededAPIs))
+}
+
+func GetAPIPayload(apiOrProduct interface{}, accessToken, cmdUploadEnvironment string, uploadProducts bool) map[string]interface{} {
+	var name string
+	var resp *resty.Response
+	var err error
+
+	if uploadProducts {
+		api := apiOrProduct.(utils.APIProduct)
+		if api.LifeCycleStatus != "PUBLISHED" && api.LifeCycleStatus != "PROTOTYPED" {
+			return nil
+		}
+		resp, err = ExportAPIProductFromEnv(accessToken, api.Name, api.Version, "", api.Provider, "json", cmdUploadEnvironment, false, true)
+		name = api.Name + "-" + api.Version
+	} else {
+		api := apiOrProduct.(utils.API)
+		if api.LifeCycleStatus != "PUBLISHED" && api.LifeCycleStatus != "PROTOTYPED" {
+			return nil
+		}
+		resp, err = ExportAPIFromEnv(accessToken, api.Name, api.Version, "", api.Provider, "json", cmdUploadEnvironment, true, false)
+		name = api.Name + "-" + api.Version
+	}
+
+	if err != nil {
+		utils.HandleErrorAndContinue("Error exporting API ", err)
+		return nil
+	}
+
+	if resp.StatusCode() == http.StatusOK {
+		zipReader, err := zip.NewReader(bytes.NewReader(resp.Body()), int64(len(resp.Body())))
+		if err != nil {
+			utils.HandleErrorAndContinue("Error reading zip file", err)
+			return nil
+		}
+
+		apiPayload := map[string]interface{}{}
+
+		for _, file := range zipReader.File {
+			apiPayload = ReadZipFile(file, apiPayload, name)
+			if apiPayload == nil {
+				return nil
+			}
+		}
+		return apiPayload
+	}
+
+	fmt.Println("Error exporting API: " + name + " Status: " + resp.Status())
+	return nil
+}
+
+func ReadZipFile(file *zip.File, apiPayload map[string]interface{}, name string) map[string]interface{} {
+	fileReader, err := file.Open()
+	if err != nil {
+		utils.HandleErrorAndContinue("Error while opening file", err)
+		return nil
+	}
+	defer fileReader.Close()
+
+	fileContents, err := ioutil.ReadAll(fileReader)
+	if err != nil {
+		utils.HandleErrorAndContinue("Error while reading file", err)
+		return nil
+	}
+
+	if strings.HasSuffix(file.Name, name+"/api.json") || strings.HasSuffix(file.Name, name+"/api_product.json") {
+		var jsonResp map[string]interface{}
+		if err := json.Unmarshal(fileContents, &jsonResp); err != nil {
+			utils.HandleErrorAndContinue("Error unmarshalling YAML content: %v\n", err)
+			return nil
+		}
+
+		data, _ := jsonResp["data"].(map[string]interface{})
+
+		if data["visibility"] != "PUBLIC" {
+			return nil
+		}
+
+		apiPayload["uuid"] = data["id"]
+		apiPayload["api_name"] = data["name"]
+		apiPayload["version"] = data["version"]
+		apiPayload["tenant_domain"] = Tenant
+		if jsonResp["type"] == "api" {
+			apiPayload["api_type"] = data["type"]
+		} else {
+			apiPayload["api_type"] = "APIPRODUCT"
+		}
+
+	} else if strings.HasSuffix(file.Name, name+"/Definitions/swagger.json") {
+		var jsonResp map[string]interface{}
+		if err := json.Unmarshal(fileContents, &jsonResp); err != nil {
+			utils.HandleErrorAndContinue("Error unmarshalling YAML content: %v\n", err)
+			return nil
+		}
+		info, _ := jsonResp["info"].(map[string]interface{})
+		description := info["description"]
+		apiPayload["description"] = description
+		apiPayload["api_spec"] = string(fileContents)
+
+	} else if strings.HasSuffix(file.Name, name+"/Definitions/schema.graphql") {
+		apiPayload["description"] = ""
+		apiPayload["sdl_schema"] = string(fileContents)
+
+	} else if strings.HasSuffix(file.Name, name+"/Definitions/asyncapi.json") {
+		var jsonResp map[string]interface{}
+		if err := json.Unmarshal(fileContents, &jsonResp); err != nil {
+			utils.HandleErrorAndContinue("Error unmarshalling YAML content: %v\n", err)
+			return nil
+		}
+		info, _ := jsonResp["info"].(map[string]interface{})
+		description := info["description"]
+		apiPayload["description"] = description
+		apiPayload["async_spec"] = string(fileContents)
+	}
+
+	return apiPayload
+}

--- a/import-export-cli/impl/aiUploadApiProducts.go
+++ b/import-export-cli/impl/aiUploadApiProducts.go
@@ -12,24 +12,17 @@ import (
 	"sync/atomic"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
 
 var apiProducts []utils.APIProduct
 
-func AddAPIProductsToQueue(apiListQueue chan<- []map[string]interface{}) {
-	fmt.Println("Uploading API Products..!")
+func AddAPIProductsToQueue(accessToken string, apiListQueue chan<- []map[string]interface{}) {
 	if count == 0 {
 		fmt.Println("No API Products available to be exported..!")
 		return
 	}
 	for count > 0 {
-		accessToken, preCommandErr := credentials.GetOAuthAccessToken(Credential, CmdUploadEnvironment)
-		if preCommandErr != nil {
-			fmt.Println("Error getting OAuth Tokens : " + preCommandErr.Error())
-			return
-		}
 		apiList := []map[string]interface{}{}
 		for i := startingApiIndexFromList; i < len(apiProducts); i++ {
 			apiPayload := GetAPIPayload(apiProducts[i], accessToken, CmdUploadEnvironment, true)

--- a/import-export-cli/impl/aiUploadApiProducts.go
+++ b/import-export-cli/impl/aiUploadApiProducts.go
@@ -12,7 +12,6 @@ import (
 	"sync/atomic"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/spf13/cast"
 	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
 	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
 )
@@ -22,37 +21,30 @@ var apiProducts []utils.APIProduct
 func AddAPIProductsToQueue(apiListQueue chan<- []map[string]interface{}) {
 	fmt.Println("Uploading API Products..!")
 	if count == 0 {
-		fmt.Println("No APIs available to be exported..!")
+		fmt.Println("No API Products available to be exported..!")
 		return
 	}
-
-	var counterSuceededAPIs int32
 	for count > 0 {
 		accessToken, preCommandErr := credentials.GetOAuthAccessToken(Credential, CmdUploadEnvironment)
 		if preCommandErr != nil {
 			fmt.Println("Error getting OAuth Tokens : " + preCommandErr.Error())
 			return
 		}
-
 		apiList := []map[string]interface{}{}
 		for i := startingApiIndexFromList; i < len(apiProducts); i++ {
 			apiPayload := GetAPIPayload(apiProducts[i], accessToken, CmdUploadEnvironment, true)
 			if apiPayload != nil {
 				apiList = append(apiList, apiPayload)
 			}
-			atomic.AddInt32(&counterSuceededAPIs, 1)
 		}
 		atomic.AddInt32(&totalAPIs, int32(len(apiList)))
 		if len(apiList) > 0 {
 			apiListQueue <- apiList
 		}
-
 		apiListOffset += utils.MaxAPIsToExportOnce
 		count, apiProducts, _ = GetAPIProductListFromEnv(accessToken, CmdUploadEnvironment, "", strconv.Itoa(utils.MaxAPIsToExportOnce)+"&offset="+strconv.Itoa(apiListOffset))
 		startingApiIndexFromList = 0
 	}
-
-	fmt.Println("\nTotal number of API Products processed: " + cast.ToString(counterSuceededAPIs))
 }
 
 func GetAPIPayload(apiOrProduct interface{}, accessToken, cmdUploadEnvironment string, uploadProducts bool) map[string]interface{} {

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -74,7 +74,6 @@ func ProduceAPIPayloads(accessToken string, apiListQueue chan<- []map[string]int
 	if UploadAll {
 		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
 		ExportAPIs(Credential, "", CmdUploadEnvironment, Tenant, "json", "", "", true, true, false, true)
-		// AddAPIsToQueue(accessToken, apiListQueue)
 		apiListOffset = 0
 		count, apiProducts, _ = GetAPIProductListFromEnv(accessToken, CmdUploadEnvironment, "", strconv.Itoa(utils.MaxAPIsToExportOnce)+"&offset="+strconv.Itoa(apiListOffset))
 		AddAPIProductsToQueue(accessToken, apiListQueue)
@@ -84,34 +83,9 @@ func ProduceAPIPayloads(accessToken string, apiListQueue chan<- []map[string]int
 	} else {
 		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
 		ExportAPIs(Credential, "", CmdUploadEnvironment, Tenant, "json", "", "", true, true, false, true)
-		// AddAPIsToQueue(accessToken, apiListQueue)
 	}
 	close(apiListQueue)
 }
-
-// can use this instead of editing ExportAPIs
-// func AddAPIsToQueue(accessToken string, apiListQueue chan<- []map[string]interface{}) {
-// 	if count == 0 {
-// 		fmt.Println("No APIs available to be uploaded..!")
-// 	} else {
-// 		for count > 0 {
-// 			apiList := []map[string]interface{}{}
-// 			for i := startingApiIndexFromList; i < len(apis); i++ {
-// 				apiPayload := GetAPIPayload(apis[i], accessToken, CmdUploadEnvironment, false)
-// 				if apiPayload != nil {
-// 					apiList = append(apiList, apiPayload)
-// 				}
-// 			}
-// 			atomic.AddInt32(&totalAPIs, int32(len(apiList)))
-// 			if len(apiList) > 0 {
-// 				apiListQueue <- apiList
-// 			}
-// 			apiListOffset += utils.MaxAPIsToExportOnce
-// 			count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
-// 			startingApiIndexFromList = 0
-// 		}
-// 	}
-// }
 
 func ConsumeAPIPayloads(apiListQueue <-chan []map[string]interface{}, wg *sync.WaitGroup) {
 	defer wg.Done()

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -1,0 +1,180 @@
+package impl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/spf13/cast"
+	"github.com/wso2/product-apim-tooling/import-export-cli/credentials"
+	"github.com/wso2/product-apim-tooling/import-export-cli/utils"
+)
+
+const (
+	DefaultTenant = "carbon.super"
+)
+
+var (
+	uploadedAPIs         int32
+	totalAPIs            int32
+	Credential           credentials.Credential
+	CmdUploadEnvironment string
+	UploadProducts       bool
+	UploadAll            bool
+	OnPremKey            string
+	Tenant               string
+	Endpoint             = utils.DefaultAIEndpoint
+)
+
+func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, authToken, endpointUrl string, uploadAll, uploadProducts bool) {
+	OnPremKey = authToken
+	Endpoint = endpointUrl
+	CmdUploadEnvironment = cmdUploadEnvironment
+	Credential = credential
+	UploadAll = uploadAll
+	UploadProducts = uploadProducts
+
+	fmt.Println("Username: ", credential.Username)
+
+	if !strings.Contains(credential.Username, "@") {
+		Tenant = DefaultTenant
+	} else {
+		Tenant = strings.Split(credential.Username, "@")[1]
+	}
+
+	AIDeleteAPIs(OnPremKey, Endpoint, Tenant)
+
+	accessToken, err := credentials.GetOAuthAccessToken(credential, cmdUploadEnvironment)
+
+	if err != nil {
+		utils.HandleErrorAndExit("Error getting OAuth Tokens", err)
+	}
+
+	apiListQueue := make(chan []map[string]interface{}, 10)
+
+	go ProduceAPIPayloads(accessToken, apiListQueue)
+
+	numConsumers := utils.MarketplaceAssistantThreadCount
+	var wg sync.WaitGroup
+	for i := 0; i < numConsumers; i++ {
+		wg.Add(1)
+		go ConsumeAPIPayloads(apiListQueue, &wg)
+	}
+
+	wg.Wait()
+
+	fmt.Printf("\nTotal number of public APIs present in the API Manager: %d\nTotal number of APIs successfully uploaded: %d\n\n", totalAPIs, uploadedAPIs)
+}
+
+func ProduceAPIPayloads(accessToken string, apiListQueue chan<- []map[string]interface{}) {
+	ProcessAPIs(accessToken, apiListQueue)
+	close(apiListQueue)
+}
+
+func ProcessAPIs(accessToken string, apiListQueue chan<- []map[string]interface{}) {
+	apiListOffset = 0
+	startingApiIndexFromList = 0
+	if UploadAll {
+		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
+		AddAPIsToQueue(apiListQueue)
+		apiListOffset = 0
+		count, apiProducts, _ = GetAPIProductListFromEnv(accessToken, CmdUploadEnvironment, "", strconv.Itoa(utils.MaxAPIsToExportOnce)+"&offset="+strconv.Itoa(apiListOffset))
+		AddAPIProductsToQueue(apiListQueue)
+	} else if UploadProducts {
+		count, apiProducts, _ = GetAPIProductListFromEnv(accessToken, CmdUploadEnvironment, "", strconv.Itoa(utils.MaxAPIsToExportOnce)+"&offset="+strconv.Itoa(apiListOffset))
+		AddAPIProductsToQueue(apiListQueue)
+	} else {
+		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
+		AddAPIsToQueue(apiListQueue)
+	}
+}
+
+func ConsumeAPIPayloads(apiListQueue <-chan []map[string]interface{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for apiList := range apiListQueue {
+		InvokePOSTRequest(apiList)
+	}
+}
+
+func InvokePOSTRequest(apiList []map[string]interface{}) {
+	fmt.Printf("Uploading %d APIs for tenant: %s\n", len(apiList), apiList[0]["tenant_domain"])
+	payload, err := json.Marshal(map[string]interface{}{"apis": apiList})
+	if err != nil {
+		utils.HandleErrorAndContinue("Error in marshalling payload:", err)
+		return
+	}
+
+	headers := make(map[string]string)
+	headers["API-KEY"] = OnPremKey
+	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
+
+	var resp *resty.Response
+	var uploadErr error
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		resp, uploadErr = utils.InvokePOSTRequest(Endpoint+"/ai/spec-populator/bulk-upload", headers, payload)
+		if uploadErr != nil {
+			fmt.Printf("API upload failed (attempt %d). Reason: %v\n", attempt, uploadErr)
+			continue
+		}
+
+		if resp.StatusCode() != 200 {
+			fmt.Printf("Failed to upload %d APIs for tenant %s with status %d %s (attempt %d).\n", len(apiList), apiList[0]["tenant_domain"], resp.StatusCode(), resp.Body(), attempt)
+			continue
+		}
+
+		jsonResp := map[string]map[string]int32{}
+
+		err := json.Unmarshal(resp.Body(), &jsonResp)
+
+		if err != nil {
+			utils.HandleErrorAndContinue("Error in unmarshalling response:", err)
+			continue
+		}
+
+		fmt.Printf("%d APIs uploaded successfully for tenant: %s (attempt %d)\n", len(apiList), apiList[0]["tenant_domain"], attempt)
+		atomic.AddInt32(&uploadedAPIs, jsonResp["message"]["upsert_count"])
+		break
+	}
+
+	if uploadErr != nil {
+		utils.HandleErrorAndContinue("API upload failed after retry. Reason: ", uploadErr)
+	}
+}
+
+func AddAPIsToQueue(apiListQueue chan<- []map[string]interface{}) {
+	fmt.Println("Uploading APIs..!")
+	if count == 0 {
+		fmt.Println("No APIs available to be uploaded..!")
+	} else {
+		var counterSuceededAPIs = 0
+		for count > 0 {
+			accessToken, err := credentials.GetOAuthAccessToken(Credential, CmdUploadEnvironment)
+			if err == nil {
+				apiList := []map[string]interface{}{}
+				for i := startingApiIndexFromList; i < len(apis); i++ {
+					apiPayload := GetAPIPayload(apis[i], accessToken, CmdUploadEnvironment, false)
+					if apiPayload != nil {
+						apiList = append(apiList, apiPayload)
+					}
+					counterSuceededAPIs++
+				}
+				atomic.AddInt32(&totalAPIs, int32(len(apiList)))
+				if len(apiList) > 0 {
+					apiListQueue <- apiList
+				}
+			} else {
+				fmt.Println("Error getting OAuth Tokens : " + err.Error())
+			}
+			apiListOffset += utils.MaxAPIsToExportOnce
+			count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
+			startingApiIndexFromList = 0
+		}
+		fmt.Println("\nTotal number of APIs processed: " + cast.ToString(counterSuceededAPIs))
+	}
+}

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -18,7 +18,7 @@ const (
 	DefaultTenant = "carbon.super"
 )
 
-func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPremKey, endpointUrl string, uploadAll, uploadProducts bool) {
+func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, aiToken, endpointUrl string, uploadAll, uploadProducts bool) {
 
 	CmdUploadEnvironment = cmdUploadEnvironment
 	Credential = credential
@@ -35,14 +35,14 @@ func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 		Endpoint = endpointUrl
 	}
 
-	if onPremKey != "" {
-		OnPremKey = onPremKey
+	if aiToken != "" {
+		AIToken = aiToken
 	} else {
-		OnPremKey = utils.OnPremKey
+		AIToken = utils.AIToken
 	}
 
-	if OnPremKey == "" {
-		fmt.Println("You have to provide your on prem key (that you generated for ai features) to do this operation.")
+	if AIToken == "" {
+		fmt.Println("You have to provide your on prem key (token that you have generated in choreo for ai features) to do this operation.")
 		os.Exit(1)
 	}
 
@@ -69,11 +69,6 @@ func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 }
 
 func ProduceAPIPayloads(accessToken string, apiListQueue chan<- []map[string]interface{}) {
-	ProcessAPIs(accessToken, apiListQueue)
-	close(apiListQueue)
-}
-
-func ProcessAPIs(accessToken string, apiListQueue chan<- []map[string]interface{}) {
 	apiListOffset = 0
 	startingApiIndexFromList = 0
 	if UploadAll {
@@ -89,6 +84,7 @@ func ProcessAPIs(accessToken string, apiListQueue chan<- []map[string]interface{
 		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
 		AddAPIsToQueue(accessToken, apiListQueue)
 	}
+	close(apiListQueue)
 }
 
 func AddAPIsToQueue(accessToken string, apiListQueue chan<- []map[string]interface{}) {
@@ -131,7 +127,7 @@ func InvokePOSTRequest(apiList []map[string]interface{}) {
 	}
 
 	headers := make(map[string]string)
-	headers["API-KEY"] = OnPremKey
+	headers["API-KEY"] = AIToken
 	headers[utils.HeaderContentType] = utils.HeaderValueApplicationJSON
 
 	var resp *resty.Response

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -46,8 +46,6 @@ func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 		os.Exit(1)
 	}
 
-	// AIDeleteAPIs(Credential, cmdUploadEnvironment, onPremKey, endpointUrl, Tenant)
-
 	accessToken, err := credentials.GetOAuthAccessToken(credential, cmdUploadEnvironment)
 
 	if err != nil {
@@ -79,7 +77,6 @@ func ProcessAPIs(accessToken string, apiListQueue chan<- []map[string]interface{
 	apiListOffset = 0
 	startingApiIndexFromList = 0
 	if UploadAll {
-		AIDeleteAPIs(Credential, CmdUploadEnvironment, OnPremKey, Endpoint, Tenant)
 		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
 		AddAPIsToQueue(accessToken, apiListQueue)
 		apiListOffset = 0

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -58,7 +58,7 @@ func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 
 	go ProduceAPIPayloads(accessToken, apiListQueue)
 
-	numConsumers := utils.MarketplaceAssistantThreadCount
+	numConsumers := utils.AIThreadCount
 	var wg sync.WaitGroup
 	for i := 0; i < numConsumers; i++ {
 		wg.Add(1)

--- a/import-export-cli/impl/aiUploadApis.go
+++ b/import-export-cli/impl/aiUploadApis.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,7 +31,22 @@ func AIUploadAPIs(credential credentials.Credential, cmdUploadEnvironment, onPre
 		Tenant = strings.Split(credential.Username, "@")[1]
 	}
 
-	AIDeleteAPIs(Credential, cmdUploadEnvironment, onPremKey, endpointUrl, Tenant)
+	if endpointUrl != "" {
+		Endpoint = endpointUrl
+	}
+
+	if onPremKey != "" {
+		OnPremKey = onPremKey
+	} else {
+		OnPremKey = utils.OnPremKey
+	}
+
+	if OnPremKey == "" {
+		fmt.Println("You have to provide your on prem key (that you generated for ai features) to do this operation.")
+		os.Exit(1)
+	}
+
+	// AIDeleteAPIs(Credential, cmdUploadEnvironment, onPremKey, endpointUrl, Tenant)
 
 	accessToken, err := credentials.GetOAuthAccessToken(credential, cmdUploadEnvironment)
 
@@ -63,6 +79,7 @@ func ProcessAPIs(accessToken string, apiListQueue chan<- []map[string]interface{
 	apiListOffset = 0
 	startingApiIndexFromList = 0
 	if UploadAll {
+		AIDeleteAPIs(Credential, CmdUploadEnvironment, OnPremKey, Endpoint, Tenant)
 		count, apis = getAPIList(Credential, CmdUploadEnvironment, "")
 		AddAPIsToQueue(accessToken, apiListQueue)
 		apiListOffset = 0

--- a/import-export-cli/shell-completions/apictl_bash_completions.sh
+++ b/import-export-cli/shell-completions/apictl_bash_completions.sh
@@ -468,6 +468,300 @@ _apictl_add()
     noun_aliases=()
 }
 
+_apictl_ai_delete_artifacts()
+{
+    last_command="apictl_ai_delete_artifacts"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--endpoint=")
+    two_word_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint=")
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--token=")
+    two_word_flags+=("--token")
+    local_nonpersistent_flags+=("--token")
+    local_nonpersistent_flags+=("--token=")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_ai_delete_help()
+{
+    last_command="apictl_ai_delete_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_ai_delete()
+{
+    last_command="apictl_ai_delete"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("artifacts")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_ai_help()
+{
+    last_command="apictl_ai_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_ai_upload_api-products()
+{
+    last_command="apictl_ai_upload_api-products"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--endpoint=")
+    two_word_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint=")
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--token=")
+    two_word_flags+=("--token")
+    local_nonpersistent_flags+=("--token")
+    local_nonpersistent_flags+=("--token=")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_ai_upload_apis()
+{
+    last_command="apictl_ai_upload_apis"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--all")
+    local_nonpersistent_flags+=("--all")
+    flags+=("--endpoint=")
+    two_word_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint")
+    local_nonpersistent_flags+=("--endpoint=")
+    flags+=("--environment=")
+    two_word_flags+=("--environment")
+    two_word_flags+=("-e")
+    local_nonpersistent_flags+=("--environment")
+    local_nonpersistent_flags+=("--environment=")
+    local_nonpersistent_flags+=("-e")
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--token=")
+    two_word_flags+=("--token")
+    local_nonpersistent_flags+=("--token")
+    local_nonpersistent_flags+=("--token=")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--environment=")
+    must_have_one_flag+=("-e")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_ai_upload_help()
+{
+    last_command="apictl_ai_upload_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_apictl_ai_upload()
+{
+    last_command="apictl_ai_upload"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("api-products")
+    commands+=("apis")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_apictl_ai()
+{
+    last_command="apictl_ai"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("delete")
+    commands+=("help")
+    commands+=("upload")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    local_nonpersistent_flags+=("--help")
+    local_nonpersistent_flags+=("-h")
+    flags+=("--insecure")
+    flags+=("-k")
+    flags+=("--verbose")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _apictl_aws_help()
 {
     last_command="apictl_aws_help"
@@ -6060,6 +6354,14 @@ _apictl_set()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--ai-thread-count=")
+    two_word_flags+=("--ai-thread-count")
+    local_nonpersistent_flags+=("--ai-thread-count")
+    local_nonpersistent_flags+=("--ai-thread-count=")
+    flags+=("--ai-token=")
+    two_word_flags+=("--ai-token")
+    local_nonpersistent_flags+=("--ai-token")
+    local_nonpersistent_flags+=("--ai-token=")
     flags+=("--export-directory=")
     two_word_flags+=("--export-directory")
     local_nonpersistent_flags+=("--export-directory")
@@ -6486,6 +6788,7 @@ _apictl_root_command()
 
     commands=()
     commands+=("add")
+    commands+=("ai")
     commands+=("aws")
     commands+=("bundle")
     commands+=("change-status")

--- a/import-export-cli/utils/configVars.go
+++ b/import-export-cli/utils/configVars.go
@@ -29,7 +29,7 @@ import (
 
 var HttpRequestTimeout = DefaultHttpRequestTimeout
 var AIThreadCount = DefaultAIThreadCount
-var OnPremKey string
+var AIToken string
 var Insecure bool
 var ExportDirectory string
 
@@ -62,8 +62,8 @@ func SetConfigVars(mainConfigFilePath string) error {
 	AIThreadCount = mainConfig.Config.AIThreadCount
 	Logln(LogPrefixInfo + "Setting AIThreadCount to " + fmt.Sprint(mainConfig.Config.AIThreadCount))
 
-	OnPremKey = mainConfig.Config.OnPremKey
-	Logln(LogPrefixInfo + "Setting OnPremKey to " + fmt.Sprint(mainConfig.Config.OnPremKey))
+	AIToken = mainConfig.Config.AIToken
+	Logln(LogPrefixInfo + "Setting AIToken to " + fmt.Sprint(mainConfig.Config.AIToken))
 
 	ExportDirectory = mainConfig.Config.ExportDirectory
 	Logln(LogPrefixInfo + "Setting ExportDirectory " + mainConfig.Config.ExportDirectory)

--- a/import-export-cli/utils/configVars.go
+++ b/import-export-cli/utils/configVars.go
@@ -29,6 +29,7 @@ import (
 
 var HttpRequestTimeout = DefaultHttpRequestTimeout
 var MarketplaceAssistantThreadCount = DefaultMarketplaceAssistantThreadCount
+var OnPremKey string
 var Insecure bool
 var ExportDirectory string
 
@@ -60,6 +61,9 @@ func SetConfigVars(mainConfigFilePath string) error {
 
 	MarketplaceAssistantThreadCount = mainConfig.Config.MarketplaceAssistantThreadCount
 	Logln(LogPrefixInfo + "Setting MarketplaceAssistantThreadCount to " + fmt.Sprint(mainConfig.Config.MarketplaceAssistantThreadCount))
+
+	OnPremKey = mainConfig.Config.OnPremKey
+	Logln(LogPrefixInfo + "Setting OnPremKey to " + fmt.Sprint(mainConfig.Config.OnPremKey))
 
 	ExportDirectory = mainConfig.Config.ExportDirectory
 	Logln(LogPrefixInfo + "Setting ExportDirectory " + mainConfig.Config.ExportDirectory)

--- a/import-export-cli/utils/configVars.go
+++ b/import-export-cli/utils/configVars.go
@@ -28,7 +28,7 @@ import (
 )
 
 var HttpRequestTimeout = DefaultHttpRequestTimeout
-var MarketplaceAssistantThreadCount = DefaultMarketplaceAssistantThreadCount
+var AIThreadCount = DefaultAIThreadCount
 var OnPremKey string
 var Insecure bool
 var ExportDirectory string
@@ -59,8 +59,8 @@ func SetConfigVars(mainConfigFilePath string) error {
 	HttpRequestTimeout = mainConfig.Config.HttpRequestTimeout
 	Logln(LogPrefixInfo + "Setting HttpTimeoutRequest to " + fmt.Sprint(mainConfig.Config.HttpRequestTimeout))
 
-	MarketplaceAssistantThreadCount = mainConfig.Config.MarketplaceAssistantThreadCount
-	Logln(LogPrefixInfo + "Setting MarketplaceAssistantThreadCount to " + fmt.Sprint(mainConfig.Config.MarketplaceAssistantThreadCount))
+	AIThreadCount = mainConfig.Config.AIThreadCount
+	Logln(LogPrefixInfo + "Setting AIThreadCount to " + fmt.Sprint(mainConfig.Config.AIThreadCount))
 
 	OnPremKey = mainConfig.Config.OnPremKey
 	Logln(LogPrefixInfo + "Setting OnPremKey to " + fmt.Sprint(mainConfig.Config.OnPremKey))

--- a/import-export-cli/utils/configVars.go
+++ b/import-export-cli/utils/configVars.go
@@ -28,6 +28,7 @@ import (
 )
 
 var HttpRequestTimeout = DefaultHttpRequestTimeout
+var MarketplaceAssistantThreadCount = DefaultMarketplaceAssistantThreadCount
 var Insecure bool
 var ExportDirectory string
 
@@ -56,6 +57,9 @@ func SetConfigVars(mainConfigFilePath string) error {
 
 	HttpRequestTimeout = mainConfig.Config.HttpRequestTimeout
 	Logln(LogPrefixInfo + "Setting HttpTimeoutRequest to " + fmt.Sprint(mainConfig.Config.HttpRequestTimeout))
+
+	MarketplaceAssistantThreadCount = mainConfig.Config.MarketplaceAssistantThreadCount
+	Logln(LogPrefixInfo + "Setting MarketplaceAssistantThreadCount to " + fmt.Sprint(mainConfig.Config.MarketplaceAssistantThreadCount))
 
 	ExportDirectory = mainConfig.Config.ExportDirectory
 	Logln(LogPrefixInfo + "Setting ExportDirectory " + mainConfig.Config.ExportDirectory)

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -190,6 +190,8 @@ const SearchAndTag = "&"
 // Other
 const DefaultTokenValidityPeriod = 3600
 const DefaultHttpRequestTimeout = 10000
+
+// AI
 const DefaultMarketplaceAssistantThreadCount = 3
 const DefaultAIEndpoint = "https://dev-tools.wso2.com/apim-ai-service"
 
@@ -203,7 +205,7 @@ const TLSRenegotiationOnce = "once"
 const TLSRenegotiationFreely = "freely"
 
 // Migration export
-const MaxAPIsToExportOnce = 5
+const MaxAPIsToExportOnce = 20
 const MigrationAPIsExportMetadataFileName = "migration-apis-export-metadata.yaml"
 const LastSucceededApiFileName = "last-succeeded-api.log"
 const LastSuceededContentDelimiter = " " // space

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -190,6 +190,8 @@ const SearchAndTag = "&"
 // Other
 const DefaultTokenValidityPeriod = 3600
 const DefaultHttpRequestTimeout = 10000
+const DefaultMarketplaceAssistantThreadCount = 3
+const DefaultAIEndpoint = "https://dev-tools.wso2.com/apim-ai-service"
 
 // TLSRenegotiationNever : never negotiate
 const TLSRenegotiationNever = "never"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -193,7 +193,7 @@ const DefaultHttpRequestTimeout = 10000
 
 // AI
 const DefaultAIThreadCount = 3
-const DefaultAIEndpoint = "https://dev-tools.wso2.com/apim-ai-service"
+const DefaultAIEndpoint = "https://e95488c8-8511-4882-967f-ec3ae2a0f86f-prod.e1-us-east-azure.choreoapis.dev/lgpt/interceptor-service/interceptor-service-be2/v1.0"
 
 // TLSRenegotiationNever : never negotiate
 const TLSRenegotiationNever = "never"

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -203,7 +203,7 @@ const TLSRenegotiationOnce = "once"
 const TLSRenegotiationFreely = "freely"
 
 // Migration export
-const MaxAPIsToExportOnce = 20
+const MaxAPIsToExportOnce = 5
 const MigrationAPIsExportMetadataFileName = "migration-apis-export-metadata.yaml"
 const LastSucceededApiFileName = "last-succeeded-api.log"
 const LastSuceededContentDelimiter = " " // space

--- a/import-export-cli/utils/constants.go
+++ b/import-export-cli/utils/constants.go
@@ -192,7 +192,7 @@ const DefaultTokenValidityPeriod = 3600
 const DefaultHttpRequestTimeout = 10000
 
 // AI
-const DefaultMarketplaceAssistantThreadCount = 3
+const DefaultAIThreadCount = 3
 const DefaultAIEndpoint = "https://dev-tools.wso2.com/apim-ai-service"
 
 // TLSRenegotiationNever : never negotiate

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -39,17 +39,17 @@ type MainConfig struct {
 }
 
 type Config struct {
-	HttpRequestTimeout              int    `yaml:"http_request_timeout"`
-	ExportDirectory                 string `yaml:"export_directory"`
-	KubernetesMode                  bool   `yaml:"kubernetes_mode"`
-	TokenType                       string `yaml:"token_type"`
-	VCSDeletionEnabled              bool   `yaml:"vcs_deletion_enabled"`
-	VCSConfigFilePath               string `yaml:"vcs_config_file_path"`
-	VCSSourceRepoPath               string `yaml:"vcs_source_repo_path"`
-	VCSDeploymentRepoPath           string `yaml:"vcs_deployment_repo_path"`
-	TLSRenegotiationMode            string `yaml:"tls-renegotiation-mode"`
-	MarketplaceAssistantThreadCount int    `yaml:"ai_thread_count"`
-	OnPremKey                       string `yaml:"ai_token"`
+	HttpRequestTimeout    int    `yaml:"http_request_timeout"`
+	ExportDirectory       string `yaml:"export_directory"`
+	KubernetesMode        bool   `yaml:"kubernetes_mode"`
+	TokenType             string `yaml:"token_type"`
+	VCSDeletionEnabled    bool   `yaml:"vcs_deletion_enabled"`
+	VCSConfigFilePath     string `yaml:"vcs_config_file_path"`
+	VCSSourceRepoPath     string `yaml:"vcs_source_repo_path"`
+	VCSDeploymentRepoPath string `yaml:"vcs_deployment_repo_path"`
+	TLSRenegotiationMode  string `yaml:"tls-renegotiation-mode"`
+	AIThreadCount         int    `yaml:"ai_thread_count"`
+	OnPremKey             string `yaml:"ai_token"`
 }
 
 type EnvKeys struct {

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -39,15 +39,16 @@ type MainConfig struct {
 }
 
 type Config struct {
-	HttpRequestTimeout    int    `yaml:"http_request_timeout"`
-	ExportDirectory       string `yaml:"export_directory"`
-	KubernetesMode        bool   `yaml:"kubernetes_mode"`
-	TokenType             string `yaml:"token_type"`
-	VCSDeletionEnabled    bool   `yaml:"vcs_deletion_enabled"`
-	VCSConfigFilePath     string `yaml:"vcs_config_file_path"`
-	VCSSourceRepoPath     string `yaml:"vcs_source_repo_path"`
-	VCSDeploymentRepoPath string `yaml:"vcs_deployment_repo_path"`
-	TLSRenegotiationMode  string `yaml:"tls-renegotiation-mode"`
+	HttpRequestTimeout              int    `yaml:"http_request_timeout"`
+	MarketplaceAssistantThreadCount int    `yaml:"marketplace_assistant_thread_count"`
+	ExportDirectory                 string `yaml:"export_directory"`
+	KubernetesMode                  bool   `yaml:"kubernetes_mode"`
+	TokenType                       string `yaml:"token_type"`
+	VCSDeletionEnabled              bool   `yaml:"vcs_deletion_enabled"`
+	VCSConfigFilePath               string `yaml:"vcs_config_file_path"`
+	VCSSourceRepoPath               string `yaml:"vcs_source_repo_path"`
+	VCSDeploymentRepoPath           string `yaml:"vcs_deployment_repo_path"`
+	TLSRenegotiationMode            string `yaml:"tls-renegotiation-mode"`
 }
 
 type EnvKeys struct {

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -49,7 +49,7 @@ type Config struct {
 	VCSDeploymentRepoPath string `yaml:"vcs_deployment_repo_path"`
 	TLSRenegotiationMode  string `yaml:"tls-renegotiation-mode"`
 	AIThreadCount         int    `yaml:"ai_thread_count"`
-	OnPremKey             string `yaml:"ai_token"`
+	AIToken               string `yaml:"ai_token"`
 }
 
 type EnvKeys struct {

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -40,7 +40,6 @@ type MainConfig struct {
 
 type Config struct {
 	HttpRequestTimeout              int    `yaml:"http_request_timeout"`
-	MarketplaceAssistantThreadCount int    `yaml:"marketplace_assistant_thread_count"`
 	ExportDirectory                 string `yaml:"export_directory"`
 	KubernetesMode                  bool   `yaml:"kubernetes_mode"`
 	TokenType                       string `yaml:"token_type"`
@@ -49,6 +48,8 @@ type Config struct {
 	VCSSourceRepoPath               string `yaml:"vcs_source_repo_path"`
 	VCSDeploymentRepoPath           string `yaml:"vcs_deployment_repo_path"`
 	TLSRenegotiationMode            string `yaml:"tls-renegotiation-mode"`
+	MarketplaceAssistantThreadCount int    `yaml:"ai_thread_count"`
+	OnPremKey                       string `yaml:"ai_token"`
 }
 
 type EnvKeys struct {


### PR DESCRIPTION
## Purpose
> Add support for AI related bulk upload and delete operations.

## Approach
> Delete all the existing APIs and API Products from the vector database.
> Upload all the public APIs which are available in the dev portal.
> Upload all the public API Products which are available in the dev portal.
> Set the ai-token and ai-thread-count as config variables.
> Add set command for ai-token and ai-thread-count.
> Add endpoint with default endpoint.
> token and endpoint are optional flags.

## Sample cmd (endpoint and token are optional)
> apictl ai upload apis --endpoint `<endpoint>` --token `<on-prem-key>` --environment `<environment>`
> apictl ai upload api-products --endpoint `<endpoint>` --token `<on-prem-key>` --environment `<environment>`
> apictl ai delete artifcats --endpoint `<endpoint>` --token `<on-prem-key>` --environment `<environment>`