### PR TITLE
[4.0.0] Add ignoreTier query param to import application api call

### DIFF
--- a/import-export-cli/cmd/deprecated/importApp.go
+++ b/import-export-cli/cmd/deprecated/importApp.go
@@ -32,6 +32,7 @@ var importAppOwner string
 var preserveOwner bool
 var skipSubscriptions bool
 var importAppSkipKeys bool
+var ignoreTier bool
 var importAppUpdateApplication bool
 var importAppSkipCleanup bool
 
@@ -70,7 +71,7 @@ func executeImportAppCmd(credential credentials.Credential) {
 		utils.HandleErrorAndExit("Error getting OAuth Tokens", err)
 	}
 	_, err = impl.ImportApplicationToEnv(accessToken, importAppEnvironment, importAppFile, importAppOwner,
-		importAppUpdateApplication, preserveOwner, skipSubscriptions, importAppSkipKeys, importAppSkipCleanup)
+		importAppUpdateApplication, preserveOwner, skipSubscriptions, importAppSkipKeys, importAppSkipCleanup, ignoreTier)
 	if err != nil {
 		utils.HandleErrorAndExit("Error importing Application", err)
 	}

--- a/import-export-cli/cmd/importApp.go
+++ b/import-export-cli/cmd/importApp.go
@@ -29,6 +29,7 @@ var importAppFile string
 var importAppEnvironment string
 var importAppOwner string
 var preserveOwner bool
+var ignoreTier bool
 var skipSubscriptions bool
 var importAppSkipKeys bool
 var importAppUpdateApplication bool
@@ -68,7 +69,7 @@ func executeImportAppCmd(credential credentials.Credential) {
 		utils.HandleErrorAndExit("Error getting OAuth Tokens", err)
 	}
 	_, err = impl.ImportApplicationToEnv(accessToken, importAppEnvironment, importAppFile, importAppOwner,
-		importAppUpdateApplication, preserveOwner, skipSubscriptions, importAppSkipKeys, importAppSkipCleanup)
+		importAppUpdateApplication, preserveOwner, skipSubscriptions, importAppSkipKeys, importAppSkipCleanup, ignoreTier)
 	if err != nil {
 		utils.HandleErrorAndExit("Error importing Application", err)
 	}
@@ -84,6 +85,8 @@ func init() {
 		"", "Environment from the which the Application should be imported")
 	ImportAppCmd.Flags().BoolVarP(&preserveOwner, "preserve-owner", "", false,
 		"Preserves app owner")
+	ImportAppCmd.Flags().BoolVarP(&ignoreTier, "ignore-tier", "", false,
+		"Ignores validation of the tier")
 	ImportAppCmd.Flags().BoolVarP(&skipSubscriptions, "skip-subscriptions", "s", false,
 		"Skip subscriptions of the Application")
 	ImportAppCmd.Flags().BoolVarP(&importAppSkipKeys, "skip-keys", "", false,

--- a/import-export-cli/git/gitUtils.go
+++ b/import-export-cli/git/gitUtils.go
@@ -473,7 +473,7 @@ func deployUpdatedProjects(accessToken, sourceRepoId, deploymentRepoId, environm
 			importParams := projectParam.MetaData.DeployConfig.Import
 			fmt.Println(strconv.Itoa(i+1) + ": " + projectParam.NickName + ": (" + projectParam.RelativePath + ")")
 			_, err := impl.ImportApplicationToEnv(accessToken, environment, projectParam.AbsolutePath, projectParam.MetaData.Owner,
-				importParams.Update, importParams.PreserveOwner, importParams.SkipSubscriptions, importParams.SkipKeys, false)
+				importParams.Update, importParams.PreserveOwner, importParams.SkipSubscriptions, importParams.SkipKeys, false, importParams.IgnoreTier)
 			if err != nil {
 				fmt.Println("\terror... ", err)
 				failedProjects[projectParam.Type] = append(failedProjects[projectParam.Type], projectParam)

--- a/import-export-cli/impl/importApp.go
+++ b/import-export-cli/impl/importApp.go
@@ -44,11 +44,12 @@ import (
 // @param skipSubscriptions: Skip importing subscriptions
 // @param skipKeys: skip importing keys of application
 // @param skipCleanup: skip cleaning up temporary files created during the operation
+// @param ignoreTier: skip considering/validating the tier when importing
 func ImportApplicationToEnv(accessToken, environment, filename, appOwner string, updateApplication, preserveOwner,
-	skipSubscriptions, skipKeys, skipCleanup bool) (*http.Response, error) {
+	skipSubscriptions, skipKeys, skipCleanup, ignoreTier bool) (*http.Response, error) {
 	devportalApplicationsEndpoint := utils.GetDevPortalApplicationListEndpointOfEnv(environment, utils.MainConfigFilePath)
 	return ImportApplication(accessToken, devportalApplicationsEndpoint, filename, appOwner, updateApplication, preserveOwner,
-		skipSubscriptions, skipKeys, skipCleanup)
+		skipSubscriptions, skipKeys, skipCleanup, ignoreTier)
 }
 
 // ImportApplication function is used with import-app command
@@ -62,7 +63,7 @@ func ImportApplicationToEnv(accessToken, environment, filename, appOwner string,
 // @param skipKeys: skip importing keys of application
 // @param skipCleanup: skip cleaning up temporary files created during the operation
 func ImportApplication(accessToken, devportalApplicationsEndpoint, filename, appOwner string, updateApplication, preserveOwner,
-	skipSubscriptions, skipKeys, skipCleanup bool) (*http.Response, error) {
+	skipSubscriptions, skipKeys, skipCleanup, ignoreTier bool) (*http.Response, error) {
 
 	exportDirectory := filepath.Join(utils.ExportDirectory, utils.ExportedAppsDirName)
 	devportalApplicationsEndpoint = utils.AppendSlashToString(devportalApplicationsEndpoint)
@@ -71,7 +72,8 @@ func ImportApplication(accessToken, devportalApplicationsEndpoint, filename, app
 	applicationImportUrl := applicationImportEndpoint + "?appOwner=" + appOwner + utils.SearchAndTag + "preserveOwner=" +
 		strconv.FormatBool(preserveOwner) + utils.SearchAndTag + "skipSubscriptions=" +
 		strconv.FormatBool(skipSubscriptions) + utils.SearchAndTag + "skipApplicationKeys=" + strconv.FormatBool(skipKeys) +
-		utils.SearchAndTag + "update=" + strconv.FormatBool(updateApplication)
+		utils.SearchAndTag + "update=" + strconv.FormatBool(updateApplication) +
+		utils.SearchAndTag + "ignoreTier=" + strconv.FormatBool(ignoreTier)
 	utils.Logln(utils.LogPrefixInfo + "Import URL: " + applicationImportEndpoint)
 
 	applicationFilePath, err := resolveApplicationImportFilePath(filename, exportDirectory)

--- a/import-export-cli/utils/structs.go
+++ b/import-export-cli/utils/structs.go
@@ -375,6 +375,7 @@ type ImportConfig struct {
 	PreserveOwner     bool `json:"preserveOwner,omitempty" yaml:"preserveOwner,omitempty"`
 	SkipSubscriptions bool `json:"skipSubscriptions,omitempty" yaml:"skipSubscriptions,omitempty"`
 	SkipKeys          bool `json:"skipKeys,omitempty" yaml:"skipKeys,omitempty"`
+	IgnoreTier        bool `json:"ignoreTier,omitempty" yaml:"ignoreTier,omitempty"`
 }
 
 type RevisionListResponse struct {


### PR DESCRIPTION
Related PR: https://github.com/wso2-support/carbon-apimgt/pull/6451
Fixes https://github.com/wso2-enterprise/wso2-apim-internal/issues/5982
In the carbon side previously added the `ignoreTier` query param from the PR https://github.com/wso2-support/carbon-apimgt/pull/6451.

``` 
Ex:- https://127.0.0.1:9443/api/am/devportal/v2/applications/import?preserveOwner=true&skipSubscriptions=false&appOwner=admin&skipApplicationKeys=false&update=true&ignoreTier=true
```

This PR is created to support the `ignore-tier` query param for the previous done in the carbon side.
```
Ex:- apictl import app --file /Users/sahanrandika/.wso2apictl/exported/apps/dev/admin_testApp.zip --environment dev --ignore-tier=true --insecure
```
