### PR TITLE
Add support for mcp servers in get keys

### DIFF
--- a/import-export-cli/cmd/get.go
+++ b/import-export-cli/cmd/get.go
@@ -36,7 +36,7 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of MCP Server revisions of a specific MCP Server in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
-Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API or API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
 Get the log level of each API in the environment specified by flag (--environment, -e)/
 Get the log level of each MCP Server in the environment specified by flag (--environment, -e)/
 Get the correlation log configurations in the environment specified by flag (--environment, -e)

--- a/import-export-cli/cmd/get.go
+++ b/import-export-cli/cmd/get.go
@@ -36,7 +36,7 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of MCP Server revisions of a specific MCP Server in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
-Get a generated JWT token to invoke an API or API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API, API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
 Get the log level of each API in the environment specified by flag (--environment, -e)/
 Get the log level of each MCP Server in the environment specified by flag (--environment, -e)/
 Get the correlation log configurations in the environment specified by flag (--environment, -e)

--- a/import-export-cli/cmd/getKeys.go
+++ b/import-export-cli/cmd/getKeys.go
@@ -26,8 +26,8 @@ import (
 
 // keys command related Info
 const GetKeysCmdLiteral = "keys"
-const getKeysCmdShortDesc = "Generate access token to invoke the API or API Product or MCP Server"
-const getKeysCmdLongDesc = `Generate JWT token to invoke the API or API Product or MCP Server by subscribing to a default application for testing purposes`
+const getKeysCmdShortDesc = "Generate access token to invoke the API, API Product or MCP Server"
+const getKeysCmdLongDesc = `Generate JWT token to invoke the API, API Product or MCP Server by subscribing to a default application for testing purposes`
 const getKeysCmdExamples = utils.ProjectName + " " + GetCmdLiteral + " " + GetKeysCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev --provider admin
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory.
 You can override the default token endpoint using --token (-t) optional flag providing a new token endpoint`
@@ -61,13 +61,13 @@ var getKeysCmd = &cobra.Command{
 	},
 }
 
-//init function to add the cli command to the root command
+// init function to add the cli command to the root command
 func init() {
 	GetCmd.AddCommand(getKeysCmd)
 	getKeysCmd.Flags().StringVarP(&keyGenEnv, "environment", "e", "", "Key generation environment")
-	getKeysCmd.Flags().StringVarP(&apiName, "name", "n", "", "API or API Product or MCP Server to generate keys")
-	getKeysCmd.Flags().StringVarP(&apiVersion, "version", "v", "", "Version of the API or API Product or MCP Server")
-	getKeysCmd.Flags().StringVarP(&apiProvider, "provider", "r", "", "Provider of the API or API Product or MCP Server")
+	getKeysCmd.Flags().StringVarP(&apiName, "name", "n", "", "API, API Product or MCP Server to generate keys")
+	getKeysCmd.Flags().StringVarP(&apiVersion, "version", "v", "", "Version of the API, API Product or MCP Server")
+	getKeysCmd.Flags().StringVarP(&apiProvider, "provider", "r", "", "Provider of the API, API Product or MCP Server")
 	getKeysCmd.Flags().StringVarP(&keyGenTokenEndpoint, "token", "t", "", "Token endpoint URL of Environment")
 	_ = getKeysCmd.MarkFlagRequired("name")
 	_ = getKeysCmd.MarkFlagRequired("environment")

--- a/import-export-cli/cmd/getKeys.go
+++ b/import-export-cli/cmd/getKeys.go
@@ -26,8 +26,8 @@ import (
 
 // keys command related Info
 const GetKeysCmdLiteral = "keys"
-const getKeysCmdShortDesc = "Generate access token to invoke the API or API Product"
-const getKeysCmdLongDesc = `Generate JWT token to invoke the API or API Product by subscribing to a default application for testing purposes`
+const getKeysCmdShortDesc = "Generate access token to invoke the API or API Product or MCP Server"
+const getKeysCmdLongDesc = `Generate JWT token to invoke the API or API Product or MCP Server by subscribing to a default application for testing purposes`
 const getKeysCmdExamples = utils.ProjectName + " " + GetCmdLiteral + " " + GetKeysCmdLiteral + ` -n TwitterAPI -v 1.0.0 -e dev --provider admin
 NOTE: Both the flags (--name (-n) and --environment (-e)) are mandatory.
 You can override the default token endpoint using --token (-t) optional flag providing a new token endpoint`
@@ -65,9 +65,9 @@ var getKeysCmd = &cobra.Command{
 func init() {
 	GetCmd.AddCommand(getKeysCmd)
 	getKeysCmd.Flags().StringVarP(&keyGenEnv, "environment", "e", "", "Key generation environment")
-	getKeysCmd.Flags().StringVarP(&apiName, "name", "n", "", "API or API Product to generate keys")
-	getKeysCmd.Flags().StringVarP(&apiVersion, "version", "v", "", "Version of the API")
-	getKeysCmd.Flags().StringVarP(&apiProvider, "provider", "r", "", "Provider of the API or API Product")
+	getKeysCmd.Flags().StringVarP(&apiName, "name", "n", "", "API or API Product or MCP Server to generate keys")
+	getKeysCmd.Flags().StringVarP(&apiVersion, "version", "v", "", "Version of the API or API Product or MCP Server")
+	getKeysCmd.Flags().StringVarP(&apiProvider, "provider", "r", "", "Provider of the API or API Product or MCP Server")
 	getKeysCmd.Flags().StringVarP(&keyGenTokenEndpoint, "token", "t", "", "Token endpoint URL of Environment")
 	_ = getKeysCmd.MarkFlagRequired("name")
 	_ = getKeysCmd.MarkFlagRequired("environment")

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -11,7 +11,7 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of MCP Server revisions of a specific MCP Server in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
-Get a generated JWT token to invoke an API or API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API, API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
 Get the log level of each API in the environment specified by flag (--environment, -e)/
 Get the log level of each MCP Server in the environment specified by flag (--environment, -e)/
 Get the correlation log configurations in the environment specified by flag (--environment, -e)
@@ -64,7 +64,7 @@ apictl get correlation-logging -e dev
 * [apictl get apps](apictl_get_apps.md)	 - Display a list of Applications in an environment specific to an owner
 * [apictl get correlation-logging](apictl_get_correlation-logging.md)	 - Display a list of correlation logging components in an environment
 * [apictl get envs](apictl_get_envs.md)	 - Display the list of environments
-* [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API or API Product or MCP Server
+* [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API, API Product or MCP Server
 * [apictl get mcp-server-logging](apictl_get_mcp-server-logging.md)	 - Display a list of MCP Server loggers in an environment
 * [apictl get mcp-server-revisions](apictl_get_mcp-server-revisions.md)	 - Display a list of Revisions for the MCP Server
 * [apictl get mcp-servers](apictl_get_mcp-servers.md)	 - Display a list of MCP Servers in an environment

--- a/import-export-cli/docs/apictl_get.md
+++ b/import-export-cli/docs/apictl_get.md
@@ -11,7 +11,7 @@ Display a list of Applications of a specific user in the environment specified b
 Display a list of API revisions of a specific API in the environment specified by flag (--environment, -e)/
 Display a list of MCP Server revisions of a specific MCP Server in the environment specified by flag (--environment, -e)/
 Display a list of API Product revisions of a specific API Product in the environment specified by flag (--environment, -e)/
-Get a generated JWT token to invoke an API or API Product by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
+Get a generated JWT token to invoke an API or API Product or MCP Server by subscribing to a default application for testing purposes in the environment specified by flag (--environment, -e)/
 Get the log level of each API in the environment specified by flag (--environment, -e)/
 Get the log level of each MCP Server in the environment specified by flag (--environment, -e)/
 Get the correlation log configurations in the environment specified by flag (--environment, -e)
@@ -64,7 +64,7 @@ apictl get correlation-logging -e dev
 * [apictl get apps](apictl_get_apps.md)	 - Display a list of Applications in an environment specific to an owner
 * [apictl get correlation-logging](apictl_get_correlation-logging.md)	 - Display a list of correlation logging components in an environment
 * [apictl get envs](apictl_get_envs.md)	 - Display the list of environments
-* [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API or API Product
+* [apictl get keys](apictl_get_keys.md)	 - Generate access token to invoke the API or API Product or MCP Server
 * [apictl get mcp-server-logging](apictl_get_mcp-server-logging.md)	 - Display a list of MCP Server loggers in an environment
 * [apictl get mcp-server-revisions](apictl_get_mcp-server-revisions.md)	 - Display a list of Revisions for the MCP Server
 * [apictl get mcp-servers](apictl_get_mcp-servers.md)	 - Display a list of MCP Servers in an environment

--- a/import-export-cli/docs/apictl_get_keys.md
+++ b/import-export-cli/docs/apictl_get_keys.md
@@ -1,10 +1,10 @@
 ## apictl get keys
 
-Generate access token to invoke the API or API Product
+Generate access token to invoke the API or API Product or MCP Server
 
 ### Synopsis
 
-Generate JWT token to invoke the API or API Product by subscribing to a default application for testing purposes
+Generate JWT token to invoke the API or API Product or MCP Server by subscribing to a default application for testing purposes
 
 ```
 apictl get keys [flags]
@@ -23,10 +23,10 @@ You can override the default token endpoint using --token (-t) optional flag pro
 ```
   -e, --environment string   Key generation environment
   -h, --help                 help for keys
-  -n, --name string          API or API Product to generate keys
-  -r, --provider string      Provider of the API or API Product
+  -n, --name string          API or API Product or MCP Server to generate keys
+  -r, --provider string      Provider of the API or API Product or MCP Server
   -t, --token string         Token endpoint URL of Environment
-  -v, --version string       Version of the API
+  -v, --version string       Version of the API or API Product or MCP Server
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/docs/apictl_get_keys.md
+++ b/import-export-cli/docs/apictl_get_keys.md
@@ -1,10 +1,10 @@
 ## apictl get keys
 
-Generate access token to invoke the API or API Product or MCP Server
+Generate access token to invoke the API, API Product or MCP Server
 
 ### Synopsis
 
-Generate JWT token to invoke the API or API Product or MCP Server by subscribing to a default application for testing purposes
+Generate JWT token to invoke the API, API Product or MCP Server by subscribing to a default application for testing purposes
 
 ```
 apictl get keys [flags]
@@ -23,10 +23,10 @@ You can override the default token endpoint using --token (-t) optional flag pro
 ```
   -e, --environment string   Key generation environment
   -h, --help                 help for keys
-  -n, --name string          API or API Product or MCP Server to generate keys
-  -r, --provider string      Provider of the API or API Product or MCP Server
+  -n, --name string          API, API Product or MCP Server to generate keys
+  -r, --provider string      Provider of the API, API Product or MCP Server
   -t, --token string         Token endpoint URL of Environment
-  -v, --version string       Version of the API or API Product or MCP Server
+  -v, --version string       Version of the API, API Product or MCP Server
 ```
 
 ### Options inherited from parent commands

--- a/import-export-cli/impl/getKeys.go
+++ b/import-export-cli/impl/getKeys.go
@@ -40,7 +40,7 @@ var apiProvider string
 var keyGenEnv string
 var keyGenTokenEndpoint string
 
-// Subscribe the given API or API Product or MCP Server to the default application and generate an access token
+// Subscribe the given API, API Product or MCP Server to the default application and generate an access token
 func GetKeys(cred credentials.Credential, envName, name, version, provider, tokenEndpoint string) {
 	keyGenEnv = envName
 	apiName = name
@@ -58,8 +58,8 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 	tiers, err := getAvailableAPITiers(accessToken)
 
 	if tiers != nil && err == nil {
-		utils.Logln(utils.LogPrefixInfo+"Retrieved available subscription tiers of the API or API Product or MCP Server: ", tiers)
-		// Needs an available subscription tier when subscribing to the particular API or API Product or MCP Server using the application
+		utils.Logln(utils.LogPrefixInfo+"Retrieved available subscription tiers of the API, API Product or MCP Server: ", tiers)
+		// Needs an available subscription tier when subscribing to the particular API, API Product or MCP Server using the application
 		subscriptionThrottlingTier = tiers[0]
 	} else {
 		utils.HandleErrorAndExit("Internal error occurred", err)
@@ -139,7 +139,7 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 			//if error occurred while creating the application, then
 			utils.HandleErrorAndExit("Error while creating the CLI application:", err)
 		}
-		//Search if the given API or API Product or MCP Server is present to subscribe
+		//Search if the given API, API Product or MCP Server is present to subscribe
 		subId, err := subscribe(appId, accessToken)
 		//If subscription failed
 		if subId == "" && err != nil {
@@ -168,7 +168,7 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 	}
 }
 
-// Retrieve an available throttling tiers of the API or API Product or MCP Server
+// Retrieve an available throttling tiers of the API, API Product or MCP Server
 // @param accessToken : Access token to authenticate the devportal REST API
 // @return tiers, error
 func getAvailableAPITiers(accessToken string) ([]string, error) {
@@ -298,7 +298,7 @@ func searchApplication(appName string, accessToken string) (string, error) {
 	}
 }
 
-// Searching if the API or API Product or MCP Server is available
+// Searching if the artifact is available
 // @param accessToken : Access token to call the devportal REST API
 // @return apiId, error
 func searchApiOrProduct(accessToken string) (string, error) {
@@ -371,7 +371,7 @@ func searchApiOrProduct(accessToken string) (string, error) {
 	}
 }
 
-// Searching if the API or API Product or MCP Server is available specifying the type
+// Searching if the API, API Product or MCP Server is available specifying the type
 // @param accessToken : Access token to call the devportal REST API
 // @param searchType : Type of the searching artifact
 // @return response, error
@@ -404,28 +404,28 @@ func getApiOrApiProductByType(accessToken, searchType string) (*resty.Response, 
 	return utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
 }
 
-// Subscribe API or API Product or MCP Server to a given application
-// @param appId : Application ID to subscribe the API or API Product or MCP Server
+// Subscribe API, API Product or MCP Server to a given application
+// @param appId : Application ID to subscribe the API, API Product or MCP Server
 // @param accessToken : Token to call REST API
 // @return subscriptionId, error
 func subscribe(appId string, accessToken string) (string, error) {
 	apiId, err := searchApiOrProduct(accessToken)
 	if apiId != "" && err == nil {
-		//If the API or API Product or MCP Server is present, subscribe that API or API Product or MCP Server to the application
-		utils.Logln(utils.LogPrefixInfo+"API or API Product or MCP Server name: ", apiName, "& version: ", apiVersion, "exists")
+		//If the API, API Product or MCP Server is present, perform application subscription
+		utils.Logln(utils.LogPrefixInfo+"API, API Product or MCP Server name: ", apiName, "& version: ", apiVersion, "exists")
 		subId, err := subscribeApiOrProduct(apiId, appId, accessToken)
 		if subId != "" {
-			utils.Logln(utils.LogPrefixInfo+"API or API Product or MCP Server", apiName, ":", apiVersion, "subscribed successfully.")
+			utils.Logln(utils.LogPrefixInfo+"API, API Product or MCP Server", apiName, ":", apiVersion, "subscribed successfully.")
 		} else {
 			utils.HandleErrorAndExit("Error while subscribing the CLI application to the API, API Product, or MCP Server: "+appId, err)
 		}
 		return subId, err
 	} else {
-		return "", errors.New("API or API Product or MCP Server is not found. Name: " + apiName + " version: " + apiVersion)
+		return "", errors.New("API, API Product or MCP Server is not found. Name: " + apiName + " version: " + apiVersion)
 	}
 }
 
-// Get API or API Product or MCP Server specific details of a given API or API Product or MCP Server
+// Get API, API Product or MCP Server specific details of a given API, API Product or MCP Server
 // @param apiId : API ID to retrieve the information
 // @param accessToken : Access token to call the REST API
 // @return API, error
@@ -478,8 +478,8 @@ func getApiOrProduct(apiId string, accessToken string) (*utils.APIData, error) {
 	}
 }
 
-// Subscribe the API or API Product or MCP Server to a given Application
-// @param apiId : API or API Product or MCP Server ID to be subscribed
+// Subscribe the API, API Product or MCP Server to a given Application
+// @param apiId : API, API Product or MCP Server ID to be subscribed
 // @param appId : Application ID to be subscribed
 // @param accessToken : Access token to call the REST API
 // @return subscriptionId, error

--- a/import-export-cli/impl/getKeys.go
+++ b/import-export-cli/impl/getKeys.go
@@ -40,7 +40,7 @@ var apiProvider string
 var keyGenEnv string
 var keyGenTokenEndpoint string
 
-//Subscribe the given API or API Product to the default application and generate an access token
+// Subscribe the given API or API Product or MCP Server to the default application and generate an access token
 func GetKeys(cred credentials.Credential, envName, name, version, provider, tokenEndpoint string) {
 	keyGenEnv = envName
 	apiName = name
@@ -58,8 +58,8 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 	tiers, err := getAvailableAPITiers(accessToken)
 
 	if tiers != nil && err == nil {
-		utils.Logln(utils.LogPrefixInfo+"Retrieved available subscription tiers of the API or API Product: ", tiers)
-		// Needs an available subscription tier when subscribing to the particular API or API Product using the application
+		utils.Logln(utils.LogPrefixInfo+"Retrieved available subscription tiers of the API or API Product or MCP Server: ", tiers)
+		// Needs an available subscription tier when subscribing to the particular API or API Product or MCP Server using the application
 		subscriptionThrottlingTier = tiers[0]
 	} else {
 		utils.HandleErrorAndExit("Internal error occurred", err)
@@ -139,7 +139,7 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 			//if error occurred while creating the application, then
 			utils.HandleErrorAndExit("Error while creating the CLI application:", err)
 		}
-		//Search the if the given API or API Product is present to subscribe
+		//Search if the given API or API Product or MCP Server is present to subscribe
 		subId, err := subscribe(appId, accessToken)
 		//If subscription failed
 		if subId == "" && err != nil {
@@ -168,7 +168,7 @@ func GetKeys(cred credentials.Credential, envName, name, version, provider, toke
 	}
 }
 
-// Retrieve an available throttling tiers of the API or API Product
+// Retrieve an available throttling tiers of the API or API Product or MCP Server
 // @param accessToken : Access token to authenticate the devportal REST API
 // @return tiers, error
 func getAvailableAPITiers(accessToken string) ([]string, error) {
@@ -298,7 +298,7 @@ func searchApplication(appName string, accessToken string) (string, error) {
 	}
 }
 
-// Searching if the API or API Product is available
+// Searching if the API or API Product or MCP Server is available
 // @param accessToken : Access token to call the devportal REST API
 // @return apiId, error
 func searchApiOrProduct(accessToken string) (string, error) {
@@ -332,11 +332,33 @@ func searchApiOrProduct(accessToken string) (string, error) {
 			}
 			return "", errors.New("Request didn't respond 200 OK for searching APIs and API Products. Status: " + resp.Status())
 		}
+
+		// Search by defining the type as an MCP Server
+		resp, err = getApiOrApiProductByType(accessToken, utils.DefaultMcpServerType)
+		if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+			// 200 OK or 201 Created
+			apiData := &utils.ApiSearch{}
+			data := []byte(resp.Body())
+			err = json.Unmarshal(data, &apiData)
+			if apiData.Count != 0 {
+				apiId := apiData.List[0].ID
+				return apiId, err
+			}
+		} else {
+			utils.Logf("Error: %s\n", resp.Error())
+			utils.Logf("Body: %s\n", resp.Body())
+			if resp.StatusCode() == http.StatusUnauthorized {
+				// 401 Unauthorized
+				return "", fmt.Errorf("authorization failed while searching MCP Server: " + apiName)
+			}
+			return "", errors.New("Request didn't respond 200 OK for searching MCP Servers. Status: " + resp.Status())
+		}
+
 		if apiProvider != "" {
-			return "", errors.New("Requested API is not available in the devportal. API: " + apiName +
+			return "", errors.New("Requested API, API Product, or MCP Server is not available in the devportal. Name: " + apiName +
 				" Version: " + apiVersion + " Provider: " + apiProvider)
 		}
-		return "", errors.New("Requested API is not available in the devportal. API: " + apiName +
+		return "", errors.New("Requested API, API Product, or MCP Server is not available in the devportal. Name: " + apiName +
 			" Version: " + apiVersion)
 	} else {
 		utils.Logf("Error: %s\n", resp.Error())
@@ -349,7 +371,7 @@ func searchApiOrProduct(accessToken string) (string, error) {
 	}
 }
 
-// Searching if the API or API Product is available specifying the type
+// Searching if the API or API Product or MCP Server is available specifying the type
 // @param accessToken : Access token to call the devportal REST API
 // @param searchType : Type of the searching artifact
 // @return response, error
@@ -375,32 +397,35 @@ func getApiOrApiProductByType(accessToken, searchType string) (*resty.Response, 
 		if strings.EqualFold(searchType, utils.DefaultApiProductType) {
 			queryVal = queryVal + " type:\"" + searchType + "\""
 		}
+		if strings.EqualFold(searchType, utils.DefaultMcpServerType) {
+			queryVal = queryVal + " type:\"" + searchType + "\""
+		}
 	}
 	return utils.InvokeGETRequestWithQueryParam("query", queryVal, unifiedSearchEndpoint, headers)
 }
 
-// Subscribe API or API Product to a given application
-// @param appId : Application ID to subscribe the API or API Product
+// Subscribe API or API Product or MCP Server to a given application
+// @param appId : Application ID to subscribe the API or API Product or MCP Server
 // @param accessToken : Token to call REST API
 // @return subscriptionId, error
 func subscribe(appId string, accessToken string) (string, error) {
 	apiId, err := searchApiOrProduct(accessToken)
 	if apiId != "" && err == nil {
-		//If the API or API Product is present, subscribe that API or API Product to the application
-		utils.Logln(utils.LogPrefixInfo+"API or API Product name: ", apiName, "& version: ", apiVersion, "exists")
+		//If the API or API Product or MCP Server is present, subscribe that API or API Product or MCP Server to the application
+		utils.Logln(utils.LogPrefixInfo+"API or API Product or MCP Server name: ", apiName, "& version: ", apiVersion, "exists")
 		subId, err := subscribeApiOrProduct(apiId, appId, accessToken)
 		if subId != "" {
-			utils.Logln(utils.LogPrefixInfo+"API or API Product", apiName, ":", apiVersion, "subscribed successfully.")
+			utils.Logln(utils.LogPrefixInfo+"API or API Product or MCP Server", apiName, ":", apiVersion, "subscribed successfully.")
 		} else {
-			utils.HandleErrorAndExit("Error while subscribing the CLI application to the API: "+appId, err)
+			utils.HandleErrorAndExit("Error while subscribing the CLI application to the API, API Product, or MCP Server: "+appId, err)
 		}
 		return subId, err
 	} else {
-		return "", errors.New("API or API Product is not found. Name: " + apiName + " version: " + apiVersion)
+		return "", errors.New("API or API Product or MCP Server is not found. Name: " + apiName + " version: " + apiVersion)
 	}
 }
 
-// Get API or API Product specific details of a given API or API Product
+// Get API or API Product or MCP Server specific details of a given API or API Product or MCP Server
 // @param apiId : API ID to retrieve the information
 // @param accessToken : Access token to call the REST API
 // @return API, error
@@ -429,19 +454,32 @@ func getApiOrProduct(apiId string, accessToken string) (*utils.APIData, error) {
 			err = json.Unmarshal(data, &apiData)
 			return apiData, err
 		} else {
-			utils.Logf("Error: %s\n", resp.Error())
-			utils.Logf("Body: %s\n", resp.Body())
-			if resp.StatusCode() == http.StatusUnauthorized {
-				// 401 Unauthorized
-				return nil, fmt.Errorf("authorization failed while trying to retrieve the details of API or API Prodcut: " + apiId)
+			// Third check whether this is an MCP Server
+			mcpServerEndpoint := utils.GetMcpServerListEndpointOfEnv(keyGenEnv, utils.MainConfigFilePath) + "/" + apiId
+			headers := make(map[string]string)
+			headers[utils.HeaderAuthorization] = utils.HeaderValueAuthBearerPrefix + " " + accessToken
+			resp, err := utils.InvokeGETRequest(mcpServerEndpoint, headers)
+			if resp.StatusCode() == http.StatusOK || resp.StatusCode() == http.StatusCreated {
+				// 200 OK or 201 Created
+				apiData := &utils.APIData{}
+				data := []byte(resp.Body())
+				err = json.Unmarshal(data, &apiData)
+				return apiData, err
+			} else {
+				utils.Logf("Error: %s\n", resp.Error())
+				utils.Logf("Body: %s\n", resp.Body())
+				if resp.StatusCode() == http.StatusUnauthorized {
+					// 401 Unauthorized
+					return nil, fmt.Errorf("authorization failed while trying to retrieve the details of API, API Product, or MCP Server: " + apiId)
+				}
+				return nil, errors.New("Request didn't respond 200 OK for retrieving API, API Product, or MCP Server details. Status: " + resp.Status())
 			}
-			return nil, errors.New("Request didn't respond 200 OK for retrieving API or API Product details. Status: " + resp.Status())
 		}
 	}
 }
 
-// Subscribe the API or API Product to a given Application
-// @param apiId : API or API Product ID to be subscribed
+// Subscribe the API or API Product or MCP Server to a given Application
+// @param apiId : API or API Product or MCP Server ID to be subscribed
 // @param appId : Application ID to be subscribed
 // @param accessToken : Access token to call the REST API
 // @return subscriptionId, error
@@ -495,15 +533,15 @@ func subscribeApiOrProduct(apiId string, appId string, accessToken string) (stri
 			utils.Logf("Body: %s\n", resp.Body())
 			if resp.StatusCode() == http.StatusUnauthorized {
 				// 401 Unauthorized
-				return "", fmt.Errorf("authorization failed while trying to subscribe to the API or API Product: " + apiId)
+				return "", fmt.Errorf("authorization failed while trying to subscribe to the API, API Product, or MCP Server: " + apiId)
 			}
-			return "", errors.New("Request didn't respond 200 OK for subscribing to the API or API Product. Status: " + resp.Status())
+			return "", errors.New("Request didn't respond 200 OK for subscribing to the API, API Product, or MCP Server. Status: " + resp.Status())
 		}
 	} else {
 		utils.Logf("Error: %s\n", subResp.Error())
 		utils.Logf("Body: %s\n", subResp.Body())
 		if subResp.StatusCode() == http.StatusUnauthorized {
-			return "", fmt.Errorf("authorization failed while trying to check existing subscriptions of API or API Product: " +
+			return "", fmt.Errorf("authorization failed while trying to check existing subscriptions of API, API Product, or MCP Server: " +
 				apiId)
 		}
 		return "", errors.New("Request didn't respond 200 OK: " + subResp.Status())


### PR DESCRIPTION
Add missing `apictl get keys` support for MCP Servers. 

Related Issue: [wso2/api-manager#4099](https://github.com/wso2/api-manager/issues/4099)