### PR TITLE
Apply URL Encoding to API Product Name During Export via API CTL Tool

### DIFF
--- a/import-export-cli/impl/exportAPIProduct.go
+++ b/import-export-cli/impl/exportAPIProduct.go
@@ -20,6 +20,7 @@ package impl
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"strconv"
 
@@ -45,7 +46,7 @@ func ExportAPIProductFromEnv(accessToken, name, version, revisionNum, provider, 
 func exportAPIProduct(name, version, revisionNum, provider, format, publisherEndpoint, accessToken string,
 	exportLatestRevision bool, exportAPIProductPreserveStatus bool) (*resty.Response, error) {
 	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
-	query := "api-products/export?name=" + name + "&version=" + version + "&providerName=" + provider +
+	query := "api-products/export?name=" + url.QueryEscape(name) + "&version=" + version + "&providerName=" + provider +
 		"&preserveStatus=" + strconv.FormatBool(exportAPIProductPreserveStatus)
 	if revisionNum != "" {
 		query += "&revisionNumber=" + revisionNum


### PR DESCRIPTION
## Purpose
The current implementation of API Product export does not apply URL encoding to the `name` field. As a result, if the name contains space characters, the tool fails.

## Approach
Implement URL encoding for the `name` of the API Product to ensure compatibility and prevent failures during export.

## Issue
https://github.com/wso2/api-manager/issues/3571