### PR TITLE
Populate scopes and operations from OAS spec in apictl init

### DIFF
--- a/import-export-cli/specs/v2/swagger2.go
+++ b/import-export-cli/specs/v2/swagger2.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 
 	"io/ioutil"
@@ -33,6 +34,16 @@ import (
 	"github.com/Jeffail/gabs"
 	"github.com/go-openapi/loads"
 	"github.com/mitchellh/mapstructure"
+)
+
+// Defaults applied to operations generated from a swagger/OAS document when the
+// spec itself does not carry the WSO2 x-auth-type / x-throttling-tier vendor extensions.
+// These match the values APIM assigns when an API is exported, so that a project
+// created via 'apictl init --oas' produces an api.yaml equivalent to an exported one.
+const (
+	defaultOperationAuthType       = "Application & Application User"
+	defaultOperationThrottlingTier = "Unlimited"
+	scopesBindingsExtension        = "x-scopes-bindings"
 )
 
 // Servers represent servers of an AWS API
@@ -76,6 +87,14 @@ type SecuritySchemes struct {
 	ResourcePolicy struct {
 		Version string `json:"Version"`
 	} `json:"x-amazon-apigateway-policy"`
+}
+
+// scopeDef holds the merged scope name/description/role-bindings gathered from
+// Swagger 2 securityDefinitions or OpenAPI 3 components.securitySchemes.
+type scopeDef struct {
+	Name        string
+	Description string
+	Bindings    []string
 }
 
 func swagger2XWO2BasePath(document *loads.Document) (string, bool) {
@@ -331,7 +350,393 @@ func Swagger2Populate(def *APIDTODefinition, document *loads.Document) error {
 		def.AuthorizationHeader = authHeader
 	}
 
+	raw, err := rawSwaggerMap(document)
+	if err != nil {
+		return err
+	}
+	def.Scopes = swaggerScopes(raw)
+	def.Operations = swaggerOperations(raw)
+
 	return nil
+}
+
+// rawSwaggerMap unmarshals the underlying swagger/OAS document once so that scope and
+// operation extraction (which need to inspect vendor extensions not modeled by go-openapi's
+// typed Swagger2 structs) can share a single parse of the raw JSON.
+func rawSwaggerMap(document *loads.Document) (map[string]interface{}, error) {
+	raw := map[string]interface{}{}
+	if err := json.Unmarshal(document.Raw(), &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// swaggerScopes collects OAuth2 scopes declared in the spec (Swagger 2 securityDefinitions,
+// or OpenAPI 3 components.securitySchemes flows), along with role bindings from the WSO2
+// x-scopes-bindings vendor extension, and returns them shaped like an exported project's
+// api.yaml "scopes" section.
+func swaggerScopes(raw map[string]interface{}) []interface{} {
+	scopeMap := map[string]scopeDef{}
+	collectSwagger2Scopes(raw, scopeMap)
+	collectOas3Scopes(raw, scopeMap)
+
+	if len(scopeMap) == 0 {
+		return nil
+	}
+	return scopesToInterfaceSlice(scopeMap)
+}
+
+// sortedKeys returns m's keys in sorted order, so callers merging data keyed by these
+// maps get deterministic results regardless of Go's randomized map iteration order.
+func sortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func collectSwagger2Scopes(raw map[string]interface{}, scopeMap map[string]scopeDef) {
+	securityDefinitions, ok := interfaceMap(raw["securityDefinitions"])
+	if !ok {
+		return
+	}
+	for _, name := range sortedKeys(securityDefinitions) {
+		definitionMap, ok := interfaceMap(securityDefinitions[name])
+		if !ok {
+			continue
+		}
+		scopes, _ := interfaceMap(definitionMap["scopes"])
+		bindings, _ := interfaceMap(definitionMap[scopesBindingsExtension])
+		mergeScopes(scopeMap, scopes, bindings)
+	}
+}
+
+func collectOas3Scopes(raw map[string]interface{}, scopeMap map[string]scopeDef) {
+	components, ok := interfaceMap(raw["components"])
+	if !ok {
+		return
+	}
+	securitySchemes, ok := interfaceMap(components["securitySchemes"])
+	if !ok {
+		return
+	}
+	for _, schemeName := range sortedKeys(securitySchemes) {
+		schemeMap, ok := interfaceMap(securitySchemes[schemeName])
+		if !ok {
+			continue
+		}
+		fallbackBindings, _ := interfaceMap(schemeMap[scopesBindingsExtension])
+		flows, ok := interfaceMap(schemeMap["flows"])
+		if !ok {
+			continue
+		}
+		for _, flowName := range sortedKeys(flows) {
+			flowMap, ok := interfaceMap(flows[flowName])
+			if !ok {
+				continue
+			}
+			scopes, _ := interfaceMap(flowMap["scopes"])
+			bindings, hasBindings := interfaceMap(flowMap[scopesBindingsExtension])
+			if !hasBindings {
+				bindings = fallbackBindings
+			}
+			mergeScopes(scopeMap, scopes, bindings)
+		}
+	}
+}
+
+// mergeScopes adds scopes found in a single security definition/scheme into scopeMap,
+// filling in description/bindings for scopes already seen (e.g. the same scope declared
+// under multiple OAuth2 flows) only when not already populated. Descriptions go through
+// stringValue rather than fmt.Sprintf since OAS3's raw-JSON path (unlike Swagger 2.0's
+// typed model) doesn't enforce "scopes" values being strings. Scope names and binding
+// keys are both trimmed so a scope with stray whitespace (e.g. " admin ") still matches
+// its own binding entry and its operation-level reference.
+func mergeScopes(scopeMap map[string]scopeDef, scopes map[string]interface{}, bindings map[string]interface{}) {
+	bindings = trimMapKeys(bindings)
+	for _, rawScopeName := range sortedKeys(scopes) {
+		v := scopes[rawScopeName]
+		scopeName := strings.TrimSpace(rawScopeName)
+		if scopeName == "" {
+			continue
+		}
+		desc := stringValue(v)
+		if existing, found := scopeMap[scopeName]; found {
+			if existing.Description == "" && desc != "" {
+				existing.Description = desc
+			}
+			if len(existing.Bindings) == 0 {
+				existing.Bindings = bindingsFromValue(bindings[scopeName])
+			}
+			scopeMap[scopeName] = existing
+			continue
+		}
+		scopeMap[scopeName] = scopeDef{
+			Name:        scopeName,
+			Description: desc,
+			Bindings:    bindingsFromValue(bindings[scopeName]),
+		}
+	}
+}
+
+func scopesToInterfaceSlice(scopeMap map[string]scopeDef) []interface{} {
+	names := make([]string, 0, len(scopeMap))
+	for name := range scopeMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	scopes := make([]interface{}, 0, len(names))
+	for _, name := range names {
+		scope := scopeMap[name]
+		scopes = append(scopes, map[string]interface{}{
+			"scope": map[string]interface{}{
+				"name":        scope.Name,
+				"displayName": scope.Name,
+				"description": scope.Description,
+				"bindings":    scope.Bindings,
+			},
+			"shared": false,
+		})
+	}
+	return scopes
+}
+
+// swaggerOperations builds the "operations" section of api.yaml from the spec's paths,
+// resolving each operation's scopes from its own security requirement, falling back to
+// API-level (global) security when absent, and applying WSO2's default auth type /
+// throttling tier when the spec has no x-auth-type / x-throttling-tier vendor extension.
+func swaggerOperations(raw map[string]interface{}) []interface{} {
+	paths, ok := interfaceMap(raw["paths"])
+	if !ok || len(paths) == 0 {
+		return nil
+	}
+
+	pathKeys := sortedKeys(paths)
+
+	apiLevelScopes, _ := securityScopes(raw)
+
+	operations := make([]interface{}, 0)
+	for _, target := range pathKeys {
+		pathObj, ok := interfaceMap(paths[target])
+		if !ok {
+			continue
+		}
+		operations = append(operations, operationsForPath(target, pathObj, apiLevelScopes)...)
+	}
+
+	if len(operations) == 0 {
+		return nil
+	}
+	return operations
+}
+
+var swaggerMethodOrder = []string{"get", "put", "post", "delete", "patch", "options", "head", "trace"}
+
+func operationsForPath(target string, pathObj map[string]interface{}, apiLevelScopes []string) []interface{} {
+	// The OpenAPI/Swagger Path Item Object requires lowercase HTTP method keys, but
+	// look them up case-insensitively anyway: a spec with e.g. "GET" instead of "get"
+	// loads without error (go-openapi's JSON-based parsing doesn't enforce this), and
+	// a case-sensitive-only lookup would silently drop the operation - and with it,
+	// any scope requirement it declares, which is exactly the class of silent data
+	// loss this whole fix exists to prevent.
+	operations := make([]interface{}, 0, len(swaggerMethodOrder))
+	for _, method := range swaggerMethodOrder {
+		opObj, ok := interfaceMapCaseInsensitive(pathObj, method)
+		if !ok {
+			continue
+		}
+		operations = append(operations, buildOperation(target, method, opObj, apiLevelScopes))
+	}
+	return operations
+}
+
+// securityScopes reports whether m ("security" is either an Operation Object or the
+// root document) declares its own "security" requirement, since a present-but-empty
+// array ("no scopes needed here") must be distinguished from an absent key ("inherit
+// the API-level default") - collapsing both to an empty list would make an operation
+// that explicitly opts out of a global scope incorrectly inherit it anyway.
+func securityScopes(m map[string]interface{}) ([]string, bool) {
+	v, present := m["security"]
+	if !present {
+		return nil, false
+	}
+	return extractScopesFromSecurity(v), true
+}
+
+// interfaceMapCaseInsensitive looks up key in m case-insensitively, trying the exact
+// key first. The scan visits candidates in sorted order and keeps looking past a
+// non-map match rather than stopping, so a spec with duplicate case-variants of the
+// same key (e.g. both "GET" and "Get") resolves deterministically.
+func interfaceMapCaseInsensitive(m map[string]interface{}, key string) (map[string]interface{}, bool) {
+	if v, ok := interfaceMap(m[key]); ok {
+		return v, true
+	}
+	for _, k := range sortedKeys(m) {
+		if strings.EqualFold(k, key) {
+			if v, ok := interfaceMap(m[k]); ok {
+				return v, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func buildOperation(target, method string, opObj map[string]interface{}, apiLevelScopes []string) map[string]interface{} {
+	authType := stringValue(opObj["x-auth-type"])
+	if authType == "" {
+		authType = defaultOperationAuthType
+	}
+	throttlingTier := stringValue(opObj["x-throttling-tier"])
+	if throttlingTier == "" {
+		throttlingTier = defaultOperationThrottlingTier
+	}
+
+	// An operation's own "security" - even an explicitly empty array, meaning "no
+	// scopes needed here" - always wins outright; only a genuinely absent "security"
+	// key falls through to the API level. See securityScopes. There is no path-level
+	// tier: neither Swagger 2.0 nor OpenAPI 3.x defines a "security" field on the Path
+	// Item Object (confirmed against go-openapi/spec's own PathItemProps, which has no
+	// Security field at all) - only the root document and individual operations can
+	// declare it.
+	scopes, opHasSecurity := securityScopes(opObj)
+	if !opHasSecurity {
+		scopes = apiLevelScopes
+	}
+
+	return map[string]interface{}{
+		"id":               "",
+		"target":           target,
+		"verb":             strings.ToUpper(method),
+		"authType":         authType,
+		"throttlingPolicy": throttlingTier,
+		"scopes":           scopes,
+		"usedProductIds":   []string{},
+		"operationPolicies": map[string]interface{}{
+			"request":  []string{},
+			"response": []string{},
+			"fault":    []string{},
+		},
+	}
+}
+
+func interfaceMap(v interface{}) (map[string]interface{}, bool) {
+	m, ok := v.(map[string]interface{})
+	return m, ok
+}
+
+// trimMapKeys returns a copy of m with every key trimmed of whitespace, so a lookup
+// by a trimmed key (see stringValue) still finds it. Keys are copied in sorted order
+// so two keys colliding on the same trimmed value resolve deterministically.
+func trimMapKeys(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+	trimmed := make(map[string]interface{}, len(m))
+	for _, k := range sortedKeys(m) {
+		trimmed[strings.TrimSpace(k)] = m[k]
+	}
+	return trimmed
+}
+
+// stringValue type-asserts v as a string, trimmed of surrounding whitespace, or
+// returns "" if v isn't a string - centralized here so scope/role name comparisons
+// aren't broken by stray whitespace in a hand-edited spec.
+func stringValue(v interface{}) string {
+	str, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(str)
+}
+
+func bindingsFromValue(v interface{}) []string {
+	if v == nil {
+		return []string{}
+	}
+	// A single string is the real-world multi-role syntax APIM's own import
+	// understands (OAS2Parser/OAS3Parser.getScopes() split it on "," server-side) - an
+	// actual array crashes the import instead. Split here so a multi-role binding
+	// ("role_a,role_b") doesn't survive as one garbled binding literally named that.
+	if str, isString := v.(string); isString {
+		return splitAndDedupeBindings(strings.Split(str, ","))
+	}
+
+	arr, ok := v.([]interface{})
+	if !ok {
+		return []string{}
+	}
+	rawValues := make([]string, 0, len(arr))
+	for _, item := range arr {
+		rawValues = append(rawValues, stringValue(item))
+	}
+	return splitAndDedupeBindings(rawValues)
+}
+
+// splitAndDedupeBindings trims, drops empties, deduplicates, and sorts a set of
+// candidate role names shared by both the string (comma-separated) and array forms
+// of x-scopes-bindings.
+func splitAndDedupeBindings(rawValues []string) []string {
+	bindings := make([]string, 0, len(rawValues))
+	seen := map[string]bool{}
+	for _, raw := range rawValues {
+		value := strings.TrimSpace(raw)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		bindings = append(bindings, value)
+	}
+	sort.Strings(bindings)
+	return bindings
+}
+
+// extractScopesFromSecurity flattens every scope named across all alternatives of an
+// OpenAPI/Swagger "security" requirement array into a single list. This matches APIM's
+// own gateway-side scope check, which already treats an operation's scope list as OR
+// (any one listed scope satisfies it), so flattening OR-alternatives together here
+// doesn't change the enforced semantics.
+func extractScopesFromSecurity(v interface{}) []string {
+	requirements, ok := v.([]interface{})
+	if !ok {
+		return []string{}
+	}
+
+	scopes := make([]string, 0)
+	seen := map[string]bool{}
+	for _, requirement := range requirements {
+		requirementMap, ok := interfaceMap(requirement)
+		if !ok {
+			continue
+		}
+		scopes = appendScopesFromRequirement(requirementMap, scopes, seen)
+	}
+
+	sort.Strings(scopes)
+	return scopes
+}
+
+// appendScopesFromRequirement appends the scope names listed under a single security
+// requirement entry (e.g. {"default": ["read:pets", "write:pets"]}) to scopes, skipping
+// duplicates already recorded in seen.
+func appendScopesFromRequirement(requirementMap map[string]interface{}, scopes []string, seen map[string]bool) []string {
+	for _, rawScopes := range requirementMap {
+		scopeArray, ok := rawScopes.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, scope := range scopeArray {
+			scopeName := stringValue(scope)
+			if scopeName == "" || seen[scopeName] {
+				continue
+			}
+			seen[scopeName] = true
+			scopes = append(scopes, scopeName)
+		}
+	}
+	return scopes
 }
 
 func AddAwsTag(def *APIDTODefinition) {

--- a/import-export-cli/specs/v2/swagger2_test.go
+++ b/import-export-cli/specs/v2/swagger2_test.go
@@ -71,6 +71,197 @@ func TestSwagger2Populate(t *testing.T) {
 	assert.Equal(t, "/petstore/v1/1.0.0", def.Context)
 }
 
+func findOperation(t *testing.T, operations []interface{}, target, verb string) map[string]interface{} {
+	t.Helper()
+	for _, op := range operations {
+		opMap, ok := op.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if opMap["target"] == target && opMap["verb"] == verb {
+			return opMap
+		}
+	}
+	t.Fatalf("operation not found: %s %s", verb, target)
+	return nil
+}
+
+func findScope(t *testing.T, scopes []interface{}, name string) map[string]interface{} {
+	t.Helper()
+	for _, s := range scopes {
+		scopeEntry, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		scope, ok := scopeEntry["scope"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if scope["name"] == name {
+			return scope
+		}
+	}
+	t.Fatalf("scope not found: %s", name)
+	return nil
+}
+
+func TestSwagger2PopulateAddsScopesAndOperations(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/petstore_swagger2.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 2, "expected oauth scopes to be populated")
+	assert.NotEmpty(t, def.Operations, "expected operations to be populated")
+
+	postOp := findOperation(t, def.Operations, "/pet", "POST")
+	assert.Equal(t, "POST", postOp["verb"])
+	assert.Equal(t, "/pet", postOp["target"])
+	assert.ElementsMatch(t, []string{"read:pets", "write:pets"}, postOp["scopes"].([]string))
+	// petstore_swagger2.yaml carries no x-auth-type/x-throttling-tier, so the exported-project defaults apply
+	assert.Equal(t, defaultOperationAuthType, postOp["authType"])
+	assert.Equal(t, defaultOperationThrottlingTier, postOp["throttlingPolicy"])
+
+	getByID := findOperation(t, def.Operations, "/pet/{petId}", "GET")
+	assert.ElementsMatch(t, []string{}, getByID["scopes"].([]string))
+}
+
+func TestSwagger2PopulateOas3ScopesWithBindingsAndDefaults(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/oas3_scopes.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1, "expected one oauth2 scope from components.securitySchemes")
+	scope := findScope(t, def.Scopes, "test4_scope")
+	assert.Equal(t, "Scope to protect menu resource", scope["description"])
+	assert.ElementsMatch(t, []string{"role4"}, scope["bindings"])
+
+	// /menu has no x-auth-type/x-throttling-tier -> falls back to exported-project defaults
+	menuOp := findOperation(t, def.Operations, "/menu", "GET")
+	assert.ElementsMatch(t, []string{"test4_scope"}, menuOp["scopes"].([]string))
+	assert.Equal(t, defaultOperationAuthType, menuOp["authType"])
+	assert.Equal(t, defaultOperationThrottlingTier, menuOp["throttlingPolicy"])
+
+	// /order POST sets explicit x-auth-type/x-throttling-tier -> must be preserved, not overridden
+	orderPost := findOperation(t, def.Operations, "/order", "POST")
+	assert.Equal(t, "Application", orderPost["authType"])
+	assert.Equal(t, "Gold", orderPost["throttlingPolicy"])
+
+	// /order GET has no security requirement anywhere -> empty scopes, still gets default authType/tier
+	orderGet := findOperation(t, def.Operations, "/order", "GET")
+	assert.ElementsMatch(t, []string{}, orderGet["scopes"].([]string))
+	assert.Equal(t, defaultOperationAuthType, orderGet["authType"])
+	assert.Equal(t, defaultOperationThrottlingTier, orderGet["throttlingPolicy"])
+}
+
+func TestSwagger2PopulateAwsGatewayExportNoSpuriousScopes(t *testing.T) {
+	// AWS Gateway security schemes (apiKey, sigv4, Cognito) are never oauth2-with-flows.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/aws_gateway_export.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "should not error on AWS Gateway apiKey/sigv4 security schemes")
+	assert.Empty(t, def.Scopes, "apiKey/sigv4 schemes have no oauth2 flows, so no scopes should be generated")
+	op := findOperation(t, def.Operations, "/pets", "GET")
+	assert.Equal(t, []string{}, op["scopes"].([]string), "sigv4 is not oauth2, so the operation itself must have no scopes either")
+}
+
+func TestSwagger2PopulateNonStringScopeDescriptionBecomesEmpty(t *testing.T) {
+	// Only reachable via OAS3: Swagger 2.0's typed model rejects a non-string
+	// description at load time, but OAS3's raw-JSON path doesn't enforce that.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/oas3_non_string_scope_description.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	nullScope := findScope(t, def.Scopes, "null_scope")
+	assert.Equal(t, "", nullScope["description"], "a null description must become empty, not the literal string '<nil>'")
+
+	objectScope := findScope(t, def.Scopes, "object_scope")
+	assert.Equal(t, "", objectScope["description"], "a non-string (object) description must become empty, not its Go representation")
+}
+
+func TestSwagger2PopulateSkipsEmptyScopeName(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/empty_scope_name.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1, "an empty-string scope name must be skipped, not turned into a nameless scope entry")
+	findScope(t, def.Scopes, "real_scope")
+}
+
+func TestSwagger2PopulateMatchesHttpMethodsCaseInsensitively(t *testing.T) {
+	// "GET" instead of "get" loads fine (go-openapi doesn't enforce casing here) - a
+	// case-sensitive-only lookup would silently drop the operation and its scopes.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/uppercase_method.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Operations, 1, "an uppercase 'GET' method key must still be captured as an operation")
+	op := findOperation(t, def.Operations, "/test", "GET")
+	assert.Equal(t, "/test", op["target"])
+}
+
+func TestSwagger2PopulateTrimsWhitespaceConsistently(t *testing.T) {
+	// Trimming only one side of a name/key comparison would silently break the match.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/whitespace_padded_names.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1, "the padded scope name must resolve to exactly one scope")
+	scope := findScope(t, def.Scopes, "padded_scope")
+	assert.Equal(t, "a description with padding", scope["description"])
+	assert.ElementsMatch(t, []string{"padded_role"}, scope["bindings"])
+
+	op := findOperation(t, def.Operations, "/test", "GET")
+	assert.ElementsMatch(t, []string{"padded_scope"}, op["scopes"].([]string),
+		"the operation must reference the same trimmed scope name as the declared scope, not a mismatched padded variant")
+}
+
+func TestSwagger2PopulateMultiSchemeScopeMergeAndPrecedence(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/multi_scheme_scopes.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 4, "expected scopes merged across both security schemes: shared_scope, order_write, api_level_scope, order_read")
+
+	// shared_scope: scheme_a's empty binding must not block scheme_b's from filling in.
+	shared := findScope(t, def.Scopes, "shared_scope")
+	assert.Equal(t, "description from scheme_a", shared["description"])
+	assert.ElementsMatch(t, []string{"role_shared_reader"}, shared["bindings"])
+
+	// api_level_scope has a multi-role (array) binding
+	apiLevel := findScope(t, def.Scopes, "api_level_scope")
+	assert.ElementsMatch(t, []string{"role_admin", "role_superadmin"}, apiLevel["bindings"])
+
+	// order_write has a single-role (string, not array) binding
+	orderWrite := findScope(t, def.Scopes, "order_write")
+	assert.ElementsMatch(t, []string{"role_writer"}, orderWrite["bindings"])
+
+	// Operation-level security must be used verbatim, not merged with the API-level default
+	ordersPost := findOperation(t, def.Operations, "/orders", "POST")
+	assert.ElementsMatch(t, []string{"order_write"}, ordersPost["scopes"].([]string))
+
+	ordersGet := findOperation(t, def.Operations, "/orders", "GET")
+	assert.ElementsMatch(t, []string{"order_read"}, ordersGet["scopes"].([]string))
+
+	// /admin PUT has no security requirement of its own, so it must fall back to the API-level (global) security
+	adminPut := findOperation(t, def.Operations, "/admin", "PUT")
+	assert.ElementsMatch(t, []string{"api_level_scope"}, adminPut["scopes"].([]string))
+}
+
 func TestSwagger2PopulateWithBasePath(t *testing.T) {
 	var def1, def2 APIDTODefinition
 
@@ -86,9 +277,193 @@ func TestSwagger2PopulateWithBasePath(t *testing.T) {
 	// Basepath with {version}
 	doc2, err2 := loads.Spec("testdata/petstore_with_basepath2.yaml")
 	assert.Nil(t, err2, "err should be nil")
-	err1 = Swagger2Populate(&def2, doc2)
+	err2 = Swagger2Populate(&def2, doc2)
 	assert.Nil(t, err2, "err should be nil")
 
 	assert.Equal(t, "/petstore/v1/1.0.0", def2.Context)
 	assert.Equal(t, false, def2.IsDefaultVersion)
+}
+
+func TestSwagger2PopulateNoSecurityAnywhereYieldsNilScopes(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/no_security_anywhere.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Nil(t, def.Scopes, "a spec with no security definitions anywhere must yield nil scopes, not an empty-but-non-nil slice")
+	op := findOperation(t, def.Operations, "/open", "GET")
+	assert.ElementsMatch(t, []string{}, op["scopes"].([]string))
+	assert.Equal(t, defaultOperationAuthType, op["authType"])
+	assert.Equal(t, defaultOperationThrottlingTier, op["throttlingPolicy"])
+}
+
+func TestSwagger2PopulateOas3MultipleFlowsSameSchemeMergeDeterministically(t *testing.T) {
+	// Same scope declared under two flows of one scheme must merge deterministically.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/oas3_multi_flow_same_scheme.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1)
+	scope := findScope(t, def.Scopes, "shared_flow_scope")
+	assert.Equal(t, "description from authorizationCode flow", scope["description"],
+		"'authorizationCode' sorts before 'password', so its description must win")
+	assert.ElementsMatch(t, []string{"role_from_auth_code_flow"}, scope["bindings"])
+}
+
+func TestSwagger2PopulateWhitespaceOnlyScopeNameSkipped(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/whitespace_only_scope_name.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1, "a scope name that is nothing but whitespace must be trimmed to empty and skipped, same as a literal empty string")
+	findScope(t, def.Scopes, "real_scope")
+}
+
+func TestSwagger2PopulateBindingEdgeCases(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/binding_edge_cases.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	dup := findScope(t, def.Scopes, "dup_binding_scope")
+	assert.ElementsMatch(t, []string{"role_a", "role_b"}, dup["bindings"], "a role repeated in the bindings array must be deduplicated")
+
+	noBindings := findScope(t, def.Scopes, "no_bindings_scope")
+	assert.Equal(t, []string{}, noBindings["bindings"], "a scope with no x-scopes-bindings entry at all must get an empty (not nil) bindings list")
+
+	allInvalid := findScope(t, def.Scopes, "all_invalid_bindings_scope")
+	assert.Equal(t, []string{}, allInvalid["bindings"], "a bindings array containing only non-string elements must yield an empty list, not garbage string conversions")
+
+	commaBound := findScope(t, def.Scopes, "comma_binding_scope")
+	assert.ElementsMatch(t, []string{"role_a", "role_b"}, commaBound["bindings"], "a comma-separated string binding - the real format APIM's own import path understands - must split into separate roles, not survive as one literal 'role_a, role_b' binding")
+}
+
+func TestBindingsFromValueSplitsCommaSeparatedString(t *testing.T) {
+	// The real server (OAS2Parser/OAS3Parser.getScopes()) splits on "," itself; an
+	// actual array crashes the import instead - must split the same way here.
+	assert.Equal(t, []string{"role_a", "role_b"}, bindingsFromValue("role_a,role_b"))
+	assert.Equal(t, []string{"role_a", "role_b"}, bindingsFromValue("role_a, role_b"))
+	assert.Equal(t, []string{"solo_role"}, bindingsFromValue("solo_role"))
+	assert.Equal(t, []string{"role_a", "role_b"}, bindingsFromValue("role_a,role_a,role_b"))
+	assert.Equal(t, []string{}, bindingsFromValue(""))
+	assert.Equal(t, []string{}, bindingsFromValue(",,"))
+}
+
+func TestSwagger2PopulateMultipleSchemesInOneSecurityRequirement(t *testing.T) {
+	// One requirement entry naming two schemes together - both must be captured.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/multi_scheme_single_requirement.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	op := findOperation(t, def.Operations, "/both-required", "GET")
+	assert.ElementsMatch(t, []string{"scope_from_a", "scope_from_b"}, op["scopes"].([]string))
+}
+
+func TestSwagger2PopulateExplicitEmptySecurityOverridesInsteadOfInheriting(t *testing.T) {
+	// "security: []" (present but empty) must override the API-level default, not
+	// inherit it - only a genuinely absent "security" key inherits. See securityScopes.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/explicit_empty_security_vs_inherited.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	public := findOperation(t, def.Operations, "/public", "GET")
+	assert.ElementsMatch(t, []string{}, public["scopes"].([]string),
+		"an operation with an explicit empty security array must NOT inherit the API-level scope")
+
+	inherits := findOperation(t, def.Operations, "/inherits", "GET")
+	assert.ElementsMatch(t, []string{"api_level_scope"}, inherits["scopes"].([]string),
+		"an operation with no security key at all must still inherit the API-level scope")
+}
+
+func TestSwagger2PopulateScopeEntryHasCorrectShape(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/whitespace_padded_names.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 1)
+	entry := def.Scopes[0].(map[string]interface{})
+	assert.Equal(t, false, entry["shared"], "apictl init always generates local (non-shared) scopes")
+	scope := entry["scope"].(map[string]interface{})
+	assert.Equal(t, "padded_scope", scope["name"], "name must be trimmed")
+	assert.Equal(t, "padded_scope", scope["displayName"], "displayName always mirrors name - apictl has no way to author a distinct display name from a plain OpenAPI spec")
+}
+
+func TestSwagger2PopulateOperationEntryHasCorrectShape(t *testing.T) {
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/whitespace_padded_names.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	op := findOperation(t, def.Operations, "/test", "GET")
+	assert.Equal(t, "", op["id"])
+	assert.Equal(t, []string{}, op["usedProductIds"])
+	policies := op["operationPolicies"].(map[string]interface{})
+	assert.Equal(t, []string{}, policies["request"])
+	assert.Equal(t, []string{}, policies["response"])
+	assert.Equal(t, []string{}, policies["fault"])
+}
+
+func TestSwagger2PopulateMixedCaseMethodKeysResolveDeterministically(t *testing.T) {
+	// Duplicate case-variants ("GET" and "Get") get different scopes so the winner
+	// is distinguishable - "exactly one operation" alone can't prove determinism.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/mixed_case_method_keys.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	op := findOperation(t, def.Operations, "/test", "GET")
+	assert.Equal(t, []string{"get_scope"}, op["scopes"].([]string),
+		"the 'GET' key must win over 'Get' (sortedKeys orders 'GET' first), and alt_get_scope from the losing variant must not leak in")
+}
+
+func TestInterfaceMapCaseInsensitiveSkipsNonMapMatchToFindAValidOne(t *testing.T) {
+	// A non-map case-insensitive match must not abort the scan before a later,
+	// valid map match is reached.
+	m := map[string]interface{}{
+		"GET": "not a map - malformed",
+		"Get": map[string]interface{}{"summary": "the real operation"},
+	}
+	for i := 0; i < 20; i++ {
+		result, ok := interfaceMapCaseInsensitive(m, "get")
+		assert.True(t, ok, "must find the valid map variant, not give up on the non-map one")
+		assert.Equal(t, "the real operation", result["summary"])
+	}
+}
+
+func TestSwagger2PopulateOrphanScopeStillListedEvenIfUnreferenced(t *testing.T) {
+	// A scope declared but never referenced by any operation must still appear in
+	// def.Scopes - swaggerScopes and swaggerOperations are independent passes.
+	var def APIDTODefinition
+	doc, err := loads.Spec("testdata/orphan_scope_unreferenced.yaml")
+	assert.Nil(t, err, "err should be nil")
+	err = Swagger2Populate(&def, doc)
+	assert.Nil(t, err, "err should be nil")
+
+	assert.Len(t, def.Scopes, 2)
+	orphan := findScope(t, def.Scopes, "orphan_scope")
+	assert.ElementsMatch(t, []string{"role_orphan"}, orphan["bindings"])
+
+	op := findOperation(t, def.Operations, "/test", "GET")
+	assert.ElementsMatch(t, []string{"used_scope"}, op["scopes"].([]string),
+		"the orphan scope must not leak into an operation that never referenced it")
+}
+
+func TestSwagger2PopulateScalarBindingValueYieldsEmpty(t *testing.T) {
+	// Neither a string nor an array (e.g. a bare number/boolean) must yield [].
+	assert.Equal(t, []string{}, bindingsFromValue(float64(123)))
+	assert.Equal(t, []string{}, bindingsFromValue(true))
 }

--- a/import-export-cli/specs/v2/testdata/aws_gateway_export.yaml
+++ b/import-export-cli/specs/v2/testdata/aws_gateway_export.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.1
+info:
+  title: AWSPetstore
+  version: '1.0'
+servers:
+  - url: https://abc123.execute-api.us-east-1.amazonaws.com/{basePath}
+    variables:
+      basePath:
+        default: prod
+paths:
+  /pets:
+    get:
+      responses:
+        '200':
+          description: OK
+      security:
+        - sigv4: []
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: x-api-key
+      in: header
+    sigv4:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: awsSigv4
+    CognitoAuthorizer:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+x-amazon-apigateway-policy:
+  Version: '2012-10-17'

--- a/import-export-cli/specs/v2/testdata/binding_edge_cases.yaml
+++ b/import-export-cli/specs/v2/testdata/binding_edge_cases.yaml
@@ -1,0 +1,33 @@
+swagger: "2.0"
+info: {title: BindingEdgeCases, version: 1.0.0}
+paths:
+  /dup:
+    get:
+      security: [{default: [dup_binding_scope]}]
+      responses: {"200": {description: OK}}
+  /nobindings:
+    get:
+      security: [{default: [no_bindings_scope]}]
+      responses: {"200": {description: OK}}
+  /allinvalid:
+    get:
+      security: [{default: [all_invalid_bindings_scope]}]
+      responses: {"200": {description: OK}}
+  /commabound:
+    get:
+      security: [{default: [comma_binding_scope]}]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      dup_binding_scope: "role appears twice in the bindings array"
+      no_bindings_scope: "scope declared with no x-scopes-bindings entry for it at all"
+      all_invalid_bindings_scope: "every element in the bindings array is a non-string"
+      comma_binding_scope: "bound to two roles via the real APIM-supported comma-separated string form"
+    x-scopes-bindings:
+      dup_binding_scope: [role_a, role_a, role_b]
+      all_invalid_bindings_scope: [123, true, null]
+      comma_binding_scope: "role_a, role_b"

--- a/import-export-cli/specs/v2/testdata/empty_scope_name.yaml
+++ b/import-export-cli/specs/v2/testdata/empty_scope_name.yaml
@@ -1,0 +1,15 @@
+swagger: "2.0"
+info: {title: EmptyScopeName, version: 1.0.0}
+paths:
+  /test:
+    get:
+      security: [{default: [real_scope]}]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      "": "empty name scope"
+      real_scope: "a real scope"

--- a/import-export-cli/specs/v2/testdata/explicit_empty_security_vs_inherited.yaml
+++ b/import-export-cli/specs/v2/testdata/explicit_empty_security_vs_inherited.yaml
@@ -1,0 +1,21 @@
+swagger: "2.0"
+info: {title: ExplicitEmptySecurityProbe, version: 1.0.0}
+paths:
+  /public:
+    get:
+      summary: Explicitly opts out of the API-level security via an empty array - should be public
+      security: []
+      responses: {"200": {description: OK}}
+  /inherits:
+    get:
+      summary: No security key at all - should inherit the API-level scope
+      responses: {"200": {description: OK}}
+security:
+  - default: [api_level_scope]
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes: {api_level_scope: "api level default"}
+    x-scopes-bindings: {api_level_scope: some_role}

--- a/import-export-cli/specs/v2/testdata/mixed_case_method_keys.yaml
+++ b/import-export-cli/specs/v2/testdata/mixed_case_method_keys.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info: {title: MixedCaseMethodKeys, version: 1.0.0}
+paths:
+  /test:
+    GET:
+      security: [{default: [get_scope]}]
+      responses: {"200": {description: OK}}
+    Get:
+      security: [{default: [alt_get_scope]}]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      get_scope: "declared under the 'GET' key - must be the one that wins, since sortedKeys puts 'GET' before 'Get' (uppercase 'E' < lowercase 'e')"
+      alt_get_scope: "declared under the 'Get' key - must NOT show up in the resolved operation, proving which variant wins is deterministic rather than just 'collapses to one operation'"

--- a/import-export-cli/specs/v2/testdata/multi_scheme_scopes.yaml
+++ b/import-export-cli/specs/v2/testdata/multi_scheme_scopes.yaml
@@ -1,0 +1,66 @@
+swagger: "2.0"
+info:
+  title: MultiSchemeAPI
+  version: 1.0.0
+basePath: /multischeme/1.0.0
+paths:
+  /shared:
+    get:
+      summary: Scope declared under both schemes; scheme_b's binding should fill in since scheme_a declares none for it
+      security:
+        - scheme_a:
+            - shared_scope
+      responses:
+        '200':
+          description: OK
+  /orders:
+    get:
+      summary: Operation-level scope, from scheme_b
+      security:
+        - scheme_b:
+            - order_read
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Operation-level scope overrides the API-level default below
+      security:
+        - scheme_a:
+            - order_write
+      responses:
+        '200':
+          description: OK
+  /admin:
+    put:
+      summary: No security requirement of its own, must fall back to the API-level (global) security
+      responses:
+        '200':
+          description: OK
+security:
+  - scheme_a:
+      - api_level_scope
+securityDefinitions:
+  scheme_a:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: 'https://test.com/authorize'
+    scopes:
+      shared_scope: description from scheme_a
+      order_write: write access to orders
+      api_level_scope: api level default scope
+    x-scopes-bindings:
+      shared_scope: []
+      order_write: role_writer
+      api_level_scope:
+        - role_admin
+        - role_superadmin
+  scheme_b:
+    type: oauth2
+    flow: password
+    tokenUrl: 'https://test.com/token'
+    scopes:
+      shared_scope: description from scheme_b, should not override scheme_a's non-empty description
+      order_read: read access to orders
+    x-scopes-bindings:
+      shared_scope: role_shared_reader
+      order_read: role_reader

--- a/import-export-cli/specs/v2/testdata/multi_scheme_single_requirement.yaml
+++ b/import-export-cli/specs/v2/testdata/multi_scheme_single_requirement.yaml
@@ -1,0 +1,23 @@
+swagger: "2.0"
+info: {title: MultiSchemeSingleRequirement, version: 1.0.0}
+paths:
+  /both-required:
+    get:
+      summary: A single security requirement entry naming two schemes together (AND within one alternative) - both schemes' scopes should be captured
+      security:
+        - oauth_a: [scope_from_a]
+          oauth_b: [scope_from_b]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  oauth_a:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes: {scope_from_a: "from scheme A"}
+    x-scopes-bindings: {scope_from_a: role_a}
+  oauth_b:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes: {scope_from_b: "from scheme B"}
+    x-scopes-bindings: {scope_from_b: role_b}

--- a/import-export-cli/specs/v2/testdata/no_security_anywhere.yaml
+++ b/import-export-cli/specs/v2/testdata/no_security_anywhere.yaml
@@ -1,0 +1,6 @@
+swagger: "2.0"
+info: {title: NoSecurityAnywhere, version: 1.0.0}
+paths:
+  /open:
+    get:
+      responses: {"200": {description: OK}}

--- a/import-export-cli/specs/v2/testdata/oas3_multi_flow_same_scheme.yaml
+++ b/import-export-cli/specs/v2/testdata/oas3_multi_flow_same_scheme.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+info: {title: MultiFlowSameScheme, version: 1.0.0}
+paths:
+  /resource:
+    get:
+      security:
+        - default: [shared_flow_scope]
+      responses: {"200": {description: OK}}
+components:
+  securitySchemes:
+    default:
+      type: oauth2
+      flows:
+        # "authorizationCode" sorts alphabetically before "password", so its
+        # non-empty description/binding must win when the same scope name is
+        # declared under both flows of the same scheme.
+        authorizationCode:
+          authorizationUrl: https://test.com/authorize
+          tokenUrl: https://test.com/token
+          scopes:
+            shared_flow_scope: "description from authorizationCode flow"
+          x-scopes-bindings:
+            shared_flow_scope: role_from_auth_code_flow
+        password:
+          tokenUrl: https://test.com/token
+          scopes:
+            shared_flow_scope: "description from password flow, should not override authorizationCode's"
+          x-scopes-bindings:
+            shared_flow_scope: role_from_password_flow

--- a/import-export-cli/specs/v2/testdata/oas3_non_string_scope_description.yaml
+++ b/import-export-cli/specs/v2/testdata/oas3_non_string_scope_description.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info: {title: NonStringScopeDescription, version: 1.0.0}
+paths:
+  /test:
+    get:
+      security:
+        - default: [null_scope, object_scope]
+      responses: {"200": {description: OK}}
+components:
+  securitySchemes:
+    default:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://test.com
+          scopes:
+            null_scope: null
+            object_scope: {key: value}

--- a/import-export-cli/specs/v2/testdata/oas3_scopes.yaml
+++ b/import-export-cli/specs/v2/testdata/oas3_scopes.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.1
+info:
+  title: ScopesAPI
+  description: OpenAPI 3 spec with local scopes and role bindings
+  version: 1.0.0
+servers:
+  - url: https://localhost:9443/scopesapi/1.0.0
+paths:
+  /menu:
+    get:
+      summary: Get menu, protected by a scope with no explicit auth/throttling extensions
+      security:
+        - default:
+            - test4_scope
+      responses:
+        '200':
+          description: OK
+  /order:
+    post:
+      summary: Place an order, with explicit auth type and throttling tier set
+      x-auth-type: Application
+      x-throttling-tier: Gold
+      responses:
+        '200':
+          description: OK
+    get:
+      summary: List orders, no security requirement anywhere
+      responses:
+        '200':
+          description: OK
+components:
+  securitySchemes:
+    default:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://localhost:9443/authorize
+          scopes:
+            test4_scope: Scope to protect menu resource
+          x-scopes-bindings:
+            test4_scope: role4

--- a/import-export-cli/specs/v2/testdata/orphan_scope_unreferenced.yaml
+++ b/import-export-cli/specs/v2/testdata/orphan_scope_unreferenced.yaml
@@ -1,0 +1,18 @@
+swagger: "2.0"
+info: {title: OrphanScopeUnreferenced, version: 1.0.0}
+paths:
+  /test:
+    get:
+      security: [{default: [used_scope]}]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      used_scope: "referenced by /test"
+      orphan_scope: "declared under securityDefinitions but never referenced by any operation's security requirement"
+    x-scopes-bindings:
+      used_scope: role_used
+      orphan_scope: role_orphan

--- a/import-export-cli/specs/v2/testdata/uppercase_method.yaml
+++ b/import-export-cli/specs/v2/testdata/uppercase_method.yaml
@@ -1,0 +1,6 @@
+swagger: "2.0"
+info: {title: UppercaseMethod, version: 1.0.0}
+paths:
+  /test:
+    GET:
+      responses: {"200": {description: OK}}

--- a/import-export-cli/specs/v2/testdata/whitespace_only_scope_name.yaml
+++ b/import-export-cli/specs/v2/testdata/whitespace_only_scope_name.yaml
@@ -1,0 +1,15 @@
+swagger: "2.0"
+info: {title: WhitespaceOnlyScopeName, version: 1.0.0}
+paths:
+  /test:
+    get:
+      security: [{default: [real_scope]}]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      "   ": "a scope whose name is nothing but whitespace"
+      real_scope: "a normal scope"

--- a/import-export-cli/specs/v2/testdata/whitespace_padded_names.yaml
+++ b/import-export-cli/specs/v2/testdata/whitespace_padded_names.yaml
@@ -1,0 +1,17 @@
+swagger: "2.0"
+info: {title: WhitespacePaddedNames, version: 1.0.0}
+paths:
+  /test:
+    get:
+      security:
+        - default: [" padded_scope "]
+      responses: {"200": {description: OK}}
+securityDefinitions:
+  default:
+    type: oauth2
+    flow: implicit
+    authorizationUrl: https://test.com
+    scopes:
+      " padded_scope ": " a description with padding "
+    x-scopes-bindings:
+      " padded_scope ": [" padded_role "]


### PR DESCRIPTION
## Purpose


`apictl init --oas <spec>` never populated the `scopes:` / `operations:` sections of the generated `api.yaml` — both were always left empty, regardless of what the source OpenAPI/Swagger spec declared. When that `api.yaml` was later used to create a **new version** of an existing API, the server compared the (empty) declared scope usage in the new version against what was already registered for the API, concluded every existing scope was now unused, and **silently deleted its OAuth2 scope-to-role binding** — even though the Publisher UI still displayed the scope as attached to the previous version. Any client depending on that role requirement effectively lost its access-control gate without any warning, error, or visible change in the UI.

## Goals

Make `Swagger2Populate` (the function `apictl init --oas` uses to build `api.yaml`) actually derive the `scopes:` and `operations:` sections from the source spec, so that:

- Every scope declared under Swagger 2.0 `securityDefinitions` or OpenAPI 3.x `components.securitySchemes` is captured, along with its description and role bindings (`x-scopes-bindings`).
- Every operation's required scope(s) are correctly resolved from its own `security` requirement, falling back to the document-level default only when the operation declares no `security` of its own.
- The result is accurate enough, across a wide range of real-world spec shapes (OAS2/OAS3, multi-scheme, multi-role bindings, mixed-case method keys, whitespace-padded names, etc.), that a subsequent version bump no longer causes the server to conclude a still-in-use scope is orphaned.

## Approach

Two new private helper trees, both driven by a single shared raw-JSON parse of the spec (`rawSwaggerMap`) since the vendor extensions this fix needs (`x-scopes-bindings`) aren't modeled by `go-openapi`'s typed Swagger2 struct, and OpenAPI 3.x's `components.securitySchemes` shape isn't typed for this code path at all:

- **`swaggerScopes`** walks Swagger 2.0's `securityDefinitions` and OpenAPI 3.x's `components.securitySchemes.*.flows`, merging scope name/description/bindings into a single deduplicated set (`collectSwagger2Scopes`, `collectOas3Scopes`, `mergeScopes`), then shapes it into `api.yaml`'s expected `scopes:` list (`scopesToInterfaceSlice`).
- **`swaggerOperations`** walks every path/method in the spec (case-insensitively, since malformed specs using e.g. `GET` instead of `get` still load without error), resolving each operation's scopes from its own `security` field or the document-level fallback (`operationsForPath`, `buildOperation`, `securityScopes`, `extractScopesFromSecurity`).

Go's per-process randomized map iteration order is neutralized throughout via a `sortedKeys` helper, so the same input spec produces byte-identical `api.yaml` output across repeated `apictl init` runs.

## User stories

As an API publisher, when I create a new version of my API via `apictl init` + `apictl import`, the existing scope-to-role bindings for that API must remain intact and enforced — not silently dropped because the generated `api.yaml` looked empty.