### PR TITLE
Fix APIM APK Agent Fails to Build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,12 @@ vendor
 .vscode/
 
 *.tar.gz
+*.tgz
 *.rar
+
+# APIM APK Agent builds
+apim-apk-agent/arm64/main
+apim-apk-agent/amd64/main
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/apim-apk-agent/Dockerfile
+++ b/apim-apk-agent/Dockerfile
@@ -33,11 +33,11 @@ ARG GRPC_HEALTH_PROBE_PATH=/bin/grpc_health_probe
 ARG TARGETARCH
 
 ARG MOTD="\n\
- Welcome to WSO2 Docker Resources \n\
- --------------------------------- \n\
- This Docker container comprises of a WSO2 product, running with its latest GA release \n\
- which is under the Apache License, Version 2.0. \n\
- Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+    Welcome to WSO2 Docker Resources \n\
+    --------------------------------- \n\
+    This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+    which is under the Apache License, Version 2.0. \n\
+    Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
 
 RUN \
     addgroup -S -g ${APK_USER_GROUP_ID} ${APK_USER_GROUP} \
@@ -50,7 +50,7 @@ RUN \
     wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.25/grpc_health_probe-linux-${TARGETARCH} \
     && mv grpc_health_probe-linux-${TARGETARCH} ${GRPC_HEALTH_PROBE_PATH} \
     && if [ "${TARGETARCH}" = "amd64" ]; then echo "${CHECKSUM_AMD64}  ${GRPC_HEALTH_PROBE_PATH}" | sha256sum -c -; fi
-    
+
 RUN \
     chmod +x ${GRPC_HEALTH_PROBE_PATH} \
     && chown ${APK_USER}:${APK_USER_GROUP} ${GRPC_HEALTH_PROBE_PATH} \
@@ -61,7 +61,11 @@ WORKDIR ${APK_USER_HOME}
 USER ${APK_USER_ID}
 
 COPY resources/conf/config.toml conf/
+
 COPY resources/check_health.sh .
+# Remove the Windows line endings (carriage returns)
+RUN sed -i 's/\r//' check_health.sh
+
 COPY resources/conf/log_config.toml conf/
 
 COPY ./${TARGETARCH}/main apim-apk-agent

--- a/apim-apk-agent/build.gradle
+++ b/apim-apk-agent/build.gradle
@@ -39,7 +39,13 @@ allprojects {
 tasks.register('go_test', Exec) {
     group 'go'
     description 'Automates testing the packages named by the import paths.'
-    commandLine 'sh', '-c', "go test -race -coverprofile=coverage.out -covermode=atomic ./..."
+    
+    def osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
+    if (osName.contains("windows")) {
+        commandLine 'cmd', '/c', 'set', 'CGO_ENABLED=1', "go test -race -coverprofile=coverage.out -covermode=atomic ./..."
+    } else {
+        commandLine 'sh', '-c', "go test -race -coverprofile=coverage.out -covermode=atomic ./..."
+    }
     environment "APK_HOME", "$rootDir"
 }
 

--- a/common-gradle-scripts/go.gradle
+++ b/common-gradle-scripts/go.gradle
@@ -45,8 +45,13 @@ tasks.register('go_tidy', Exec) {
 tasks.register('go_build') {
     group 'go'
     description 'Compiles the packages named by the import paths, along with their dependencies. AMD64 Archtecture'
-    dependsOn go_mac_os_build
-    dependsOn go_linux_build
+    
+     if(osName.contains("windows")) {
+        dependsOn go_windows_build
+    } else {
+        dependsOn go_mac_os_build
+        dependsOn go_linux_build
+    }
 }
 tasks.register('go_mac_os_build', Exec) {
     group 'go'
@@ -63,6 +68,19 @@ tasks.register('go_linux_build', Exec) {
     description 'Compiles the packages named by the import paths, along with their dependencies. AMD64 Archtecture'
     if (project.hasProperty('file')) {
         commandLine 'env', 'GOOS=linux', 'GOARCH=amd64','CGO_ENABLED=0', 'go', 'build', '-o','amd64/main', file
+    } else {
+        throw new StopExecutionException('Missing "file" property')
+    }
+}
+tasks.register('go_windows_build', Exec) {
+    group 'go'
+    description 'Compiles the packages named by the import paths, along with their dependencies. AMD64 Archtecture'
+    if (project.hasProperty('file')) {
+        environment 'GOOS', 'linux'
+        environment 'GOARCH', 'amd64'
+        environment 'CGO_ENABLED', '0'
+
+        commandLine 'go', 'build', '-o', 'amd64/main', file
     } else {
         throw new StopExecutionException('Missing "file" property')
     }


### PR DESCRIPTION
## Purpose
> $subject

## Approach
Configurations to run commands on Windows CMD have been added to the required configuration files. Additionally, issues with hidden characters in .sh files, which were causing errors on Windows, have been handled.