### PR TITLE
Mcp server

### DIFF
--- a/import-export-cli/cmd/exportMCPServer.go
+++ b/import-export-cli/cmd/exportMCPServer.go
@@ -89,7 +89,7 @@ func executeExportMCPServerCmd(credential credentials.Credential, exportDirector
 		utils.Logf(utils.LogPrefixInfo+"ResponseStatus: %v\n", resp.Status())
 		mcpServerZipLocationPath := filepath.Join(exportDirectory, CmdExportEnvironment)
 		if resp.StatusCode() == http.StatusOK {
-			impl.WriteToZip(exportMCPServerName, exportMCPServerVersion, "", mcpServerZipLocationPath, runningExportMCPServerCommand, resp)
+			impl.WriteMCPServerToZip(exportMCPServerName, exportMCPServerVersion, "", mcpServerZipLocationPath, runningExportMCPServerCommand, resp)
 		} else if resp.StatusCode() == http.StatusInternalServerError {
 			// 500 Internal Server Error
 			fmt.Println(string(resp.Body()))

--- a/import-export-cli/cmd/exportMCPServers.go
+++ b/import-export-cli/cmd/exportMCPServers.go
@@ -63,7 +63,7 @@ var ExportMCPServersCmd = &cobra.Command{
 // exportDirectory = <export_directory>/migration/
 func executeExportMCPServersCmd(credential credentials.Credential, exportDirectory string) {
 	//create dir structure
-	mcpServerExportDir := impl.CreateExportAPIsDirStructure(exportDirectory, CmdResourceTenantDomain, CmdExportEnvironment,
+	mcpServerExportDir := impl.CreateExportMCPServersDirStructure(exportDirectory, CmdResourceTenantDomain, CmdExportEnvironment,
 		CmdForceStartFromBegin)
 	exportRelatedFilesPath := filepath.Join(exportDirectory, CmdExportEnvironment,
 		utils.GetMigrationExportTenantDirName(CmdResourceTenantDomain))

--- a/import-export-cli/impl/exportMCPServer.go
+++ b/import-export-cli/impl/exportMCPServer.go
@@ -19,7 +19,9 @@
 package impl
 
 import (
+	"fmt"
 	"net/url"
+	"path/filepath"
 	"strconv"
 
 	"github.com/go-resty/resty/v2"
@@ -70,4 +72,55 @@ func exportMCPServer(name, version, revisionNum, provider, format, publisherEndp
 	}
 
 	return resp, nil
+}
+
+// WriteToZip
+// @param exportAPIName : Name of the API to be exported
+// @param exportAPIVersion: Version of the API to be exported
+// @param exportAPIRevisionNumber: Revision number of the api
+// @param zipLocationPath: Path to the export directory
+// @param runningExportApiCommand: Whether the export API command is running
+// @param resp : Response returned from making the HTTP request (only pass a 200 OK)
+// Exported API will be written to a zip file
+func WriteMCPServerToZip(exportMCPServerName, exportMCPServerVersion, exportMCPServerRevisionNumber, zipLocationPath string,
+	runningExportApiCommand bool, resp *resty.Response) {
+	zipFilename := exportMCPServerName + "_" + exportMCPServerVersion
+	if exportMCPServerRevisionNumber != "" {
+		zipFilename += "_" + utils.GetRevisionNamFromRevisionNum(exportMCPServerRevisionNumber)
+	}
+	zipFilename += ".zip" // MyAPI_1.0.0_Revision-1.zip
+	// Writes the REST API response to a temporary zip file
+	tempZipFile, err := utils.WriteResponseToTempZip(zipFilename, resp)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating the temporary zip file to store the exported API", err)
+	}
+
+	err = utils.CreateDirIfNotExist(zipLocationPath)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating dir to store zip archive: "+zipLocationPath, err)
+	}
+	exportedFinalZip := filepath.Join(zipLocationPath, zipFilename)
+
+	// Add api_meta.yaml file inside the zip and create a new zup file in exportedFinalZip location
+	metaData := utils.MetaData{
+		Name:    exportMCPServerName,
+		Version: exportMCPServerVersion,
+		DeployConfig: utils.DeployConfig{
+			Import: utils.ImportConfig{
+				Update:           true,
+				PreserveProvider: true,
+				RotateRevision:   false,
+			},
+		},
+	}
+	err = IncludeMetaFileToZip(tempZipFile, exportedFinalZip, utils.MetaFileAPI, metaData)
+	if err != nil {
+		utils.HandleErrorAndExit("Error creating the final zip archive with api_meta.yaml file", err)
+	}
+
+	// Output the final zip file location.
+	if runningExportApiCommand {
+		fmt.Println("Successfully exported MCP Server!")
+		fmt.Println("Find the exported MCP Server at " + exportedFinalZip)
+	}
 }

--- a/import-export-cli/impl/exportMCPServers.go
+++ b/import-export-cli/impl/exportMCPServers.go
@@ -141,7 +141,7 @@ func getRevisionsListForMCPServer(accessToken, environment string, mcpServer uti
 
 // Do the MCP Server exportation
 func ExportMCPServers(credential credentials.Credential, exportRelatedFilesPath, environment, tenantDomain, format,
-	username, exportDir string, preserveStatus, runningExportMCPServerCommand, allRevisions,
+	username, mcpServerExportDir string, preserveStatus, runningExportMCPServerCommand, allRevisions,
 	preserveCredentials bool) {
 
 	if mcpServerCount == 0 {
@@ -157,7 +157,7 @@ func ExportMCPServers(credential credentials.Credential, exportRelatedFilesPath,
 				for i := startingMCPServerIndexFromList; i < len(mcpServers); i++ {
 					if allRevisions {
 						// Export the working copy of the MCP server
-						exportMCPServerAndWriteToZip(mcpServers[i], "", accessToken, environment, exportDir,
+						exportMCPServerAndWriteToZip(mcpServers[i], "", accessToken, environment, mcpServerExportDir,
 							exportRelatedFilesPath, format, preserveStatus, runningExportMCPServerCommand,
 							preserveCredentials)
 						counterSucceededMCPServers++
@@ -171,7 +171,7 @@ func ExportMCPServers(credential credentials.Credential, exportRelatedFilesPath,
 						for j := 0; j < len(revisions); j++ {
 							exportMCPServerRevision := utils.GetRevisionNumFromRevisionName(revisions[j].RevisionNumber)
 							exportMCPServerAndWriteToZip(mcpServers[i], exportMCPServerRevision, accessToken, environment,
-								exportDir, exportRelatedFilesPath, format, preserveStatus, runningExportMCPServerCommand,
+								mcpServerExportDir, exportRelatedFilesPath, format, preserveStatus, runningExportMCPServerCommand,
 								preserveCredentials)
 							counterSucceededMCPServers++
 						}
@@ -192,7 +192,7 @@ func ExportMCPServers(credential credentials.Credential, exportRelatedFilesPath,
 			}
 		}
 		fmt.Println("\nTotal number of MCP Servers exported: " + cast.ToString(counterSucceededMCPServers))
-		fmt.Println("MCP Server export path: " + exportDir)
+		fmt.Println("MCP Server export path: " + mcpServerExportDir)
 		fmt.Println("\nCommand: export-mcp-servers execution completed !")
 	}
 }


### PR DESCRIPTION
- Currently the implementation is re-using the existing methods from export api/apis when exporting the zip files. This fix will add separate methods to create mcp-server specific paths and repose messages"