### PR TITLE
[4.2.x] Fix the tests failing due to expired certificate

### DIFF
--- a/import-export-cli/integration/testutils/api_testUtils.go
+++ b/import-export-cli/integration/testutils/api_testUtils.go
@@ -1146,7 +1146,7 @@ func ValidateAPIDeleteFailure(t *testing.T, args *ApiImportExportTestArgs) {
 }
 
 func exportApiImportedFromProject(t *testing.T, APIName string, APIVersion string, EnvName string) (string, error) {
-	return base.Execute(t, "export", "api", "-n", APIName, "-v", APIVersion, "-e", EnvName)
+	return base.Execute(t, "export", "api", "-n", APIName, "-v", APIVersion, "-e", EnvName, "-k")
 }
 
 func exportAllApisOfATenant(t *testing.T, args *ApiImportExportTestArgs) (string, error) {

--- a/import-export-cli/integration/testutils/environment_testUtils.go
+++ b/import-export-cli/integration/testutils/environment_testUtils.go
@@ -136,7 +136,7 @@ func InitProjectWithOasFlag(t *testing.T, args *InitTestArgs) (string, error) {
 	base.SetupEnvWithoutTokenFlag(t, args.SrcAPIM.GetEnvName(), args.SrcAPIM.GetApimURL())
 	base.Login(t, args.SrcAPIM.GetEnvName(), args.CtlUser.Username, args.CtlUser.Password)
 
-	output, err := base.Execute(t, "init", args.InitFlag, "--oas", args.OasFlag, "--verbose", "-f")
+	output, err := base.Execute(t, "init", args.InitFlag, "--oas", args.OasFlag, "--verbose", "-f", "-k")
 	return output, err
 }
 

--- a/import-export-cli/integration/testutils/operationPolicy_testUtils.go
+++ b/import-export-cli/integration/testutils/operationPolicy_testUtils.go
@@ -330,7 +330,7 @@ func importAPIPolicy(t *testing.T, username, password, policyName, policyVersion
 	var output string
 	var err error
 
-	output, err = base.Execute(t, "import", "policy", "api", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath)
+	output, err = base.Execute(t, "import", "policy", "api", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath, "-k")
 
 	if doClean {
 		t.Cleanup(func() {

--- a/import-export-cli/integration/testutils/policy_testUtils.go
+++ b/import-export-cli/integration/testutils/policy_testUtils.go
@@ -328,9 +328,9 @@ func importThrottlePolicy(t *testing.T, username, password, policyName, policyTy
 	var output string
 	var err error
 	if args.Update {
-		output, err = base.Execute(t, "import", "policy", "rate-limiting", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath, "-u")
+		output, err = base.Execute(t, "import", "policy", "rate-limiting", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath, "-u", "-k")
 	} else {
-		output, err = base.Execute(t, "import", "policy", "rate-limiting", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath)
+		output, err = base.Execute(t, "import", "policy", "rate-limiting", "-e", args.DestAPIM.GetEnvName(), "-f", args.ImportFilePath, "-k")
 	}
 
 	if doClean {


### PR DESCRIPTION
## Purpose
Fixing the tests failing due to expired public certificate

## Goals
Fixing the tests for 4.2.7 release

## Approach
Added the `-k` flag to the commands failing due to the certificate

## Samples
<img width="765" height="218" alt="image" src="https://github.com/user-attachments/assets/bcfa4434-ed67-427f-a78b-ea373543ff25" />
