### PR TITLE
Support preserve credentials flag in API export operations

### DIFF
--- a/import-export-cli/cmd/deprecated/exportAPI.go
+++ b/import-export-cli/cmd/deprecated/exportAPI.go
@@ -76,7 +76,7 @@ func executeExportAPICmd(credential credentials.Credential, exportDirectory stri
 
 	if preCommandErr == nil {
 		resp, err := impl.ExportAPIFromEnv(accessToken, exportAPIName, exportAPIVersion, "",
-			exportProvider, exportAPIFormat, cmd.CmdExportEnvironment, exportAPIPreserveStatus, false)
+			exportProvider, exportAPIFormat, cmd.CmdExportEnvironment, exportAPIPreserveStatus, false, false)
 		if err != nil {
 			utils.HandleErrorAndExit("Error while exporting", err)
 		}

--- a/import-export-cli/cmd/deprecated/exportAPIs.go
+++ b/import-export-cli/cmd/deprecated/exportAPIs.go
@@ -87,7 +87,7 @@ func executeExportAPIsCmd(credential credentials.Credential, exportDirectory str
 	}
 
 	impl.ExportAPIs(credential, exportRelatedFilesPath, cmd.CmdExportEnvironment, cmd.CmdResourceTenantDomain, exportAPIsFormat, cmd.CmdUsername,
-		apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, false)
+		apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, false, false)
 }
 
 func init() {

--- a/import-export-cli/cmd/exportAPI.go
+++ b/import-export-cli/cmd/exportAPI.go
@@ -40,6 +40,7 @@ var exportAPIPreserveStatus bool
 var exportAPIFormat string
 var runningExportApiCommand bool
 var exportAPILatestRevision bool
+var exportAPIPreserveCredentials bool
 
 // ExportAPI command related usage info
 const ExportAPICmdLiteral = "api"
@@ -79,7 +80,8 @@ func executeExportAPICmd(credential credentials.Credential, exportDirectory stri
 
 	if preCommandErr == nil {
 		resp, err := impl.ExportAPIFromEnv(accessToken, exportAPIName, exportAPIVersion, exportRevisionNum, exportProvider,
-			exportAPIFormat, CmdExportEnvironment, exportAPIPreserveStatus, exportAPILatestRevision)
+			exportAPIFormat, CmdExportEnvironment, exportAPIPreserveStatus, exportAPILatestRevision,
+ 			exportAPIPreserveCredentials)
 		if err != nil {
 			utils.HandleErrorAndExit("Error while exporting", err)
 		}
@@ -116,6 +118,8 @@ func init() {
 		"", "Environment to which the API should be exported")
 	ExportAPICmd.Flags().BoolVarP(&exportAPIPreserveStatus, "preserve-status", "", true,
 		"Preserve API status when exporting. Otherwise API will be exported in CREATED status")
+	ExportAPICmd.Flags().BoolVarP(&exportAPIPreserveCredentials, "preserve-credentials", "", false,
+		"Preserve endpoint credentials when exporting. Otherwise credentials will not be exported")
 	ExportAPICmd.Flags().BoolVarP(&exportAPILatestRevision, "latest", "", false,
 		"Export the latest revision of the API")
 	ExportAPICmd.Flags().StringVarP(&exportAPIFormat, "format", "", utils.DefaultExportFormat, "File format of exported archive(json or yaml)")

--- a/import-export-cli/cmd/exportAPIs.go
+++ b/import-export-cli/cmd/exportAPIs.go
@@ -87,7 +87,8 @@ func executeExportAPIsCmd(credential credentials.Credential, exportDirectory str
 	}
 
 	impl.ExportAPIs(credential, exportRelatedFilesPath, CmdExportEnvironment, CmdResourceTenantDomain, exportAPIsFormat,
-		CmdUsername, apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, exportAPIsAllRevisions)
+		CmdUsername, apiExportDir, exportAPIPreserveStatus, runningExportApiCommand, exportAPIsAllRevisions,
+ 		exportAPIPreserveCredentials)
 }
 
 func init() {
@@ -99,6 +100,8 @@ func init() {
 			"any, and to export APIs from beginning")
 	ExportAPIsCmd.Flags().BoolVarP(&exportAPIPreserveStatus, "preserve-status", "", true,
 		"Preserve API status when exporting. Otherwise API will be exported in CREATED status")
+	ExportAPIsCmd.Flags().BoolVarP(&exportAPIPreserveCredentials, "preserve-credentials", "", false,
+		"Preserve endpoint credentials when exporting. Otherwise credentials will not be exported")
 	ExportAPIsCmd.Flags().BoolVarP(&exportAPIsAllRevisions, "all", "", false,
 		"Export working copy and all revisions for the APIs in the environments ")
 	ExportAPIsCmd.Flags().StringVarP(&exportAPIsFormat, "format", "", utils.DefaultExportFormat, "File format of exported archives(json or yaml)")

--- a/import-export-cli/impl/exportAPI.go
+++ b/import-export-cli/impl/exportAPI.go
@@ -30,10 +30,10 @@ import (
 
 // ExportAPIFromEnv function is used with export api command
 func ExportAPIFromEnv(accessToken, name, version, revisionNum, provider, format, exportEnvironment string, preserveStatus,
-	exportLatestRevision bool) (*resty.Response, error) {
+	exportLatestRevision, preserveCredentials bool) (*resty.Response, error) {
 	publisherEndpoint := utils.GetPublisherEndpointOfEnv(exportEnvironment, utils.MainConfigFilePath)
 	return exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, accessToken, preserveStatus,
-		exportLatestRevision)
+		exportLatestRevision, preserveCredentials)
 }
 
 // exportAPI function is used with export api command
@@ -44,10 +44,11 @@ func ExportAPIFromEnv(accessToken, name, version, revisionNum, provider, format,
 // @param accessToken : Access Token for the resource
 // @return response Response in the form of *resty.Response
 func exportAPI(name, version, revisionNum, provider, format, publisherEndpoint, accessToken string, preserveStatus,
-	exportLatestRevision bool) (*resty.Response, error) {
+	exportLatestRevision, preserveCredentials bool) (*resty.Response, error) {
 	publisherEndpoint = utils.AppendSlashToString(publisherEndpoint)
 	query := "apis/export?name=" + url.QueryEscape(name) + "&version=" + version + "&providerName=" + provider +
-		"&preserveStatus=" + strconv.FormatBool(preserveStatus)
+		"&preserveStatus=" + strconv.FormatBool(preserveStatus) + "&preserveCredentials=" +
+ 		strconv.FormatBool(preserveCredentials)
 	if format != "" {
 		query += "&format=" + format
 	}

--- a/import-export-cli/impl/exportAPIs.go
+++ b/import-export-cli/impl/exportAPIs.go
@@ -143,7 +143,8 @@ func getRevisionsListForAPI(accessToken, cmdExportEnvironment string, api utils.
 
 // Do the API exportation
 func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdExportEnvironment, cmdResourceTenantDomain,
-	exportAPIsFormat, cmdUsername, apiExportDir string, exportAPIPreserveStatus, runningExportApiCommand, exportAllRevisions bool) {
+	exportAPIsFormat, cmdUsername, apiExportDir string, exportAPIPreserveStatus, runningExportApiCommand,
+ 	exportAllRevisions, exportAPIPreserveCredentials bool) {
 	if count == 0 {
 		fmt.Println("No APIs available to be exported..!")
 	} else {
@@ -158,7 +159,8 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 					if exportAllRevisions {
 						//Export the working copy of the api
 						exportAPIandWriteToZip(apis[i], "", accessToken, cmdExportEnvironment, apiExportDir,
-							exportRelatedFilesPath, exportAPIsFormat, exportAPIPreserveStatus, runningExportApiCommand)
+							exportRelatedFilesPath, exportAPIsFormat, exportAPIPreserveStatus, runningExportApiCommand,
+							exportAPIPreserveCredentials)
 						counterSuceededAPIs++
 					}
 					revisionCount, revisions, err := getRevisionsListForAPI(accessToken, cmdExportEnvironment, apis[i],
@@ -171,7 +173,7 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 							exportApiRevision := utils.GetRevisionNumFromRevisionName(revisions[j].RevisionNumber)
 							exportAPIandWriteToZip(apis[i], exportApiRevision, accessToken, cmdExportEnvironment,
 								apiExportDir, exportRelatedFilesPath, exportAPIsFormat, exportAPIPreserveStatus,
-								runningExportApiCommand)
+								runningExportApiCommand, exportAPIPreserveCredentials)
 							counterSuceededAPIs++
 						}
 					}
@@ -198,7 +200,8 @@ func ExportAPIs(credential credentials.Credential, exportRelatedFilesPath, cmdEx
 
 //Export the API and archive to zip format
 func exportAPIandWriteToZip(api utils.API, revisionNumber, accessToken, cmdExportEnvironment, apiExportDir,
-	exportRelatedFilesPath, exportAPIsFormat string, exportAPIPreserveStatus, runningExportApiCommand bool) {
+	exportRelatedFilesPath, exportAPIsFormat string, exportAPIPreserveStatus, runningExportApiCommand,
+ 	exportAPIPreserveCredentials bool) {
 
 	exportAPIName := api.Name
 	exportAPIVersion := api.Version
@@ -208,7 +211,8 @@ func exportAPIandWriteToZip(api utils.API, revisionNumber, accessToken, cmdExpor
 		exportApiRevision = utils.GetRevisionNumFromRevisionName(revisionNumber)
 	}
 	resp, err := ExportAPIFromEnv(accessToken, exportAPIName, exportAPIVersion, exportApiRevision,
-		exportApiProvider, exportAPIsFormat, cmdExportEnvironment, exportAPIPreserveStatus, false)
+		exportApiProvider, exportAPIsFormat, cmdExportEnvironment, exportAPIPreserveStatus, false,
+ 		exportAPIPreserveCredentials)
 	if err != nil {
 		utils.HandleErrorAndExit("Error exporting", err)
 	}


### PR DESCRIPTION
## Purpose
Allowing apictl export option to export the APIs with secret values using the `preserve-credentials` flag.
Done as a part of https://github.com/wso2-enterprise/wso2-apim-internal/issues/9104

## Goals
Giving the apictl support for exporting APIs with secret attributes in API Level / Operational policies.

## Approach
Added the `preserve-credentials` flag.

## Samples
N/A

## Related PRs
https://github.com/wso2/product-apim-tooling/commit/a85c29618346ca0176da5dffd7795e5165fdc7ff
