### PR TITLE
Add subtypeConfiguration to CTL definitions

### DIFF
--- a/import-export-cli/integration/testdata/sample-api.yaml
+++ b/import-export-cli/integration/testdata/sample-api.yaml
@@ -28,7 +28,8 @@ data: # Contains the meta data of the API
   isDefaultVersion: false # Is API default? true|false, if set to true APIM will discard version and make the API default
   enableSchemaValidation: false # Is schema validation enabled? true|false
   type: HTTP # Type of the API {HTTP|WS|GRAPHQL|SOAPTOREST} [required]
-  subtype: DEFAULT
+  subtypeConfiguration:
+    subtype: DEFAULT
   audiences: # Allowed audiences of the API as a list
    - all
   transport: # Transport protocols as a list

--- a/import-export-cli/integration/testdata/sample-revisioned-api.yaml
+++ b/import-export-cli/integration/testdata/sample-revisioned-api.yaml
@@ -28,7 +28,8 @@ data: # Contains the meta data of the API
   isDefaultVersion: false # Is API default? true|false, if set to true APIM will discard version and make the API default
   enableSchemaValidation: false # Is schema validation enabled? true|false
   type: HTTP # Type of the API {HTTP|WS|GRAPHQL|SOAPTOREST} [required]
-  subtype: DEFAULT
+  subtypeConfiguration:
+    subtype: DEFAULT
   audiences: # Allowed audiences of the API as a list
    - all
   transport: # Transport protocols as a list


### PR DESCRIPTION
## Purpose

This PR adds the `subtypeConfiguration` object to the API to align with the changes to AI APIs.