### PR TITLE
Fix search query in API policy retrieval

### DIFF
--- a/import-export-cli/impl/importAPIPolicy.go
+++ b/import-export-cli/impl/importAPIPolicy.go
@@ -231,7 +231,7 @@ func GetAPIPolicyId(accessToken, environment, policyName, policyVersion string) 
 	headers := make(map[string]string)
 	headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
 
-	queryParams := `query=name:` + policyName + `&version:` + policyVersion
+	queryParams := `query=name:` + policyName + ` version:` + policyVersion
 
 	apiPolicyEndpoint = utils.AppendSlashToString(apiPolicyEndpoint)
 

--- a/import-export-cli/integration/apim/apim.go
+++ b/import-export-cli/integration/apim/apim.go
@@ -2442,7 +2442,7 @@ func (instance *Client) GetAPIPolicy(policyId string) map[string]interface{} {
 func (instance *Client) GetAPIPolicyID(t *testing.T, policyName, policyVersion string) string {
 	var policyListResponse APIPoliciesList
 
-	queryParams := "name:" + policyName + "&version:" + policyVersion
+	queryParams := "name:" + policyName + " version:" + policyVersion
 
 	getPoliciesURL := instance.publisherRestURL + operationPolicyResourcePath
 


### PR DESCRIPTION
## Purpose
Correcting the search query in API policy retrieval

## Approach
In APIM 4.2.x API policy retrieval endpoint, the query fields are separated with spaces ` `, not with `&` signs. Updated the query with the correct one.

Note: This is only being used during API policy delete operation

## Automation tests
 - Integration tests
     - Updated the test as well

<img width="653" height="123" alt="image" src="https://github.com/user-attachments/assets/3f071b6b-2a1b-4e8a-8980-c2abed6f8b2d" />

## Samples
<img width="1393" height="137" alt="image" src="https://github.com/user-attachments/assets/6e492ae3-8a62-41c1-94f8-68f4edddd00b" />

## Related PRs
Reverted few changes done with https://github.com/wso2/product-apim-tooling/pull/1287/files
