### PR TITLE
[APIM 4.5.0] Add ApiPolicies field to APIDTODefinition and integration API struct

### DIFF
--- a/import-export-cli/integration/apim/apiDTO.go
+++ b/import-export-cli/integration/apim/apiDTO.go
@@ -80,6 +80,7 @@ type API struct {
 	AsyncTransportProtocols         []string          `json:"asyncTransportProtocols,omitempty" yaml:"asyncTransportProtocols,omitempty"`
 	GatewayType                     string            `json:"gatewayType,omitempty" yaml:"gatewayType,omitempty"`
 	EnableSubscriberVerification    bool              `json:"enableSubscriberVerification,omitempty" yaml:"enableSubscriberVerification,omitempty"`
+	ApiPolicies                     interface{}       `json:"apiPolicies,omitempty" yaml:"apiPolicies,omitempty"`
 }
 
 // GetProductionURL : Get APIs production URL

--- a/import-export-cli/specs/v2/apispec.go
+++ b/import-export-cli/specs/v2/apispec.go
@@ -87,6 +87,7 @@ type APIDTODefinition struct {
 	AsyncTransportProtocols         []string      `json:"asyncTransportProtocols,omitempty" yaml:"asyncTransportProtocols,omitempty"`
 	GatewayType                     string        `json:"gatewayType,omitempty" yaml:"gatewayType,omitempty"`
 	EnableSubscriberVerification    bool          `json:"enableSubscriberVerification,omitempty" yaml:"enableSubscriberVerification,omitempty"`
+	ApiPolicies                     interface{}   `json:"apiPolicies,omitempty" yaml:"apiPolicies,omitempty"`
 }
 
 type CorsConfiguration struct {


### PR DESCRIPTION
## Purpose
apictl init --definition silently drops API-level apiPolicies when unmarshalling the definition YAML into APIDTODefinition.

- Resolves https://github.com/wso2-enterprise/wso2-apim-internal/issues/17404

## Root cause
The struct was missing the ApiPolicies field. YAML/JSON decoders discard unknown keys.

## Fix

Added ApiPolicies interface{} to APIDTODefinition in specs/v2/apispec.go
Added same field to integration test helper API struct in integration/apim/apiDTO.go

## Impact
API-level policies now round-trip correctly through apictl init --definition → import → Publisher API.