### PR TITLE
Enhance secret creation functionality with symmetric encryption options

### DIFF
--- a/import-export-cli/cmd/secret/create.go
+++ b/import-export-cli/cmd/secret/create.go
@@ -34,6 +34,7 @@ import (
 var inputPropertiesfile string
 var encryptionAlgorithm string
 var outputType string
+var symmetricFormat string
 
 const secretCreateCmdLiteral = "create"
 const secretCreateCmdShortDesc = "Encrypt secrets"
@@ -44,6 +45,10 @@ var secretCreateCmdExamples = "To encrypt secret and get output on console\n" +
 	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + "\n" +
 	"To encrypt secret using an initialized symmetric encryption key and get output on console\n" +
 	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " " + symmetricModeLiteral + "\n" +
+	"To encrypt secret in the carbon-crypto-service ciphertext format\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " " + symmetricModeLiteral + " " + symmetricInternalModeLiteral + "\n" +
+	"To encrypt secret in the cipher-tool/carbon-secvault/carbon-mediation ciphertext format\n" +
+	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " " + symmetricModeLiteral + " " + symmetricExternalModeLiteral + "\n" +
 	"To encrypt secret and get output as a .properties file (stored in the security folder in apictl executable directory)\n" +
 	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o file\n" +
 	"To encrypt secret and get output as a .yaml file (stored in the security folder in apictl executable directory)\n" +
@@ -54,13 +59,18 @@ var secretCreateCmdExamples = "To encrypt secret and get output on console\n" +
 	"  " + utils.ProjectName + " " + secretCmdLiteral + " " + secretCreateCmdLiteral + " -o k8 -f <file_path>"
 
 var secretCreateCmd = &cobra.Command{
-	Use:     secretCreateCmdLiteral + " [" + symmetricModeLiteral + "]",
+	Use: secretCreateCmdLiteral + " [" + symmetricModeLiteral + " [" + symmetricInternalModeLiteral +
+		"|" + symmetricExternalModeLiteral + "]]",
 	Short:   secretCreateCmdShortDesc,
 	Long:    secretCreateCmdLongDesc,
 	Example: secretCreateCmdExamples,
 	Args:    validateSymmetricModeCreateArg,
 	Run: func(cmd *cobra.Command, args []string) {
 		resolveCreateCipher(cmd, args)
+		symmetricFormat = ""
+		if len(args) == 2 {
+			symmetricFormat = args[1]
+		}
 		err := validateFlags()
 		if err != nil {
 			utils.HandleErrorAndExit("Invalid flag", err)
@@ -99,7 +109,7 @@ func resolveCreateCipher(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed(cipherFlagLiteral) {
 		return
 	}
-	if len(args) == 1 && args[0] == symmetricModeLiteral {
+	if len(args) >= 1 && args[0] == symmetricModeLiteral {
 		encryptionAlgorithm = utils.SecretEncryptionAlgorithmAESGCM
 		return
 	}
@@ -108,8 +118,9 @@ func resolveCreateCipher(cmd *cobra.Command, args []string) {
 
 func initSecretInformation(keyStoreConfig *utils.KeyStoreConfig, encryptionKeyConfig *utils.EncryptionKeyConfig) {
 	secretConfig := utils.SecretConfig{
-		OutputType: outputType,
-		Algorithm:  encryptionAlgorithm,
+		OutputType:      outputType,
+		Algorithm:       encryptionAlgorithm,
+		SymmetricFormat: symmetricFormat,
 	}
 	if utils.IsAES256Encryption(secretConfig.Algorithm) {
 		encryptionKey, err := utils.GetStoredEncryptionKey(encryptionKeyConfig)
@@ -168,13 +179,17 @@ func validateFlags() error {
 }
 
 func validateSymmetricModeCreateArg(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 {
-		return cobra.MaximumNArgs(1)(cmd, args)
+	if len(args) > 2 {
+		return cobra.MaximumNArgs(2)(cmd, args)
 	}
-	if len(args) == 1 && args[0] != symmetricModeLiteral {
-		return errors.New("accepts only '" + symmetricModeLiteral + "' as an optional argument")
+	if len(args) >= 1 && args[0] != symmetricModeLiteral {
+		return errors.New("accepts only '" + symmetricModeLiteral + "' as the first optional argument")
 	}
-	if len(args) == 1 && args[0] == symmetricModeLiteral && cmd.Flags().Changed(cipherFlagLiteral) &&
+	if len(args) == 2 && args[1] != symmetricInternalModeLiteral && args[1] != symmetricExternalModeLiteral {
+		return errors.New("accepts only '" + symmetricInternalModeLiteral + "' or '" + symmetricExternalModeLiteral +
+			"' as the second optional argument")
+	}
+	if len(args) >= 1 && args[0] == symmetricModeLiteral && cmd.Flags().Changed(cipherFlagLiteral) &&
 		!utils.IsAES256Encryption(encryptionAlgorithm) {
 		return errors.New("the optional argument '" + symmetricModeLiteral + "' only supports AES/GCM/NoPadding or AES256 with -c")
 	}

--- a/import-export-cli/cmd/secret/create.go
+++ b/import-export-cli/cmd/secret/create.go
@@ -185,7 +185,7 @@ func validateSymmetricModeCreateArg(cmd *cobra.Command, args []string) error {
 	if len(args) >= 1 && args[0] != symmetricModeLiteral {
 		return errors.New("accepts only '" + symmetricModeLiteral + "' as the first optional argument")
 	}
-	if len(args) == 2 && args[1] != symmetricInternalModeLiteral && args[1] != symmetricExternalModeLiteral {
+	if len(args) == 2 && !strings.EqualFold(args[1], symmetricInternalModeLiteral) && !strings.EqualFold(args[1], symmetricExternalModeLiteral) {
 		return errors.New("accepts only '" + symmetricInternalModeLiteral + "' or '" + symmetricExternalModeLiteral +
 			"' as the second optional argument")
 	}

--- a/import-export-cli/cmd/secret/create_test.go
+++ b/import-export-cli/cmd/secret/create_test.go
@@ -48,6 +48,7 @@ func TestSecretCreateSymmetricUsesInitializedEncryptionKey(t *testing.T) {
 	oldInputPropertiesFile := inputPropertiesfile
 	oldEncryptionAlgorithm := encryptionAlgorithm
 	oldOutputType := outputType
+	oldSymmetricFormat := symmetricFormat
 
 	cipherFlag := secretCreateCmd.Flags().Lookup(cipherFlagLiteral)
 	if cipherFlag == nil {
@@ -58,6 +59,7 @@ func TestSecretCreateSymmetricUsesInitializedEncryptionKey(t *testing.T) {
 		inputPropertiesfile = oldInputPropertiesFile
 		encryptionAlgorithm = oldEncryptionAlgorithm
 		outputType = oldOutputType
+		symmetricFormat = oldSymmetricFormat
 		cipherFlag.Changed = oldCipherFlagChanged
 	}()
 

--- a/import-export-cli/cmd/secret/secret.go
+++ b/import-export-cli/cmd/secret/secret.go
@@ -26,6 +26,8 @@ import (
 const secretCmdLiteral = "secret"
 const secretCmdShortDesc = "Manage sensitive information"
 const symmetricModeLiteral = "symmetric"
+const symmetricInternalModeLiteral = "internal"
+const symmetricExternalModeLiteral = "external"
 const cipherFlagLiteral = "cipher"
 const secretCmdLongDesc = "Encrypt secrets to be used in the Micro Integrator"
 

--- a/import-export-cli/docs/apictl_secret_create.md
+++ b/import-export-cli/docs/apictl_secret_create.md
@@ -7,7 +7,7 @@ Encrypt secrets
 Create secrets based on given arguments
 
 ```
-apictl secret create [symmetric] [flags]
+apictl secret create [symmetric [internal|external]] [flags]
 ```
 
 ### Examples
@@ -17,6 +17,10 @@ To encrypt secret and get output on console
   apictl secret create
 To encrypt secret using an initialized symmetric encryption key and get output on console
   apictl secret create symmetric
+To encrypt secret in the carbon-crypto-service ciphertext format
+  apictl secret create symmetric internal
+To encrypt secret in the cipher-tool/carbon-secvault/carbon-mediation ciphertext format
+  apictl secret create symmetric external
 To encrypt secret and get output as a .properties file (stored in the security folder in apictl executable directory)
   apictl secret create -o file
 To encrypt secret and get output as a .yaml file (stored in the security folder in apictl executable directory)

--- a/import-export-cli/utils/cryptoUtils.go
+++ b/import-export-cli/utils/cryptoUtils.go
@@ -236,10 +236,6 @@ func DecryptAES256(key []byte, cryptoText string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	aesGCM, err := cipher.NewGCMWithNonceSize(block, GCMIVSize)
-	if err != nil {
-		return "", err
-	}
 
 	var outer map[string]interface{}
 	if err = json.Unmarshal(outerBytes, &outer); err != nil {
@@ -249,6 +245,10 @@ func DecryptAES256(key []byte, cryptoText string) (string, error) {
 		}
 		iv := outerBytes[:GCMIVSize]
 		ciphertext := outerBytes[GCMIVSize:]
+		aesGCM, err := cipher.NewGCMWithNonceSize(block, len(iv))
+		if err != nil {
+			return "", err
+		}
 		plainText, err := aesGCM.Open(nil, iv, ciphertext, nil)
 		if err != nil {
 			return "", err
@@ -296,6 +296,11 @@ func DecryptAES256(key []byte, cryptoText string) (string, error) {
 		return "", err
 	}
 	iv, err := base64.StdEncoding.DecodeString(ivB64)
+	if err != nil {
+		return "", err
+	}
+
+	aesGCM, err := cipher.NewGCMWithNonceSize(block, len(iv))
 	if err != nil {
 		return "", err
 	}

--- a/import-export-cli/utils/cryptoUtils.go
+++ b/import-export-cli/utils/cryptoUtils.go
@@ -23,6 +23,7 @@ import (
 	"crypto/cipher"
 	"crypto/md5"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -35,14 +36,28 @@ import (
 const (
 	AES256KeySize    = 32
 	AES256HexKeySize = 64
-	GCMIVSize        = 128
+	GCMIVSize        = 12
 	GCMTagSize       = 128
 	hexCharacters    = "0123456789abcdefABCDEF"
 )
 
-type gcmCipherText struct {
+type cipherInitializationVectorHolder struct {
+	Cipher               string `json:"cipher"`
+	InitializationVector string `json:"initializationVector"`
+	KeyId                string `json:"keyId,omitempty"`
+}
+
+type cipherMetaDataHolder struct {
+	C  string `json:"c"`
+	T  string `json:"t"`
+	Iv string `json:"iv"`
+}
+
+// legacyCipherHolder is the flat ciphertext shape used by cipher-tool, carbon-secvault, and
+// carbon-mediation's current secure vault.
+type legacyCipherHolder struct {
 	CipherText string `json:"cipherText"`
-	IV         string `json:"iv"`
+	Iv         string `json:"iv"`
 }
 
 // Returns md5 hash of a given string
@@ -122,50 +137,97 @@ func ResolveAES256Key(encryptionKey string) ([]byte, error) {
 	return keyBytes, nil
 }
 
-// EncryptAES256 encrypts plain text using AES-256 GCM and returns a self-contained ciphertext.
-func EncryptAES256(key []byte, text string) (string, error) {
+// newAES256GCMWithRandomIV builds an AES-256/GCM cipher for key and generates a fresh random IV.
+func newAES256GCMWithRandomIV(key []byte) (cipher.AEAD, []byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
 	aesGCM, err := cipher.NewGCMWithNonceSize(block, GCMIVSize)
 	if err != nil {
-		return "", err
+		return nil, nil, err
 	}
-
 	iv := make([]byte, GCMIVSize)
 	if _, err = io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, nil, err
+	}
+	return aesGCM, iv, nil
+}
+
+// EncryptAES256 encrypts plain text using AES-256 GCM and returns a self-contained ciphertext in
+// the nested {"c","t","iv"} shape used by carbon-crypto-service.
+func EncryptAES256(key []byte, text string) (string, error) {
+	aesGCM, iv, err := newAES256GCMWithRandomIV(key)
+	if err != nil {
 		return "", err
 	}
 
 	ciphertext := aesGCM.Seal(nil, iv, []byte(text), nil)
-	payload, err := json.Marshal(gcmCipherText{
-		CipherText: base64.StdEncoding.EncodeToString(ciphertext),
-		IV:         base64.StdEncoding.EncodeToString(iv),
-	})
+
+	inner := cipherInitializationVectorHolder{
+		Cipher:               base64.StdEncoding.EncodeToString(ciphertext),
+		InitializationVector: base64.StdEncoding.EncodeToString(iv),
+		KeyId:                aes256KeyId(key),
+	}
+	innerJSON, err := json.Marshal(inner)
 	if err != nil {
 		return "", err
 	}
-	return base64.StdEncoding.EncodeToString(payload), nil
+	outer := cipherMetaDataHolder{
+		C:  base64.StdEncoding.EncodeToString(innerJSON),
+		T:  SecretEncryptionAlgorithmAESGCM,
+		Iv: base64.StdEncoding.EncodeToString(iv),
+	}
+	outerJSON, err := json.Marshal(outer)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(outerJSON), nil
 }
 
-// DecryptAES256 decrypts self-contained AES-256 GCM ciphertext into plain text.
+// EncryptAES256External encrypts plain text using AES-256 GCM and returns ciphertext in the flat
+// {"cipherText","iv"} shape used by cipher-tool, carbon-secvault, and carbon-mediation's current
+// ciphertext format.
+func EncryptAES256External(key []byte, text string) (string, error) {
+	aesGCM, iv, err := newAES256GCMWithRandomIV(key)
+	if err != nil {
+		return "", err
+	}
+
+	ciphertext := aesGCM.Seal(nil, iv, []byte(text), nil)
+
+	holder := legacyCipherHolder{
+		CipherText: base64.StdEncoding.EncodeToString(ciphertext),
+		Iv:         base64.StdEncoding.EncodeToString(iv),
+	}
+	holderJSON, err := json.Marshal(holder)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(holderJSON), nil
+}
+
+// EncryptAES256Plain encrypts plain text using AES-256 GCM and returns a single opaque base64
+// value (the IV prepended to the ciphertext) - no JSON envelope, just the encrypted value itself.
+func EncryptAES256Plain(key []byte, text string) (string, error) {
+	aesGCM, iv, err := newAES256GCMWithRandomIV(key)
+	if err != nil {
+		return "", err
+	}
+
+	sealed := aesGCM.Seal(iv, iv, []byte(text), nil)
+	return base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+func aes256KeyId(key []byte) string {
+	hash := sha256.Sum256(key)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// DecryptAES256 decrypts AES-256 GCM ciphertext produced by EncryptAES256, EncryptAES256External
+// or EncryptAES256Plain, auto-detecting which of the three shapes cryptoText is in.
 func DecryptAES256(key []byte, cryptoText string) (string, error) {
-	payload, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cryptoText))
-	if err != nil {
-		return "", err
-	}
-
-	var encryptedValue gcmCipherText
-	if err = json.Unmarshal(payload, &encryptedValue); err != nil {
-		return "", err
-	}
-
-	ciphertext, err := base64.StdEncoding.DecodeString(encryptedValue.CipherText)
-	if err != nil {
-		return "", err
-	}
-	iv, err := base64.StdEncoding.DecodeString(encryptedValue.IV)
+	outerBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(cryptoText))
 	if err != nil {
 		return "", err
 	}
@@ -175,6 +237,65 @@ func DecryptAES256(key []byte, cryptoText string) (string, error) {
 		return "", err
 	}
 	aesGCM, err := cipher.NewGCMWithNonceSize(block, GCMIVSize)
+	if err != nil {
+		return "", err
+	}
+
+	var outer map[string]interface{}
+	if err = json.Unmarshal(outerBytes, &outer); err != nil {
+		// Not a JSON envelope - treat it as the plain iv||ciphertext blob.
+		if len(outerBytes) < GCMIVSize {
+			return "", errors.New("Ciphertext too short")
+		}
+		iv := outerBytes[:GCMIVSize]
+		ciphertext := outerBytes[GCMIVSize:]
+		plainText, err := aesGCM.Open(nil, iv, ciphertext, nil)
+		if err != nil {
+			return "", err
+		}
+		return string(plainText), nil
+	}
+
+	var cipherB64, ivB64 string
+	if c, ok := outer["c"]; ok {
+		// Current format: {"c": <base64 inner json>, "t": ..., "iv": ...}
+		cStr, ok := c.(string)
+		if !ok {
+			return "", errors.New("Invalid ciphertext format: \"c\" field is not a string")
+		}
+		innerJSONBytes, err := base64.StdEncoding.DecodeString(cStr)
+		if err != nil {
+			return "", errors.New("Invalid base64 in \"c\" field")
+		}
+		var inner cipherInitializationVectorHolder
+		if err = json.Unmarshal(innerJSONBytes, &inner); err != nil {
+			return "", errors.New("Invalid inner ciphertext JSON")
+		}
+		cipherB64 = inner.Cipher
+		ivB64 = inner.InitializationVector
+	} else if ct, ok := outer["cipherText"]; ok {
+		// Flat format: {"cipherText": ..., "iv": ...}
+		cipherStr, ok := ct.(string)
+		if !ok {
+			return "", errors.New("Invalid ciphertext format: \"cipherText\" field is not a string")
+		}
+		cipherB64 = cipherStr
+		if iv, ok := outer["iv"]; ok {
+			ivStr, ok := iv.(string)
+			if !ok {
+				return "", errors.New("Invalid ciphertext format: \"iv\" field is not a string")
+			}
+			ivB64 = ivStr
+		}
+	} else {
+		return "", errors.New("Unrecognized ciphertext format")
+	}
+
+	ciphertext, err := base64.StdEncoding.DecodeString(cipherB64)
+	if err != nil {
+		return "", err
+	}
+	iv, err := base64.StdEncoding.DecodeString(ivB64)
 	if err != nil {
 		return "", err
 	}

--- a/import-export-cli/utils/cryptoUtils_test.go
+++ b/import-export-cli/utils/cryptoUtils_test.go
@@ -19,6 +19,10 @@
 package utils
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -94,6 +98,248 @@ func TestEncryptDecryptAES256(t *testing.T) {
 		}
 		if s != decryptedData {
 			t.Errorf("EncryptAES256()/DecryptAES256() does not work for '%s'", s)
+		}
+	}
+}
+
+// TestEncryptAES256OutputFormat asserts EncryptAES256 produces a self-contained ciphertext with
+// the outer {c,t,iv} / inner {cipher,initializationVector,keyId} shape, and a 12-byte (96-bit) IV.
+func TestEncryptAES256OutputFormat(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	stored, err := EncryptAES256(keyBytes, "AnotherSecret#123")
+	if err != nil {
+		t.Fatalf("unexpected error encrypting: %v", err)
+	}
+
+	outerBytes, err := base64.StdEncoding.DecodeString(stored)
+	if err != nil {
+		t.Fatalf("stored value is not valid base64: %v", err)
+	}
+
+	var outer map[string]interface{}
+	if err := json.Unmarshal(outerBytes, &outer); err != nil {
+		t.Fatalf("outer envelope is not valid JSON: %v", err)
+	}
+	for _, field := range []string{"c", "t", "iv"} {
+		if _, ok := outer[field]; !ok {
+			t.Fatalf("outer envelope missing required field %q: %v", field, outer)
+		}
+	}
+	if outer["t"] != SecretEncryptionAlgorithmAESGCM {
+		t.Fatalf(`expected "t" = %q, got %v`, SecretEncryptionAlgorithmAESGCM, outer["t"])
+	}
+
+	innerBytes, err := base64.StdEncoding.DecodeString(outer["c"].(string))
+	if err != nil {
+		t.Fatalf(`"c" field is not valid base64: %v`, err)
+	}
+	var inner map[string]interface{}
+	if err := json.Unmarshal(innerBytes, &inner); err != nil {
+		t.Fatalf("inner envelope is not valid JSON: %v", err)
+	}
+	for _, field := range []string{"cipher", "initializationVector", "keyId"} {
+		if _, ok := inner[field]; !ok {
+			t.Fatalf("inner envelope missing required field %q: %v", field, inner)
+		}
+	}
+
+	// The IV must be 12 bytes (96 bits), not the 128-byte value an earlier draft used.
+	ivBytes, err := base64.StdEncoding.DecodeString(outer["iv"].(string))
+	if err != nil {
+		t.Fatalf(`"iv" field is not valid base64: %v`, err)
+	}
+	if len(ivBytes) != GCMIVSize {
+		t.Fatalf("expected a %d-byte GCM IV, got %d bytes", GCMIVSize, len(ivBytes))
+	}
+}
+
+func TestEncryptAES256KeyIdIsStableForSameKey(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	storedA, err := EncryptAES256(keyBytes, "valueA")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	storedB, err := EncryptAES256(keyBytes, "valueB")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	kidA := extractKeyId(t, storedA)
+	kidB := extractKeyId(t, storedB)
+	if kidA != kidB {
+		t.Fatalf("expected the same key to produce the same keyId across calls, got %q and %q", kidA, kidB)
+	}
+}
+
+func extractKeyId(t *testing.T, stored string) string {
+	t.Helper()
+	outerBytes, err := base64.StdEncoding.DecodeString(stored)
+	if err != nil {
+		t.Fatalf("stored value is not valid base64: %v", err)
+	}
+	var outer map[string]interface{}
+	if err := json.Unmarshal(outerBytes, &outer); err != nil {
+		t.Fatalf("outer envelope is not valid JSON: %v", err)
+	}
+	innerBytes, err := base64.StdEncoding.DecodeString(outer["c"].(string))
+	if err != nil {
+		t.Fatalf(`"c" field is not valid base64: %v`, err)
+	}
+	var inner cipherInitializationVectorHolder
+	if err := json.Unmarshal(innerBytes, &inner); err != nil {
+		t.Fatalf("inner envelope is not valid JSON: %v", err)
+	}
+	return inner.KeyId
+}
+
+// TestDecryptAES256LegacyFlatFormat confirms DecryptAES256 still reads the older
+// {"cipherText", "iv"} flat shape, for backward compatibility with values encrypted before
+// the self-contained {c,t,iv,keyId} format was introduced.
+func TestDecryptAES256LegacyFlatFormat(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	plainText := "legacyValue"
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iv := make([]byte, GCMIVSize)
+	cipherBytes := gcm.Seal(nil, iv, []byte(plainText), nil)
+
+	legacyJSON := `{"cipherText":"` + base64.StdEncoding.EncodeToString(cipherBytes) +
+		`","iv":"` + base64.StdEncoding.EncodeToString(iv) + `"}`
+	legacyStored := base64.StdEncoding.EncodeToString([]byte(legacyJSON))
+
+	decrypted, err := DecryptAES256(keyBytes, legacyStored)
+	if err != nil {
+		t.Fatalf("unexpected error decrypting legacy format: %v", err)
+	}
+	if decrypted != plainText {
+		t.Fatalf("expected %q, got %q", plainText, decrypted)
+	}
+}
+
+// TestEncryptAES256ExternalOutputFormat asserts EncryptAES256External produces the flat
+// {"cipherText","iv"} shape (no "c"/"t" envelope), and that it round-trips through DecryptAES256.
+func TestEncryptAES256ExternalOutputFormat(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	stored, err := EncryptAES256External(keyBytes, "ExternalSecret#456")
+	if err != nil {
+		t.Fatalf("unexpected error encrypting: %v", err)
+	}
+
+	outerBytes, err := base64.StdEncoding.DecodeString(stored)
+	if err != nil {
+		t.Fatalf("stored value is not valid base64: %v", err)
+	}
+
+	var outer map[string]interface{}
+	if err := json.Unmarshal(outerBytes, &outer); err != nil {
+		t.Fatalf("value is not valid JSON: %v", err)
+	}
+	for _, field := range []string{"cipherText", "iv"} {
+		if _, ok := outer[field]; !ok {
+			t.Fatalf("envelope missing required field %q: %v", field, outer)
+		}
+	}
+	if _, ok := outer["c"]; ok {
+		t.Fatalf("external format should not have a \"c\" field: %v", outer)
+	}
+	if _, ok := outer["t"]; ok {
+		t.Fatalf("external format should not have a \"t\" field: %v", outer)
+	}
+
+	ivBytes, err := base64.StdEncoding.DecodeString(outer["iv"].(string))
+	if err != nil {
+		t.Fatalf(`"iv" field is not valid base64: %v`, err)
+	}
+	if len(ivBytes) != GCMIVSize {
+		t.Fatalf("expected a %d-byte GCM IV, got %d bytes", GCMIVSize, len(ivBytes))
+	}
+
+	decrypted, err := DecryptAES256(keyBytes, stored)
+	if err != nil {
+		t.Fatalf("DecryptAES256() returned an error: %v", err)
+	}
+	if decrypted != "ExternalSecret#456" {
+		t.Fatalf("expected %q, got %q", "ExternalSecret#456", decrypted)
+	}
+}
+
+// TestEncryptAES256PlainOutputFormat asserts EncryptAES256Plain produces a single opaque
+// base64 blob (no JSON envelope at all), and that it round-trips through DecryptAES256.
+func TestEncryptAES256PlainOutputFormat(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	plainText := "PlainSecret#789"
+	stored, err := EncryptAES256Plain(keyBytes, plainText)
+	if err != nil {
+		t.Fatalf("unexpected error encrypting: %v", err)
+	}
+
+	decodedBytes, err := base64.StdEncoding.DecodeString(stored)
+	if err != nil {
+		t.Fatalf("stored value is not valid base64: %v", err)
+	}
+	if json.Valid(decodedBytes) {
+		t.Fatalf("plain format should not be a JSON envelope, got %s", decodedBytes)
+	}
+
+	// GCMIVSize bytes of IV, plus ciphertext, plus a 16-byte GCM auth tag.
+	const gcmTagSizeBytes = 16
+	expectedLen := GCMIVSize + len(plainText) + gcmTagSizeBytes
+	if len(decodedBytes) != expectedLen {
+		t.Fatalf("expected %d decoded bytes (iv+ciphertext+tag), got %d", expectedLen, len(decodedBytes))
+	}
+
+	decrypted, err := DecryptAES256(keyBytes, stored)
+	if err != nil {
+		t.Fatalf("DecryptAES256() returned an error: %v", err)
+	}
+	if decrypted != plainText {
+		t.Fatalf("expected %q, got %q", plainText, decrypted)
+	}
+}
+
+// TestDecryptAES256RejectsNonStringFields confirms DecryptAES256 returns an error, rather than
+// panicking, when a recognized envelope field holds a non-string JSON value.
+func TestDecryptAES256RejectsNonStringFields(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	cases := map[string]string{
+		"c is a number":          `{"c":123,"t":"AES/GCM/NoPadding","iv":"aXY="}`,
+		"cipherText is an array": `{"cipherText":["a"],"iv":"aXY="}`,
+		"iv is an object":        `{"cipherText":"Y2lwaGVy","iv":{}}`,
+	}
+	for name, rawJSON := range cases {
+		stored := base64.StdEncoding.EncodeToString([]byte(rawJSON))
+		if _, err := DecryptAES256(keyBytes, stored); err == nil {
+			t.Errorf("%s: expected an error, got nil", name)
 		}
 	}
 }

--- a/import-export-cli/utils/cryptoUtils_test.go
+++ b/import-export-cli/utils/cryptoUtils_test.go
@@ -234,6 +234,42 @@ func TestDecryptAES256LegacyFlatFormat(t *testing.T) {
 	}
 }
 
+// TestDecryptAES256LegacyNonceSize confirms DecryptAES256 still reads ciphertext written with the
+// former 128-byte GCM nonce size (the flat {"cipherText","iv"} shape produced by the AES-256
+// implementation that shipped before GCMIVSize was corrected to 12), not just the current
+// 12-byte nonce.
+func TestDecryptAES256LegacyNonceSize(t *testing.T) {
+	keyBytes, err := ResolveAES256Key("12345678901234567890123456789012")
+	if err != nil {
+		t.Fatalf("ResolveAES256Key() returned an error: %v", err)
+	}
+
+	const formerNonceSize = 128
+	plainText := "legacyNonceSizeValue"
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, formerNonceSize)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	iv := make([]byte, formerNonceSize)
+	cipherBytes := gcm.Seal(nil, iv, []byte(plainText), nil)
+
+	legacyJSON := `{"cipherText":"` + base64.StdEncoding.EncodeToString(cipherBytes) +
+		`","iv":"` + base64.StdEncoding.EncodeToString(iv) + `"}`
+	legacyStored := base64.StdEncoding.EncodeToString([]byte(legacyJSON))
+
+	decrypted, err := DecryptAES256(keyBytes, legacyStored)
+	if err != nil {
+		t.Fatalf("unexpected error decrypting former-nonce-size ciphertext: %v", err)
+	}
+	if decrypted != plainText {
+		t.Fatalf("expected %q, got %q", plainText, decrypted)
+	}
+}
+
 // TestEncryptAES256ExternalOutputFormat asserts EncryptAES256External produces the flat
 // {"cipherText","iv"} shape (no "c"/"t" envelope), and that it round-trips through DecryptAES256.
 func TestEncryptAES256ExternalOutputFormat(t *testing.T) {

--- a/import-export-cli/utils/encryptionUtils.go
+++ b/import-export-cli/utils/encryptionUtils.go
@@ -60,6 +60,7 @@ type SecretConfig struct {
 	OutputType          string
 	Algorithm           string
 	EncryptionKey       string
+	SymmetricFormat     string
 	InputType           string
 	InputFile           string
 	PlainTextAlias      string
@@ -122,7 +123,11 @@ func EncryptSecrets(keyStoreConfig *KeyStoreConfig, secretConfig SecretConfig) e
 		if keyErr != nil {
 			return keyErr
 		}
-		encryptedSecrets, err = encryptSymmetric(encryptionKey, plainTextSecrets, EncryptAES256)
+		symmetricEncryptFn, formatErr := symmetricEncryptFuncFor(secretConfig.SymmetricFormat)
+		if formatErr != nil {
+			return formatErr
+		}
+		encryptedSecrets, err = encryptSymmetric(encryptionKey, plainTextSecrets, symmetricEncryptFn)
 	} else {
 		encryptionKey, keyErr := getEncryptionKey(keyStoreConfig)
 		if keyErr != nil {
@@ -249,6 +254,23 @@ func encrypt(encryptionKey *rsa.PublicKey, plainTextSecrets map[string]string, e
 		encryptedSecrets[alias] = encryptedSecret
 	}
 	return encryptedSecrets, nil
+}
+
+// symmetricEncryptFuncFor picks the AES-256 ciphertext shape for the requested sub-mode:
+// "internal" mirrors carbon-crypto-service, "external" mirrors cipher-tool/carbon-secvault/
+// carbon-mediation, and an empty format (the bare "symmetric" mode) is a single opaque blob.
+// Any other, unrecognized format is rejected rather than silently falling back to a default.
+func symmetricEncryptFuncFor(format string) (symmetricEncryptFunc, error) {
+	switch {
+	case format == "":
+		return EncryptAES256Plain, nil
+	case strings.EqualFold(format, "internal"):
+		return EncryptAES256, nil
+	case strings.EqualFold(format, "external"):
+		return EncryptAES256External, nil
+	default:
+		return nil, fmt.Errorf("unrecognized symmetric ciphertext format %q: expected \"internal\", \"external\", or empty for the default", format)
+	}
 }
 
 func encryptSymmetric(encryptionKey []byte, plainTextSecrets map[string]string,


### PR DESCRIPTION
## Purpose

This pull request extends the secret encryption CLI to support multiple ciphertext formats for symmetric encryption, improves argument validation, and refactors the AES-256 encryption/decryption logic to handle different formats. The most important changes are summarized below.

**New symmetric encryption format support:**

* Added support for specifying the ciphertext format when using symmetric encryption, allowing users to choose between the `internal` (carbon-crypto-service) and `external` (cipher-tool, carbon-secvault, carbon-mediation) formats via an additional positional argument. (`import-export-cli/cmd/secret/create.go`, `import-export-cli/cmd/secret/secret.go`, `import-export-cli/docs/apictl_secret_create.md`) [[1]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04R37) [[2]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04R48-R51) [[3]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04L57-R73) [[4]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04L102-R112) [[5]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04R123) [[6]](diffhunk://#diff-64df78cb3740a314f86f52c5769750c844dfdefe2f467da8412b4a33fdc28f04L171-R192) [[7]](diffhunk://#diff-5b1268d83bb0f75324401a19fb1bc341e276c41b2589b298b86f836b7be5c4d2R29-R30) [[8]](diffhunk://#diff-76304fa386f17525ad8531bf93b7b4521fc724c45d1146cd7ab92ea551dcf9e6L10-R10) [[9]](diffhunk://#diff-76304fa386f17525ad8531bf93b7b4521fc724c45d1146cd7ab92ea551dcf9e6R20-R23)

**Encryption/decryption logic refactoring:**

* Refactored AES-256 encryption to support three output formats: the nested JSON envelope (`internal`), the flat JSON envelope (`external`), and a plain base64-encoded value. Decryption now auto-detects and supports all three formats. (`import-export-cli/utils/cryptoUtils.go`) [[1]](diffhunk://#diff-ec2afab1ba9987289737cc250bbc0b874a074b24351999ac55bbcab2a77cda2cR26) [[2]](diffhunk://#diff-ec2afab1ba9987289737cc250bbc0b874a074b24351999ac55bbcab2a77cda2cL38-R60) [[3]](diffhunk://#diff-ec2afab1ba9987289737cc250bbc0b874a074b24351999ac55bbcab2a77cda2cL125-R230) [[4]](diffhunk://#diff-ec2afab1ba9987289737cc250bbc0b874a074b24351999ac55bbcab2a77cda2cR244-R302)

**Improved CLI argument validation:**

* Enhanced validation to ensure only valid combinations of symmetric mode and format arguments are accepted, with clear error messages for invalid usage. (`import-export-cli/cmd/secret/create.go`)

**Documentation updates:**

* Updated CLI usage and examples in the documentation to reflect the new symmetric encryption format options. (`import-export-cli/docs/apictl_secret_create.md`) [[1]](diffhunk://#diff-76304fa386f17525ad8531bf93b7b4521fc724c45d1146cd7ab92ea551dcf9e6L10-R10) [[2]](diffhunk://#diff-76304fa386f17525ad8531bf93b7b4521fc724c45d1146cd7ab92ea551dcf9e6R20-R23)

**Test and variable updates:**

* Updated tests and variable handling to support the new `symmetricFormat` argument and ensure proper cleanup in tests. (`import-export-cli/cmd/secret/create_test.go`, `import-export-cli/utils/cryptoUtils_test.go`) [[1]](diffhunk://#diff-9e81c36faa7250bce12d370e9907edbdf60c0a8673d66b60e5316628ac77daf8R51) [[2]](diffhunk://#diff-9e81c36faa7250bce12d370e9907edbdf60c0a8673d66b60e5316628ac77daf8R62) [[3]](diffhunk://#diff-ff6f4601a466cfdb94027e689b5df2187c4e6c26f6c88a727ca078ce40253d41R22-R25)

## Related Issue
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/18092