### PR TITLE
[APIM 4.5.0] Fix file path issue

### DIFF
--- a/import-export-cli/impl/importAPIPolicy.go
+++ b/import-export-cli/impl/importAPIPolicy.go
@@ -76,8 +76,8 @@ func importAPIPolicy(endpoint string, importPath string, accessToken string, isO
 		return err
 	}
 
-	policyPaths := strings.Split(tmpPath, "/")
-	policyName := policyPaths[len(policyPaths)-1]
+	// Make the file name platform independent
+	policyName := filepath.Base(tmpPath)
 
 	for _, file := range files {
 		originalFilePath := tmpPath + "/" + file.Name()

--- a/import-export-cli/utils/fileIOUtils.go
+++ b/import-export-cli/utils/fileIOUtils.go
@@ -413,24 +413,29 @@ func CreateZipFileFromProject(projectPath string, skipCleanup bool) (string, err
 		if err != nil {
 			return "", err, nil
 		}
-		Logln(LogPrefixInfo+"Creating the project artifact", tmp.Name())
-		err = Zip(projectPath, tmp.Name())
+		// Read the filename and close the file to avoid file locking in windows
+		tmpPath := tmp.Name()
+		if err := tmp.Close(); err != nil {
+			return "", err, nil
+		}
+		Logln(LogPrefixInfo+"Creating the project artifact", tmpPath)
+		err = Zip(projectPath, tmpPath)
 		if err != nil {
 			return "", err, nil
 		}
 		//creates a function to cleanup the temporary folders
 		cleanup := func() {
 			if skipCleanup {
-				Logln(LogPrefixInfo+"Leaving", tmp.Name())
+				Logln(LogPrefixInfo+"Leaving", tmpPath)
 				return
 			}
-			Logln(LogPrefixInfo+"Deleting", tmp.Name())
-			err := os.Remove(tmp.Name())
+			Logln(LogPrefixInfo+"Deleting", tmpPath)
+			err := os.Remove(tmpPath)
 			if err != nil {
 				Logln(LogPrefixError + err.Error())
 			}
 		}
-		projectPath = tmp.Name()
+		projectPath = tmpPath
 		return projectPath, nil, cleanup
 	}
 	return projectPath, nil, nil


### PR DESCRIPTION
Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/16463
This pull request improves cross-platform compatibility and file handling in the CLI by making file path operations platform-independent and addressing potential file locking issues on Windows. The changes focus on using the appropriate standard library functions for path operations and ensuring temporary files are properly closed before use.

**Cross-platform file path handling:**

* Replaced manual string splitting with `filepath.Base` in `importAPIPolicy.go` to reliably extract the file name from a path, making the code platform-independent.

**Temporary file handling improvements:**

* Updated `CreateZipFileFromProject` in `fileIOUtils.go` to close the temporary file before zipping to avoid file locking issues on Windows, and consistently use the temporary file path variable for cleanup and logging.
