### PR TITLE
Deprecate MI Commands

### DIFF
--- a/import-export-cli/cmd/mi/activate/activate.go
+++ b/import-export-cli/cmd/mi/activate/activate.go
@@ -36,6 +36,7 @@ var ActivateCmd = &cobra.Command{
 	Short:   activateCmdShortDesc,
 	Long:    activateCmdLongDesc,
 	Example: activateCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + activateCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/activate/endpoint.go
+++ b/import-export-cli/cmd/mi/activate/endpoint.go
@@ -38,6 +38,7 @@ var activateEndpointCmd = &cobra.Command{
 	Long:    generateActivateCmdLongDescForArtifact(artifactEndpoint, "endpoint-name"),
 	Example: generateActivateCmdExamplesForArtifact(artifactEndpoint, miUtils.GetTrimmedCmdLiteral(activateEndpointCmdLiteral), "TestEP"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleActivateEndpointCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/activate/messageprocessor.go
+++ b/import-export-cli/cmd/mi/activate/messageprocessor.go
@@ -38,6 +38,7 @@ var activateMessageProcessorCmd = &cobra.Command{
 	Long:    generateActivateCmdLongDescForArtifact(artifactMessageProcessor, "messageprocessor-name"),
 	Example: generateActivateCmdExamplesForArtifact(artifactMessageProcessor, miUtils.GetTrimmedCmdLiteral(activateMessageProcessorCmdLiteral), "TestMessageProcessor"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleActivateMessageProcessorCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/activate/proxyservice.go
+++ b/import-export-cli/cmd/mi/activate/proxyservice.go
@@ -38,6 +38,7 @@ var activateProxyCmd = &cobra.Command{
 	Long:    generateActivateCmdLongDescForArtifact(artifactProxy, "proxy-name"),
 	Example: generateActivateCmdExamplesForArtifact(artifactProxy, miUtils.GetTrimmedCmdLiteral(activateProxyCmdLiteral), "SampleProxy"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleActivateProxyCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/add/add.go
+++ b/import-export-cli/cmd/mi/add/add.go
@@ -37,6 +37,7 @@ var AddCmd = &cobra.Command{
 	Short:   addCmdShortDesc,
 	Long:    addCmdLongDesc,
 	Example: addCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + AddCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/add/addEnv.go
+++ b/import-export-cli/cmd/mi/add/addEnv.go
@@ -44,6 +44,7 @@ var addEnvCmd = &cobra.Command{
 	Long:    addEnvCmdLongDesc,
 	Example: addEnvCmdExamples,
 	Args:    cobra.ExactArgs(2),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		envToBeAdded = args[0]
 		miManagementEndpoint = args[1]

--- a/import-export-cli/cmd/mi/add/logLevel.go
+++ b/import-export-cli/cmd/mi/add/logLevel.go
@@ -45,6 +45,7 @@ var addLogLevelCmd = &cobra.Command{
 	Long:    addLogLevelCmdLongDesc,
 	Example: addLogLevelCmdExamples,
 	Args:    cobra.ExactArgs(3),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleAddLogLevelCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/add/role.go
+++ b/import-export-cli/cmd/mi/add/role.go
@@ -48,6 +48,7 @@ var addRoleCmd = &cobra.Command{
 	Long:    addRoleCmdLongDesc,
 	Example: addRoleCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleAddRoleCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/add/user.go
+++ b/import-export-cli/cmd/mi/add/user.go
@@ -50,6 +50,7 @@ var addUserCmd = &cobra.Command{
 	Long:    addUserCmdLongDesc,
 	Example: addUserCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleAddUserCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/deactivate/deactivate.go
+++ b/import-export-cli/cmd/mi/deactivate/deactivate.go
@@ -36,6 +36,7 @@ var DeactivateCmd = &cobra.Command{
 	Short:   deactivateCmdShortDesc,
 	Long:    deactivateCmdLongDesc,
 	Example: deactivateCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deactivateCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/deactivate/endpoint.go
+++ b/import-export-cli/cmd/mi/deactivate/endpoint.go
@@ -38,6 +38,7 @@ var deactivateEndpointCmd = &cobra.Command{
 	Long:    generateDeactivateCmdLongDescForArtifact(artifactEndpoint, "endpoint-name"),
 	Example: generateDeactivateCmdExamplesForArtifact(artifactEndpoint, miUtils.GetTrimmedCmdLiteral(deactivateEndpointCmdLiteral), "TestEP"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleDeactivateEndpointCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/deactivate/messageprocessor.go
+++ b/import-export-cli/cmd/mi/deactivate/messageprocessor.go
@@ -38,6 +38,7 @@ var deactivateMessageProcessorCmd = &cobra.Command{
 	Long:    generateDeactivateCmdLongDescForArtifact(artifactMessageProcessor, "messageprocessor-name"),
 	Example: generateDeactivateCmdExamplesForArtifact(artifactMessageProcessor, miUtils.GetTrimmedCmdLiteral(deactivateMessageProcessorCmdLiteral), "TestMessageProcessor"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleDeactivateMessageProcessorCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/deactivate/proxyservice.go
+++ b/import-export-cli/cmd/mi/deactivate/proxyservice.go
@@ -38,6 +38,7 @@ var deactivateProxyCmd = &cobra.Command{
 	Long:    generateDeactivateCmdLongDescForArtifact(artifactProxy, "proxy-name"),
 	Example: generateDeactivateCmdExamplesForArtifact(artifactProxy, miUtils.GetTrimmedCmdLiteral(deactivateProxyCmdLiteral), "SampleProxy"),
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleDeactivateProxyCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/delete/delete.go
+++ b/import-export-cli/cmd/mi/delete/delete.go
@@ -36,6 +36,7 @@ var DeleteCmd = &cobra.Command{
 	Short:   deleteCmdShortDesc,
 	Long:    deleteCmdLongDesc,
 	Example: deleteCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + deleteCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/delete/removeEnv.go
+++ b/import-export-cli/cmd/mi/delete/removeEnv.go
@@ -46,6 +46,7 @@ var removeEnvCmd = &cobra.Command{
 	Long:    removeEnvCmdLongDesc,
 	Example: removeEnvCmdExamples,
 	Args:    cobra.MinimumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		envToBeRemoved := args[0]
 

--- a/import-export-cli/cmd/mi/delete/role.go
+++ b/import-export-cli/cmd/mi/delete/role.go
@@ -48,6 +48,7 @@ var deleteRoleCmd = &cobra.Command{
 	Long:    deleteRoleCmdLongDesc,
 	Example: deleteRoleCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handledeleteRoleCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/delete/user.go
+++ b/import-export-cli/cmd/mi/delete/user.go
@@ -48,6 +48,7 @@ var deleteUserCmd = &cobra.Command{
 	Long:    deleteUserCmdLongDesc,
 	Example: deleteUserCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handledeleteUserCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/apis.go
+++ b/import-export-cli/cmd/mi/get/apis.go
@@ -37,6 +37,7 @@ var getIntegrationAPICmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactAPIs, "api-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactAPIs, miUtils.GetTrimmedCmdLiteral(getIntegrationAPICmdLiteral), "SampleIntegrationAPI"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetIntegrationAPICmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/compositeApps.go
+++ b/import-export-cli/cmd/mi/get/compositeApps.go
@@ -37,6 +37,7 @@ var getApplicationCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactCompositeApps, "app-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactCompositeApps, miUtils.GetTrimmedCmdLiteral(getApplicationCmdLiteral), "SampleApp"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetApplicationCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/connectors.go
+++ b/import-export-cli/cmd/mi/get/connectors.go
@@ -43,6 +43,7 @@ var getConnectorCmd = &cobra.Command{
 	Long:    getConnectorCmdLongDesc,
 	Example: getConnectorCmdExamples,
 	Args:    cobra.ExactArgs(0),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetConnectorCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/dataservices.go
+++ b/import-export-cli/cmd/mi/get/dataservices.go
@@ -37,6 +37,7 @@ var getDataServiceCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactDataServices, "dataservice-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactDataServices, miUtils.GetTrimmedCmdLiteral(getDataServiceCmdLiteral), "SampleDataService"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetDataServiceCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/endpoints.go
+++ b/import-export-cli/cmd/mi/get/endpoints.go
@@ -37,6 +37,7 @@ var getEndpointCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactEndpoints, "endpoint-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactEndpoints, miUtils.GetTrimmedCmdLiteral(getEndpointCmdLiteral), "SampleEndpoint"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetEndpointCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/get.go
+++ b/import-export-cli/cmd/mi/get/get.go
@@ -38,6 +38,7 @@ var GetCmd = &cobra.Command{
 	Short:   getCmdShortDesc,
 	Long:    getCmdLongDesc,
 	Example: getCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + GetCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/get/getEnvs.go
+++ b/import-export-cli/cmd/mi/get/getEnvs.go
@@ -42,6 +42,7 @@ var getEnvsCmd = &cobra.Command{
 	Short:   getEnvsCmdShortDesc,
 	Long:    getEnvsCmdLongDesc,
 	Example: getEnvsCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + GetEnvsCmdLiteral + " called")
 		envs := utils.GetMainConfigFromFile(utils.MainConfigFilePath).Environments

--- a/import-export-cli/cmd/mi/get/inboundendpoints.go
+++ b/import-export-cli/cmd/mi/get/inboundendpoints.go
@@ -37,6 +37,7 @@ var getInboundEndpointCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactInboundEndpoints, "inbound-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactInboundEndpoints, miUtils.GetTrimmedCmdLiteral(getInboundEndpointCmdLiteral), "SampleInboundEndpoint"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetInboundEndpointCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/localentries.go
+++ b/import-export-cli/cmd/mi/get/localentries.go
@@ -37,6 +37,7 @@ var getLocalEntryCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactLocalEntries, "localentry-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactLocalEntries, miUtils.GetTrimmedCmdLiteral(getLocalEntryCmdLiteral), "SampleLocalEntry"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetLocalEntryCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/logLevels.go
+++ b/import-export-cli/cmd/mi/get/logLevels.go
@@ -44,6 +44,7 @@ var getLogLevelCmd = &cobra.Command{
 	Long:    getLogLevelCmdLongDesc,
 	Example: getLogLevelCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetLogLevelCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/logs.go
+++ b/import-export-cli/cmd/mi/get/logs.go
@@ -51,6 +51,7 @@ var getLogCmd = &cobra.Command{
 	Long:    getLogCmdLongDesc,
 	Example: getLogCmdExamples,
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetLogCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/messageprocessors.go
+++ b/import-export-cli/cmd/mi/get/messageprocessors.go
@@ -37,6 +37,7 @@ var getMessageProcessorCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactMessageProcessors, "messageprocessor-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactMessageProcessors, miUtils.GetTrimmedCmdLiteral(getMessageProcessorCmdLiteral), "TestMessageProcessor"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetMessageProcessorCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/messagestores.go
+++ b/import-export-cli/cmd/mi/get/messagestores.go
@@ -37,6 +37,7 @@ var getMessageStoreCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactMessageStores, "messagestore-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactMessageStores, miUtils.GetTrimmedCmdLiteral(getMessageStoreCmdLiteral), "TestMessageStore"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetMessageStoreCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/proxyservices.go
+++ b/import-export-cli/cmd/mi/get/proxyservices.go
@@ -37,6 +37,7 @@ var getProxyServiceCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactProxyServices, "proxy-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactProxyServices, miUtils.GetTrimmedCmdLiteral(getProxyServiceCmdLiteral), "SampleProxy"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetProxyServiceCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/roles.go
+++ b/import-export-cli/cmd/mi/get/roles.go
@@ -59,6 +59,7 @@ var getRoleCmd = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetRoleCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/sequences.go
+++ b/import-export-cli/cmd/mi/get/sequences.go
@@ -37,6 +37,7 @@ var getSequenceCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactSequences, "sequence-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactSequences, miUtils.GetTrimmedCmdLiteral(getSequenceCmdLiteral), "SampleSequence"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetSequenceCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/tasks.go
+++ b/import-export-cli/cmd/mi/get/tasks.go
@@ -37,6 +37,7 @@ var getTasksCmd = &cobra.Command{
 	Long:    generateGetCmdLongDescForArtifact(artifactTasks, "task-name"),
 	Example: generateGetCmdExamplesForArtifact(artifactTasks, miUtils.GetTrimmedCmdLiteral(getTaskCmdLiteral), "SampleTask"),
 	Args:    cobra.MaximumNArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetTaskCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/templates.go
+++ b/import-export-cli/cmd/mi/get/templates.go
@@ -69,6 +69,7 @@ var getTemplateCmd = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetTemplateCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/transactionCount.go
+++ b/import-export-cli/cmd/mi/get/transactionCount.go
@@ -49,6 +49,7 @@ var getTransactionCountCmd = &cobra.Command{
 	Short:   getTransactionCountCmdShortDesc,
 	Long:    getTransactionCountCmdLongDesc,
 	Example: getTransactionCountCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 || len(args) == 2 {
 			return nil

--- a/import-export-cli/cmd/mi/get/transactionReports.go
+++ b/import-export-cli/cmd/mi/get/transactionReports.go
@@ -54,6 +54,7 @@ var getTransactionReportCmd = &cobra.Command{
 	Long:    getTransactionReportCmdLongDesc,
 	Example: getTransactionReportCmdExamples,
 	Args:    cobra.RangeArgs(1, 2),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetTransactionReportCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/get/users.go
+++ b/import-export-cli/cmd/mi/get/users.go
@@ -71,6 +71,7 @@ var getUserCmd = &cobra.Command{
 		}
 		return nil
 	},
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleGetUserCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/login.go
+++ b/import-export-cli/cmd/mi/login.go
@@ -47,6 +47,7 @@ var loginCmd = &cobra.Command{
 	Long:    loginCmdLongDesc,
 	Example: loginCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		environment := args[0]
 

--- a/import-export-cli/cmd/mi/logout.go
+++ b/import-export-cli/cmd/mi/logout.go
@@ -39,6 +39,7 @@ var logoutCmd = &cobra.Command{
 	Long:    logoutCmdLongDesc,
 	Example: logoutCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := credentials.RunMILogout(args[0])
 		if err != nil {

--- a/import-export-cli/cmd/mi/mi.go
+++ b/import-export-cli/cmd/mi/mi.go
@@ -54,6 +54,7 @@ var MICmd = &cobra.Command{
 	Short: miCmdShortDesc,
 	Long:  miCmdLongDesc,
 	// Example: miCmdExamples,
+		Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + utils.MiCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/update/hashiCorpVault.go
+++ b/import-export-cli/cmd/mi/update/hashiCorpVault.go
@@ -45,6 +45,7 @@ var updateHashiCorpSecretCmd = &cobra.Command{
 	Long:    updateHashiCorpSecretCmdLongDesc,
 	Example: updateHashiCorpSecretCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleUpdateHashiCorpSecretCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/update/logLevel.go
+++ b/import-export-cli/cmd/mi/update/logLevel.go
@@ -45,6 +45,7 @@ var updateLogLevelCmd = &cobra.Command{
 	Long:    updateLogLevelCmdLongDesc,
 	Example: updateLogLevelCmdExamples,
 	Args:    cobra.ExactArgs(2),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleupdateLogLevelCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/update/update.go
+++ b/import-export-cli/cmd/mi/update/update.go
@@ -36,6 +36,7 @@ var UpdateCmd = &cobra.Command{
 	Short:   updateCmdShortDesc,
 	Long:    updateCmdLongDesc,
 	Example: updateCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		utils.Logln(utils.LogPrefixInfo + updateCmdLiteral + " called")
 		cmd.Help()

--- a/import-export-cli/cmd/mi/update/user.go
+++ b/import-export-cli/cmd/mi/update/user.go
@@ -48,6 +48,7 @@ var updateUserCmd = &cobra.Command{
 	Long:    updateUserCmdLongDesc,
 	Example: updateUserCmdExamples,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		handleupdateUserCmdArguments(args)
 	},

--- a/import-export-cli/cmd/mi/version.go
+++ b/import-export-cli/cmd/mi/version.go
@@ -45,6 +45,7 @@ var VersionCmd = &cobra.Command{
 	Short:   versionCmdShortDesc,
 	Long:    versionCmdLongDesc,
 	Example: versionCmdExamples,
+	Deprecated: "instead refer to https://mi.docs.wso2.com/en/latest/observe-and-manage/managing-integrations-with-micli/ for updated usage.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Version:", Version)
 		fmt.Println("Build Date:", BuildDate)


### PR DESCRIPTION
## Purpose
> Deprecating MI commands and adding a reference to MI CLI in the deprecation message.

